### PR TITLE
:sparkles: Flow Bubbles Validate Endpoint

### DIFF
--- a/apps/builder/src/features/typebot/api/getTypebotValidation.ts
+++ b/apps/builder/src/features/typebot/api/getTypebotValidation.ts
@@ -1,0 +1,73 @@
+import { publicProcedure } from '@/helpers/server/trpc'
+import prisma from '@typebot.io/lib/prisma'
+import { TRPCError } from '@trpc/server'
+import { z } from 'zod'
+
+type Block = {
+  type: string
+  outgoingEdgeId?: string | null
+}
+type Group = {
+  title: string
+  blocks: Block[]
+}
+
+const typebotValidationSchema = z.object({
+  typebotId: z.string().describe('Typebot id to be validated'),
+})
+
+const responseSchema = z.object({
+  isValid: z.boolean(),
+  outgoingEdgeIds: z.array(z.string().nullable()),
+  invalidGroups: z.array(z.string()),
+})
+
+export const getTypebotValidation = publicProcedure
+  .meta({
+    openapi: {
+      method: 'GET',
+      path: '/v1/typebots/{typebotId}/validate',
+      protect: true,
+      summary: 'Validate a typebot',
+      tags: ['Typebot'],
+    },
+  })
+  .input(typebotValidationSchema)
+  .output(responseSchema)
+  .query(async ({ input: { typebotId } }) => {
+    const typebot = await prisma.typebot.findFirst({
+      where: {
+        id: typebotId,
+      },
+      select: {
+        groups: true,
+      },
+    })
+
+    if (!typebot) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Typebot not found' })
+    }
+
+    const outgoingEdgeIds: (string | null)[] = []
+    const invalidGroups: string[] = []
+
+    if (Array.isArray(typebot.groups)) {
+      ;(typebot.groups as Group[]).forEach((group) => {
+        if ('blocks' in group && Array.isArray(group.blocks)) {
+          const groupOutgoingEdgeIds = group.blocks
+            .filter((block) => block.type.toLowerCase() === 'condition')
+            .map((block) => block.outgoingEdgeId ?? null)
+
+          outgoingEdgeIds.push(...groupOutgoingEdgeIds)
+
+          if (groupOutgoingEdgeIds.includes(null)) {
+            invalidGroups.push(group.title)
+          }
+        }
+      })
+    }
+
+    const isValid = invalidGroups.length === 0
+
+    return { isValid, outgoingEdgeIds, invalidGroups }
+  })

--- a/apps/builder/src/features/typebot/api/getTypebotValidation.ts
+++ b/apps/builder/src/features/typebot/api/getTypebotValidation.ts
@@ -22,6 +22,13 @@ const responseSchema = z.object({
   invalidGroups: z.array(z.string()),
 })
 
+const isGroupArray = (groups: unknown): groups is Group[] =>
+  Array.isArray(groups)
+const hasBlocks = (group: Group): boolean =>
+  'blocks' in group && Array.isArray(group.blocks)
+const isConditionBlock = (block: Block): boolean =>
+  block.type.toLowerCase() === 'condition'
+
 export const getTypebotValidation = publicProcedure
   .meta({
     openapi: {
@@ -51,11 +58,11 @@ export const getTypebotValidation = publicProcedure
     const outgoingEdgeIds: (string | null)[] = []
     const invalidGroups: string[] = []
 
-    if (Array.isArray(typebot.groups)) {
-      ;(typebot.groups as Group[]).forEach((group) => {
-        if ('blocks' in group && Array.isArray(group.blocks)) {
+    if (isGroupArray(typebot.groups)) {
+      typebot.groups.forEach((group) => {
+        if (hasBlocks(group)) {
           const groupOutgoingEdgeIds = group.blocks
-            .filter((block) => block.type.toLowerCase() === 'condition')
+            .filter(isConditionBlock)
             .map((block) => block.outgoingEdgeId ?? null)
 
           outgoingEdgeIds.push(...groupOutgoingEdgeIds)

--- a/apps/builder/src/features/typebot/api/router.ts
+++ b/apps/builder/src/features/typebot/api/router.ts
@@ -13,6 +13,7 @@ import { unpublishTypebot } from './unpublishTypebot'
 import { deleteTypebot } from './deleteTypebot'
 import { importTypebot } from './importTypebot'
 import { listTypebotsClaudia } from './listTypebotsClaudia'
+import { getTypebotValidation } from './getTypebotValidation'
 
 export const typebotRouter = router({
   listTypebotsClaudia,
@@ -26,4 +27,5 @@ export const typebotRouter = router({
   listTypebots,
   deleteTypebot,
   importTypebot,
+  getTypebotValidation,
 })


### PR DESCRIPTION
Endpoint para validação das bubbles por typebotId

(builderUrl)/api/v1/typebots/${typebotId}/validate

Exemplo de Retorno :
{
    "isValid": false,
    "outgoingEdgeIds": [
        "xsawsj9etuyrnkdnnryxu1vw",
        "e24esflw8be3hx70bv0kt80c",       
        null,
        null,
        null   
    ],
    "invalidGroups": [
        "Condições - menu RH início",
        "Condições (início fluxo SOS) (2)",
        "Condições (ocorrências fluxo SOS) (2)"
    ]
}

![image](https://github.com/user-attachments/assets/51ab4a10-b6dd-45ef-897f-f98af401c857)
