### PR TITLE
update deployment version tags to '1.1' for typebot-builder and typebot-viewer

### DIFF
--- a/deploy/base/typebot-builder-deployment.yaml
+++ b/deploy/base/typebot-builder-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app: typebot-builder
     tags.datadoghq.com/env: production
     tags.datadoghq.com/service: typebot-builder
-    tags.datadoghq.com/version: '${DD_VERSION_SHA}'
+    tags.datadoghq.com/version: '1.1'
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -24,7 +24,7 @@ spec:
         app: typebot-builder
         tags.datadoghq.com/env: production
         tags.datadoghq.com/service: typebot-builder
-        tags.datadoghq.com/version: '${DD_VERSION_SHA}'
+        tags.datadoghq.com/version: '1.1'
         admission.datadoghq.com/enabled: 'true'
       annotations:
         admission.datadoghq.com/js-lib.version: v5.24.0
@@ -49,7 +49,7 @@ spec:
             - name: DD_SERVICE
               value: 'typebot-builder'
             - name: DD_VERSION
-              value: '${DD_VERSION_SHA}'
+              value: '1.1'
           envFrom:
             - configMapRef:
                 name: typebot-builder

--- a/deploy/base/typebot-viewer-deployment.yaml
+++ b/deploy/base/typebot-viewer-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app: typebot-viewer
     tags.datadoghq.com/env: production
     tags.datadoghq.com/service: typebot-viewer
-    tags.datadoghq.com/version: '${DD_VERSION_SHA}'
+    tags.datadoghq.com/version: '1.1'
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -24,7 +24,7 @@ spec:
         app: typebot-viewer
         tags.datadoghq.com/env: production
         tags.datadoghq.com/service: typebot-viewer
-        tags.datadoghq.com/version: '${DD_VERSION_SHA}'
+        tags.datadoghq.com/version: '1.1'
         admission.datadoghq.com/enabled: 'true'
       annotations:
         admission.datadoghq.com/js-lib.version: v5.24.0
@@ -49,7 +49,7 @@ spec:
             - name: DD_SERVICE
               value: 'typebot-viewer'
             - name: DD_VERSION
-              value: '${DD_VERSION_SHA}'
+              value: '1.1'
           envFrom:
             - configMapRef:
                 name: typebot-viewer


### PR DESCRIPTION
This pull request updates the versioning for the `typebot-builder` and `typebot-viewer` deployments by replacing dynamic version references with a static version (`1.1`). These changes ensure consistency and simplify version management across the deployment configurations.

### Updates to `typebot-builder` deployment:

* [`deploy/base/typebot-builder-deployment.yaml`](diffhunk://#diff-813663f6a1b28c21eae1e4e88b8fee9e427f5438b7b5d3bf3eaba5c1575f2e60L9-R9): Changed the `tags.datadoghq.com/version` and `DD_VERSION` from `${DD_VERSION_SHA}` to a static value of `1.1` in both `metadata` and `spec` sections. [[1]](diffhunk://#diff-813663f6a1b28c21eae1e4e88b8fee9e427f5438b7b5d3bf3eaba5c1575f2e60L9-R9) [[2]](diffhunk://#diff-813663f6a1b28c21eae1e4e88b8fee9e427f5438b7b5d3bf3eaba5c1575f2e60L27-R27) [[3]](diffhunk://#diff-813663f6a1b28c21eae1e4e88b8fee9e427f5438b7b5d3bf3eaba5c1575f2e60L52-R52)

### Updates to `typebot-viewer` deployment:

* [`deploy/base/typebot-viewer-deployment.yaml`](diffhunk://#diff-d134faea32dee72db2bd524b43b63eb0e98e14d93e070adc2d7929da68dfadcdL9-R9): Updated the `tags.datadoghq.com/version` and `DD_VERSION` from `${DD_VERSION_SHA}` to `1.1` in both `metadata` and `spec` sections. [[1]](diffhunk://#diff-d134faea32dee72db2bd524b43b63eb0e98e14d93e070adc2d7929da68dfadcdL9-R9) [[2]](diffhunk://#diff-d134faea32dee72db2bd524b43b63eb0e98e14d93e070adc2d7929da68dfadcdL27-R27) [[3]](diffhunk://#diff-d134faea32dee72db2bd524b43b63eb0e98e14d93e070adc2d7929da68dfadcdL52-R52)