### PR TITLE
refactor: replace DD_VERSION_SHA export with app-version action for versioning

### DIFF
--- a/.github/workflows/typebot.yaml
+++ b/.github/workflows/typebot.yaml
@@ -31,13 +31,10 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Export DD_VERSION_SHA
-        run: |
-          export DD_VERSION_SHA=$(echo ${{ github.sha }} | cut -c1-8)
-          for file in deploy/**/*.yaml; do
-            envsubst < "$file" > "$file.tmp"
-            mv "$file.tmp" "$file"
-          done
+      - name: Conpute version
+        uses: cloudhumans/actions/app-version@v1
+        with:
+          format: '{sha7}'
 
       - name: Build, tag, and push BUILDER image to Amazon ECR
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/deploy/base/typebot-builder-deployment.yaml
+++ b/deploy/base/typebot-builder-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app: typebot-builder
     tags.datadoghq.com/env: production
     tags.datadoghq.com/service: typebot-builder
-    tags.datadoghq.com/version: '${DD_VERSION_SHA}'
+    tags.datadoghq.com/version: '${APP_VERSION}'
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -24,7 +24,7 @@ spec:
         app: typebot-builder
         tags.datadoghq.com/env: production
         tags.datadoghq.com/service: typebot-builder
-        tags.datadoghq.com/version: '${DD_VERSION_SHA}'
+        tags.datadoghq.com/version: '${APP_VERSION}'
         admission.datadoghq.com/enabled: 'true'
       annotations:
         admission.datadoghq.com/js-lib.version: v5.24.0
@@ -49,7 +49,7 @@ spec:
             - name: DD_SERVICE
               value: 'typebot-builder'
             - name: DD_VERSION
-              value: '${DD_VERSION_SHA}'
+              value: '${APP_VERSION}'
           envFrom:
             - configMapRef:
                 name: typebot-builder

--- a/deploy/base/typebot-viewer-deployment.yaml
+++ b/deploy/base/typebot-viewer-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app: typebot-viewer
     tags.datadoghq.com/env: production
     tags.datadoghq.com/service: typebot-viewer
-    tags.datadoghq.com/version: '${DD_VERSION_SHA}'
+    tags.datadoghq.com/version: '${APP_VERSION}'
 spec:
   replicas: 1
   revisionHistoryLimit: 10
@@ -24,7 +24,7 @@ spec:
         app: typebot-viewer
         tags.datadoghq.com/env: production
         tags.datadoghq.com/service: typebot-viewer
-        tags.datadoghq.com/version: '${DD_VERSION_SHA}'
+        tags.datadoghq.com/version: '${APP_VERSION}'
         admission.datadoghq.com/enabled: 'true'
       annotations:
         admission.datadoghq.com/js-lib.version: v5.24.0
@@ -49,7 +49,7 @@ spec:
             - name: DD_SERVICE
               value: 'typebot-viewer'
             - name: DD_VERSION
-              value: '${DD_VERSION_SHA}'
+              value: '${APP_VERSION}'
           envFrom:
             - configMapRef:
                 name: typebot-viewer


### PR DESCRIPTION
This pull request updates the CI/CD workflow in `.github/workflows/typebot.yaml` to improve how the application version is computed during deployment. The main change is the replacement of a manual shell script for versioning with a reusable GitHub Action.

**CI/CD workflow improvements:**

* Replaced the manual shell script that exported `DD_VERSION_SHA` and processed deployment YAML files with the `cloudhumans/actions/app-version@v1` GitHub Action, which computes the application version using the `{sha7}` format.