### PR TITLE
fix: include tools without parameters in OpenAI payload

### DIFF
--- a/packages/forge/blocks/openai/helpers/parseToolParameters.ts
+++ b/packages/forge/blocks/openai/helpers/parseToolParameters.ts
@@ -3,20 +3,19 @@ import { toolParametersSchema } from '../shared/parseChatCompletionOptions'
 import { z } from '@typebot.io/forge/zod'
 
 export const parseToolParameters = (
-  parameters: z.infer<typeof toolParametersSchema>
+  parameters: z.infer<typeof toolParametersSchema> | undefined
 ): OpenAI.FunctionParameters => ({
   type: 'object',
-  properties: parameters?.reduce<{
-    [x: string]: unknown
-  }>((acc, param) => {
-    if (!param.name) return acc
-    acc[param.name] = {
-      type: param.type === 'enum' ? 'string' : param.type,
-      enum: param.type === 'enum' ? param.values : undefined,
-      description: param.description,
-    }
-    return acc
-  }, {}),
+  properties:
+    parameters?.reduce((acc, param) => {
+      if (!param.name) return acc
+      acc[param.name] = {
+        type: param.type === 'enum' ? 'string' : param.type,
+        enum: param.type === 'enum' ? param.values : undefined,
+        description: param.description,
+      }
+      return acc
+    }, {} as Record<string, any>) ?? {},
   required:
     parameters?.filter((param) => param.required).map((param) => param.name) ??
     [],

--- a/packages/forge/blocks/openai/shared/runChatCompletion.ts
+++ b/packages/forge/blocks/openai/shared/runChatCompletion.ts
@@ -49,7 +49,7 @@ export const runChatCompletion = async ({
   const openai = new OpenAI(config)
 
   const tools = options.tools
-    ?.filter((t) => t.name && t.parameters)
+    ?.filter((t) => t.name)
     .map((t) => ({
       type: 'function',
       function: {
@@ -85,7 +85,7 @@ export const runChatCompletion = async ({
       const name = toolCall.function?.name
       if (!name) continue
       const toolDefinition = options.tools?.find((t) => t.name === name)
-      if (!toolDefinition?.code || !toolDefinition.parameters) {
+      if (!toolDefinition?.code) {
         messages.push({
           tool_call_id: toolCall.id,
           role: 'tool',
@@ -94,7 +94,7 @@ export const runChatCompletion = async ({
         continue
       }
       const toolParams = Object.fromEntries(
-        toolDefinition.parameters.map(({ name }) => [name, null])
+        (toolDefinition.parameters ?? []).map(({ name }) => [name, null])
       )
       const toolArgs = toolCall.function?.arguments
         ? JSON.parse(toolCall.function?.arguments)

--- a/packages/forge/blocks/openai/shared/runChatCompletionStream.ts
+++ b/packages/forge/blocks/openai/shared/runChatCompletionStream.ts
@@ -43,7 +43,7 @@ export const runChatCompletionStream = async ({
       function: {
         name: t.name as string,
         description: t.description,
-        parameters: parseToolParameters(t.parameters),
+        parameters: parseToolParameters(t.parameters ?? []),
       },
     })) satisfies ChatCompletionTool[] | undefined
 

--- a/packages/forge/blocks/openai/shared/runChatCompletionStream.ts
+++ b/packages/forge/blocks/openai/shared/runChatCompletionStream.ts
@@ -37,13 +37,13 @@ export const runChatCompletionStream = async ({
   const openai = new OpenAI(config)
 
   const tools = options.tools
-    ?.filter((t) => t.name && t.parameters)
+    ?.filter((t) => t.name)
     .map((t) => ({
       type: 'function',
       function: {
         name: t.name as string,
         description: t.description,
-        parameters: parseToolParameters(t.parameters!),
+        parameters: parseToolParameters(t.parameters),
       },
     })) satisfies ChatCompletionTool[] | undefined
 
@@ -66,7 +66,7 @@ export const runChatCompletionStream = async ({
         const name = toolCall.func?.name
         if (!name) continue
         const toolDefinition = options.tools?.find((t) => t.name === name)
-        if (!toolDefinition?.code || !toolDefinition.parameters) {
+        if (!toolDefinition?.code) {
           messages.push({
             tool_call_id: toolCall.id,
             role: 'tool',


### PR DESCRIPTION
### 🛠️ Fix: Allow tools without parameters in OpenAI block

This PR addresses an issue where tools without defined parameters were silently excluded from the request sent to OpenAI. As a result, instructions relying on those tools (e.g., calling `water` or `detectViolence`) would never trigger function calls, even when the input matched the condition.

#### ✅ Changes made

- `parseToolParameters` now gracefully handles `undefined` parameters and returns an empty `properties` and `required` list instead of failing.
- Removed unnecessary checks for `t.parameters` during tools mapping (`options.tools?.filter((t) => t.name && t.parameters)` → `filter((t) => t.name)`).
- Guarded usage of `toolDefinition.parameters` during tool execution with fallback to empty array.

#### 🧪 Before

- Tools without any parameters would not be passed to the OpenAI `tools` payload.
- Function calls were never triggered even when instructions matched.

#### ✅ After

- Tools without parameters are now included properly in the payload.
- Function calling works correctly for all tools, even if they have no parameters defined.

#### 🎥 Video walkthrough

For a visual explanation of the issue and the fix, see this Loom video:  
https://www.loom.com/share/d0d061fb034940289f5d7f2248e95762
