### PR TITLE
feat: add wildcard domain support for builder embedding

### DIFF
--- a/apps/builder/src/features/embedded-auth/utils.ts
+++ b/apps/builder/src/features/embedded-auth/utils.ts
@@ -1,4 +1,5 @@
 import { env } from '@typebot.io/env'
+import { isOriginAllowed as checkOriginAllowed } from '@typebot.io/lib/origin'
 
 // Helper function to get the allowed origins for postMessage
 export const getAllowedOrigins = (): string[] => {
@@ -18,5 +19,5 @@ export const getAllowedOrigin = (): string => {
 // Helper function to check if an origin is allowed
 export const isOriginAllowed = (origin: string): boolean => {
   const allowedOrigins = getAllowedOrigins()
-  return allowedOrigins.includes(origin)
+  return checkOriginAllowed(origin, allowedOrigins)
 }

--- a/deploy/base/typebot-builder-configmap.yaml
+++ b/deploy/base/typebot-builder-configmap.yaml
@@ -19,4 +19,4 @@ data:
   SMTP_HOST: email-smtp.us-east-1.amazonaws.com
   SMTP_PORT: '465'
   SMTP_SECURE: 'true'
-  NEXT_PUBLIC_EMBEDDED_AUTH_ALLOWED_ORIGIN: https://eddie.us-east-1.prd.cloudhumans.io,https://cloudchat.cloudhumans.com,https://cloudchat2.cloudhumans.com,https://cloudchat3.cloudhumans.com
+  NEXT_PUBLIC_EMBEDDED_AUTH_ALLOWED_ORIGIN: https://eddie.us-east-1.prd.cloudhumans.io,https://cloudchat.cloudhumans.com,https://cloudchat2.cloudhumans.com,https://cloudchat3.cloudhumans.com,https://*.app.cloudhumans.com

--- a/deploy/overlays/prd-instance2/typebot-builder-configmap.yaml
+++ b/deploy/overlays/prd-instance2/typebot-builder-configmap.yaml
@@ -20,4 +20,4 @@ data:
   SMTP_PORT: '465'
   SMTP_SECURE: 'true'
   AWS_COGNITO_REGION: us-east-1
-  NEXT_PUBLIC_EMBEDDED_AUTH_ALLOWED_ORIGIN: https://eddie2.us-east-1.prd.cloudhumans.io,https://cloudchat.cloudhumans.com,https://cloudchat2.cloudhumans.com,https://cloudchat3.cloudhumans.com
+  NEXT_PUBLIC_EMBEDDED_AUTH_ALLOWED_ORIGIN: https://eddie2.us-east-1.prd.cloudhumans.io,https://cloudchat.cloudhumans.com,https://cloudchat2.cloudhumans.com,https://cloudchat3.cloudhumans.com,https://*.app.cloudhumans.com

--- a/deploy/overlays/prd/typebot-builder-configmap.yaml
+++ b/deploy/overlays/prd/typebot-builder-configmap.yaml
@@ -20,4 +20,4 @@ data:
   SMTP_PORT: '465'
   SMTP_SECURE: 'true'
   AWS_COGNITO_REGION: us-east-1
-  NEXT_PUBLIC_EMBEDDED_AUTH_ALLOWED_ORIGIN: https://eddie.us-east-1.prd.cloudhumans.io,https://cloudchat.cloudhumans.com,https://cloudchat2.cloudhumans.com,https://cloudchat3.cloudhumans.com
+  NEXT_PUBLIC_EMBEDDED_AUTH_ALLOWED_ORIGIN: https://eddie.us-east-1.prd.cloudhumans.io,https://cloudchat.cloudhumans.com,https://cloudchat2.cloudhumans.com,https://cloudchat3.cloudhumans.com,https://*.app.cloudhumans.com

--- a/packages/lib/origin.ts
+++ b/packages/lib/origin.ts
@@ -1,0 +1,28 @@
+/**
+ * Helper function to check if an origin matches a pattern (supporting wildcards)
+ * @param origin - The origin to check (e.g., "https://myapp.app.cloudhumans.com")
+ * @param pattern - The pattern to match against (e.g., "https://*.app.cloudhumans.com")
+ * @returns true if the origin matches the pattern
+ */
+export const matchesOriginPattern = (origin: string, pattern: string): boolean => {
+  if (pattern.startsWith('*.')) {
+    const domain = pattern.substring(2)
+    try {
+      const originUrl = new URL(origin)
+      return originUrl.hostname.endsWith('.' + domain) || originUrl.hostname === domain
+    } catch {
+      return false
+    }
+  }
+  return origin === pattern
+}
+
+/**
+ * Helper function to check if an origin is allowed against a list of patterns
+ * @param origin - The origin to check
+ * @param allowedPatterns - Array of allowed origin patterns (may include wildcards)
+ * @returns true if the origin matches any of the allowed patterns
+ */
+export const isOriginAllowed = (origin: string, allowedPatterns: string[]): boolean => {
+  return allowedPatterns.some(pattern => matchesOriginPattern(origin, pattern))
+}


### PR DESCRIPTION
- Add support for *.app.cloudhumans.com in NEXT_PUBLIC_EMBEDDED_AUTH_ALLOWED_ORIGIN
- Create shared utility in packages/lib/origin.ts for wildcard domain matching
- Update embedded auth utils to use wildcard matching
- Simplify CORS middleware with cleaner CSP frame-ancestors handling
- Add https://*.app.cloudhumans.com to deployment configs

This allows the builder to be embedded on any subdomain of app.cloudhumans.com while maintaining security through proper origin validation.