### PR TITLE
feat: add migration job for running typebot migration on GitHub

### DIFF
--- a/.github/workflows/typebot.yaml
+++ b/.github/workflows/typebot.yaml
@@ -156,6 +156,7 @@ jobs:
 
   build:
     if: ${{ github.ref == 'refs/heads/main' }}
+    needs: migrate
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/typebot.yaml
+++ b/.github/workflows/typebot.yaml
@@ -11,6 +11,7 @@ env:
   ECR_BUILDER_REPOSITORY: typebot-builder
   ECR_VIEWER_REPOSITORY: typebot-viewer
   ECR_REGISTRY: 585814034319.dkr.ecr.us-east-1.amazonaws.com
+  SSM_PARAM_NAME: '/prd/typebot/databases'
 
 jobs:
   prepare-matrix:
@@ -30,8 +31,6 @@ jobs:
 
       - name: Fetch SSM parameter & build matrix (names only, no jq)
         id: build-matrix
-        env:
-          SSM_PARAM_NAME: '/prd/typebot/databases'
         run: |
           set -euo pipefail
           echo "Reading SSM parameter: $SSM_PARAM_NAME"
@@ -110,7 +109,6 @@ jobs:
         id: prepare-connection
         env:
           INSTANCE_NAME: ${{ matrix.name }}
-          SSM_PARAM_NAME: '/prd/typebot/databases'
         run: |
           set -euo pipefail
           if [ -z "${INSTANCE_NAME:-}" ]; then

--- a/.github/workflows/typebot.yaml
+++ b/.github/workflows/typebot.yaml
@@ -86,11 +86,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18'
-
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/typebot.yaml
+++ b/.github/workflows/typebot.yaml
@@ -21,7 +21,7 @@ jobs:
       count: ${{ steps.build-matrix.outputs.count }}
     steps:
       - name: Configure AWS credentials production
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_CI_EKS_PRODUCTION_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_CI_EKS_PRODUCTION_SECRET }}

--- a/.github/workflows/typebot.yaml
+++ b/.github/workflows/typebot.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - fix/migrations
+      - feat/run-typbot-migration-on-github
 
 env:
   AWS_REGION: us-east-1
@@ -13,6 +13,32 @@ env:
   ECR_REGISTRY: 585814034319.dkr.ecr.us-east-1.amazonaws.com
 
 jobs:
+  migrate:
+    if: ${{ github.ref == 'refs/heads/feat/run-typbot-migration-on-github' }}
+    runs-on: [self-hosted, production]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials production
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_CI_EKS_PRODUCTION_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_CI_EKS_PRODUCTION_SECRET }}
+          aws-region: us-east-1
+
+      - name: test postgres connection
+        run: |
+          set -euo pipefail
+          IMAGE=postgres:17-alpine
+          echo "Pulling $IMAGE..."
+          docker pull "$IMAGE"
+          echo "Testing Postgres connection (using official image)..."
+          # Usando SELECT 1 para teste rápido; troque para SELECT now() se quiser timestamp.
+          docker run --rm "$IMAGE" \
+            psql "${{ secrets.POSTGRES_CONNECTION }}" -v ON_ERROR_STOP=1 -c 'SELECT 1;'
+
   build:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/typebot.yaml
+++ b/.github/workflows/typebot.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
 
 env:
   AWS_REGION: us-east-1
@@ -150,7 +154,7 @@ jobs:
           echo "Migration done for $INSTANCE_NAME"
 
   build:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     needs: migrate
     runs-on: ubuntu-latest
 

--- a/.github/workflows/typebot.yaml
+++ b/.github/workflows/typebot.yaml
@@ -77,7 +77,7 @@ jobs:
     runs-on: [self-hosted, production]
     steps:
       - name: Configure AWS credentials production
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_CI_EKS_PRODUCTION_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_CI_EKS_PRODUCTION_SECRET }}

--- a/.github/workflows/typebot.yaml
+++ b/.github/workflows/typebot.yaml
@@ -118,7 +118,7 @@ jobs:
           echo "Testing Postgres connection to instance $INSTANCE_NAME (using official image)..."
           # Usando SELECT 1 para teste rápido; troque para SELECT now() se quiser timestamp.
           docker run --rm "$IMAGE" \
-            psql "${{ CONNECTION }}" -v ON_ERROR_STOP=1 -c 'SELECT 1;'
+            psql "$CONNECTION" -v ON_ERROR_STOP=1 -c 'SELECT 1;'
 
       # - name: Run migration
       #   if: false

--- a/.github/workflows/typebot.yaml
+++ b/.github/workflows/typebot.yaml
@@ -90,10 +90,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          node-version: '18'
           version: 8.15.4
           run_install: false
 

--- a/.github/workflows/typebot.yaml
+++ b/.github/workflows/typebot.yaml
@@ -84,7 +84,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/typebot.yaml
+++ b/.github/workflows/typebot.yaml
@@ -117,13 +117,13 @@ jobs:
           esac
           echo "::add-mask::$CONNECTION"
           echo "Prepared connection for $INSTANCE_NAME"
-          # Export for subsequent steps
-          echo "CONNECTION=$CONNECTION" >> "$GITHUB_ENV"
+          # Set as step output
+          echo "connection=$CONNECTION" >> "$GITHUB_OUTPUT"
 
       - name: Test connection
         env:
           INSTANCE_NAME: ${{ matrix.name }}
-          CONNECTION: ${{ env.CONNECTION }}
+          CONNECTION: ${{ steps.prepare-connection.outputs.connection }}
         run: |
           set -euo pipefail
           if [ -z "${CONNECTION:-}" ]; then
@@ -139,7 +139,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         env:
           INSTANCE_NAME: ${{ matrix.name }}
-          CONNECTION: ${{ env.CONNECTION }}
+          CONNECTION: ${{ steps.prepare-connection.outputs.connection }}
         run: |
           set -euo pipefail
           if [ -z "${CONNECTION:-}" ]; then

--- a/.github/workflows/typebot.yaml
+++ b/.github/workflows/typebot.yaml
@@ -13,14 +13,14 @@ env:
   ECR_REGISTRY: 585814034319.dkr.ecr.us-east-1.amazonaws.com
 
 jobs:
-  migrate:
+  prepare-matrix:
+    name: Prepare migration matrix
     if: ${{ github.ref == 'refs/heads/feat/run-typbot-migration-on-github' }}
-    runs-on: [self-hosted, production]
-
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+      count: ${{ steps.build-matrix.outputs.count }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
       - name: Configure AWS credentials production
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -28,16 +28,113 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_CI_EKS_PRODUCTION_SECRET }}
           aws-region: us-east-1
 
-      - name: test postgres connection
+      - name: Fetch SSM parameter & build matrix JSON
+        id: build-matrix
+        env:
+          SSM_PARAM_NAME: '/prd/typebot/databases'
+        run: |
+          set -euo pipefail
+          echo "Reading SSM parameter: $SSM_PARAM_NAME"
+          RAW=$(aws ssm get-parameter --name "$SSM_PARAM_NAME" --with-decryption --query 'Parameter.Value' --output text || true)
+          if [ -z "$RAW" ]; then
+            echo "No content in parameter" >&2
+            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Building matrix... (content redacted)"
+          JSON_ITEMS="[]"
+          # Use jq if available; otherwise fall back to manual assembly
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "jq not found. Downloading locally..."
+            curl -sSL https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-amd64 -o jq && chmod +x jq
+            PATH="$PWD:$PATH"
+          fi
+          # Filter valid lines and turn into JSON objects
+          # Supports passwords containing '=' by using parameter expansion
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            case "$line" in \#*) continue;; esac
+            case "$line" in *=*) : ;; *) continue;; esac
+            NAME=${line%%=*}
+            CONN=${line#*=}
+            [ -z "$CONN" ] && continue
+            case "$CONN" in
+              postgresql://*|postgres://*) : ;;
+              *) echo "Skipping $NAME (invalid protocol)" >&2; continue;;
+            esac
+            OBJ=$(jq -nc --arg name "$NAME" --arg connection "$CONN" '{name:$name,connection:$connection}')
+            JSON_ITEMS=$(jq -nc --argjson arr "$JSON_ITEMS" --argjson obj "$OBJ" '$arr + [$obj]')
+          done <<< "$RAW"
+          MATRIX=$(jq -nc --argjson inc "$JSON_ITEMS" '{include:$inc}')
+          COUNT=$(echo "$MATRIX" | jq '.include | length')
+          echo "Matrix count: $COUNT" >&2
+          if [ "$COUNT" -gt 0 ]; then
+            echo "Instances included:" >&2
+            echo "$MATRIX" | jq -r '.include[] | " - " + .name' >&2
+          fi
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+  migrate:
+    name: Migrate (per instance)
+    if: ${{ github.ref == 'refs/heads/feat/run-typbot-migration-on-github' && needs.prepare-matrix.outputs.count != '0' }}
+    needs: prepare-matrix
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
+    runs-on: [self-hosted, production]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.4
+          run_install: false
+
+      - name: Install dependencies (prisma only)
+        run: |
+          set -euo pipefail
+          pnpm install --frozen-lockfile --filter @typebot.io/prisma... || pnpm install --frozen-lockfile
+
+      - name: Test connection
+        if: false
+        env:
+          INSTANCE_NAME: ${{ matrix.name }}
+          CONNECTION: ${{ matrix.connection }}
         run: |
           set -euo pipefail
           IMAGE=postgres:17-alpine
           echo "Pulling $IMAGE..."
           docker pull "$IMAGE"
-          echo "Testing Postgres connection (using official image)..."
+          echo "Testing Postgres connection to instance $INSTANCE_NAME (using official image)..."
           # Usando SELECT 1 para teste rápido; troque para SELECT now() se quiser timestamp.
           docker run --rm "$IMAGE" \
-            psql "${{ secrets.POSTGRES_CONNECTION }}" -v ON_ERROR_STOP=1 -c 'SELECT 1;'
+            psql "${{ CONNECTION }}" -v ON_ERROR_STOP=1 -c 'SELECT 1;'
+
+      # - name: Run migration
+      #   if: false
+      #   env:
+      #     INSTANCE_NAME: ${{ matrix.name }}
+      #     CONNECTION: ${{ matrix.connection }}
+      #   run: |
+      #     set -euo pipefail
+      #     if [ -z "${CONNECTION:-}" ]; then
+      #       echo "Empty connection for $INSTANCE_NAME" >&2
+      #       exit 1
+      #     fi
+
+      #     echo "Running migration for instance: $INSTANCE_NAME"
+      #     DATABASE_URL="$CONNECTION" pnpm --filter @typebot.io/prisma exec prisma migrate deploy --schema=packages/prisma/postgresql/schema.prisma
+      #     echo "Migration done for $INSTANCE_NAME"
 
   build:
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/typebot.yaml
+++ b/.github/workflows/typebot.yaml
@@ -85,13 +85,13 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '18'
           cache: 'pnpm'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8.15.4
+          node-version: '18'
           run_install: false
 
       - name: Install dependencies (prisma only)

--- a/.github/workflows/typebot.yaml
+++ b/.github/workflows/typebot.yaml
@@ -28,7 +28,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_CI_EKS_PRODUCTION_SECRET }}
           aws-region: us-east-1
 
-      - name: Fetch SSM parameter & build matrix JSON
+      - name: Fetch SSM parameter & build matrix (names only, no jq)
         id: build-matrix
         env:
           SSM_PARAM_NAME: '/prd/typebot/databases'
@@ -41,39 +41,33 @@ jobs:
             echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "Building matrix... (content redacted)"
-          JSON_ITEMS="[]"
-          # Use jq if available; otherwise fall back to manual assembly
-          if ! command -v jq >/dev/null 2>&1; then
-            echo "jq not found. Downloading locally..."
-            curl -sSL https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-amd64 -o jq && chmod +x jq
-            PATH="$PWD:$PATH"
-          fi
-          # Filter valid lines and turn into JSON objects
-          # Supports passwords containing '=' by using parameter expansion
+          echo "Building matrix (pure bash)..."
+          items=""
+          count=0
           while IFS= read -r line; do
             [ -z "$line" ] && continue
             case "$line" in \#*) continue;; esac
             case "$line" in *=*) : ;; *) continue;; esac
-            NAME=${line%%=*}
-            CONN=${line#*=}
-            [ -z "$CONN" ] && continue
-            case "$CONN" in
-              postgresql://*|postgres://*) : ;;
-              *) echo "Skipping $NAME (invalid protocol)" >&2; continue;;
-            esac
-            OBJ=$(jq -nc --arg name "$NAME" --arg connection "$CONN" '{name:$name,connection:$connection}')
-            JSON_ITEMS=$(jq -nc --argjson arr "$JSON_ITEMS" --argjson obj "$OBJ" '$arr + [$obj]')
+            name=${line%%=*}
+            [ -z "$name" ] && continue
+            safe_name=$(printf '%s' "$name" | tr -cd '[:alnum:]_-')
+            [ -z "$safe_name" ] && continue
+            case ",$items," in *",{\"name\":\"$safe_name\"},"*) continue;; esac
+            if [ -n "$items" ]; then
+              items="$items,{\"name\":\"$safe_name\"}"
+            else
+              items="{\"name\":\"$safe_name\"}"
+            fi
+            count=$((count+1))
           done <<< "$RAW"
-          MATRIX=$(jq -nc --argjson inc "$JSON_ITEMS" '{include:$inc}')
-          COUNT=$(echo "$MATRIX" | jq '.include | length')
-          echo "Matrix count: $COUNT" >&2
-          if [ "$COUNT" -gt 0 ]; then
-            echo "Instances included:" >&2
-            echo "$MATRIX" | jq -r '.include[] | " - " + .name' >&2
+          MATRIX='{"include":['"$items"']}'
+          echo "Matrix count: $count" >&2
+          if [ "$count" -gt 0 ]; then
+            echo "Instances included (names only):" >&2
+            printf '%s' "$items" | sed -n 's/.*"name":"\([^"]*\)".*/ - \1/p'
           fi
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
 
   migrate:
     name: Migrate (per instance)
@@ -105,36 +99,56 @@ jobs:
           set -euo pipefail
           pnpm install --frozen-lockfile --filter @typebot.io/prisma... || pnpm install --frozen-lockfile
 
-      - name: Test connection
-        if: false
+      - name: Prepare connection
+        id: prepare-connection
         env:
           INSTANCE_NAME: ${{ matrix.name }}
-          CONNECTION: ${{ matrix.connection }}
+          SSM_PARAM_NAME: '/prd/typebot/databases'
         run: |
           set -euo pipefail
+          if [ -z "${INSTANCE_NAME:-}" ]; then
+            echo "Missing INSTANCE_NAME" >&2; exit 1; fi
+          RAW=$(aws ssm get-parameter --name "$SSM_PARAM_NAME" --with-decryption --query 'Parameter.Value' --output text)
+          LINE=$(printf '%s\n' "$RAW" | grep -E "^${INSTANCE_NAME}=") || { echo "Instance $INSTANCE_NAME not found" >&2; exit 1; }
+          CONNECTION=${LINE#*=}
+          if [ -z "$CONNECTION" ]; then
+            echo "Empty connection string for $INSTANCE_NAME" >&2; exit 1; fi
+          case "$CONNECTION" in
+            postgresql://*|postgres://*) : ;;
+            *) echo "Invalid protocol for $INSTANCE_NAME" >&2; exit 1;;
+          esac
+          echo "::add-mask::$CONNECTION"
+          echo "Prepared connection for $INSTANCE_NAME"
+          # Export for subsequent steps
+          echo "CONNECTION=$CONNECTION" >> "$GITHUB_ENV"
+
+      - name: Test connection
+        env:
+          INSTANCE_NAME: ${{ matrix.name }}
+          CONNECTION: ${{ env.CONNECTION }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CONNECTION:-}" ]; then
+            echo "Missing CONNECTION variable for $INSTANCE_NAME" >&2; exit 1; fi
           IMAGE=postgres:17-alpine
-          echo "Pulling $IMAGE..."
-          docker pull "$IMAGE"
-          echo "Testing Postgres connection to instance $INSTANCE_NAME (using official image)..."
-          # Usando SELECT 1 para teste rápido; troque para SELECT now() se quiser timestamp.
-          docker run --rm "$IMAGE" \
-            psql "$CONNECTION" -v ON_ERROR_STOP=1 -c 'SELECT 1;'
+          echo "Pulling $IMAGE for test..."
+          docker pull "$IMAGE" >/dev/null
+          echo "Testing connection for $INSTANCE_NAME"
+          docker run --rm "$IMAGE" sh -c "PGCONNECT_TIMEOUT=5 psql '$CONNECTION' -v ON_ERROR_STOP=1 -c 'SELECT 1;'" >/dev/null
+          echo "Connection OK for $INSTANCE_NAME"
 
-      # - name: Run migration
-      #   if: false
-      #   env:
-      #     INSTANCE_NAME: ${{ matrix.name }}
-      #     CONNECTION: ${{ matrix.connection }}
-      #   run: |
-      #     set -euo pipefail
-      #     if [ -z "${CONNECTION:-}" ]; then
-      #       echo "Empty connection for $INSTANCE_NAME" >&2
-      #       exit 1
-      #     fi
-
-      #     echo "Running migration for instance: $INSTANCE_NAME"
-      #     DATABASE_URL="$CONNECTION" pnpm --filter @typebot.io/prisma exec prisma migrate deploy --schema=packages/prisma/postgresql/schema.prisma
-      #     echo "Migration done for $INSTANCE_NAME"
+      - name: Run migration
+        if: false # Temporarily disabled; enable later by removing or changing this condition
+        env:
+          INSTANCE_NAME: ${{ matrix.name }}
+          CONNECTION: ${{ env.CONNECTION }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CONNECTION:-}" ]; then
+            echo "Missing CONNECTION variable for $INSTANCE_NAME" >&2; exit 1; fi
+          echo "Running migration for instance: $INSTANCE_NAME"
+          DATABASE_URL="$CONNECTION" pnpm --filter @typebot.io/prisma exec prisma migrate deploy --schema=packages/prisma/postgresql/schema.prisma
+          echo "Migration done for $INSTANCE_NAME"
 
   build:
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/typebot.yaml
+++ b/.github/workflows/typebot.yaml
@@ -86,12 +86,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18'
-          cache: 'pnpm'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
           node-version: '18'
+          version: 8.15.4
           run_install: false
 
       - name: Install dependencies (prisma only)

--- a/.github/workflows/typebot.yaml
+++ b/.github/workflows/typebot.yaml
@@ -79,6 +79,13 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
     runs-on: [self-hosted, production]
     steps:
+      - name: Configure AWS credentials production
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_CI_EKS_PRODUCTION_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_CI_EKS_PRODUCTION_SECRET }}
+          aws-region: us-east-1
+
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/typebot.yaml
+++ b/.github/workflows/typebot.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feat/run-typbot-migration-on-github
 
 env:
   AWS_REGION: us-east-1
@@ -16,7 +15,6 @@ env:
 jobs:
   prepare-matrix:
     name: Prepare migration matrix
-    if: ${{ github.ref == 'refs/heads/feat/run-typbot-migration-on-github' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
@@ -70,7 +68,7 @@ jobs:
 
   migrate:
     name: Migrate (per instance)
-    if: ${{ github.ref == 'refs/heads/feat/run-typbot-migration-on-github' && needs.prepare-matrix.outputs.count != '0' }}
+    if: ${{ needs.prepare-matrix.outputs.count != '0' }}
     needs: prepare-matrix
     strategy:
       fail-fast: false
@@ -143,7 +141,7 @@ jobs:
           echo "Connection OK for $INSTANCE_NAME"
 
       - name: Run migration
-        if: false # Temporarily disabled; enable later by removing or changing this condition
+        if: ${{ github.ref == 'refs/heads/main' }}
         env:
           INSTANCE_NAME: ${{ matrix.name }}
           CONNECTION: ${{ env.CONNECTION }}

--- a/.github/workflows/typebot.yaml
+++ b/.github/workflows/typebot.yaml
@@ -154,7 +154,8 @@ jobs:
           if [ -z "${CONNECTION:-}" ]; then
             echo "Missing CONNECTION variable for $INSTANCE_NAME" >&2; exit 1; fi
           echo "Running migration for instance: $INSTANCE_NAME"
-          DATABASE_URL="$CONNECTION" pnpm --filter @typebot.io/prisma exec prisma migrate deploy --schema=packages/prisma/postgresql/schema.prisma
+          # Use the package script which auto-selects the correct schema based on DATABASE_URL
+          DATABASE_URL="$CONNECTION" pnpm --filter @typebot.io/prisma run migrate:deploy
           echo "Migration done for $INSTANCE_NAME"
 
   build:

--- a/packages/prisma/postgresql/migrations/20250929000000_remove_editing_fields_from_typebot_2/migration.sql
+++ b/packages/prisma/postgresql/migrations/20250929000000_remove_editing_fields_from_typebot_2/migration.sql
@@ -1,0 +1,7 @@
+-- Migration: remove_editing_fields_from_typebot
+
+ALTER TABLE "Typebot"
+  DROP COLUMN IF EXISTS "editingUserName",
+  DROP COLUMN IF EXISTS "editingUserEmail",
+  DROP COLUMN IF EXISTS "isBeingEdited",
+  DROP COLUMN IF EXISTS "editingStartedAt";


### PR DESCRIPTION
This pull request introduces a major update to the `typebot` GitHub Actions workflow for production migrations. The workflow now dynamically discovers database instances from AWS SSM, prepares a matrix of instances, and runs migrations in parallel per instance. This ensures that migrations are applied safely and efficiently across all managed databases.

**Workflow orchestration and AWS integration:**

* Added a new `prepare-matrix` job to fetch database instance names from AWS SSM Parameter Store, build a matrix, and expose it for subsequent jobs. This enables dynamic discovery and scaling of migrations to all configured instances.
* Updated the environment variable configuration to include `SSM_PARAM_NAME`, making the workflow parameterized and easier to maintain for different environments.

**Parallel migration execution:**

* Introduced a new `migrate` job that runs per instance in the matrix, sets up the environment, securely prepares and validates database connections, and runs Prisma migrations only on the `main` branch. This job is triggered only if there are instances to migrate.
* The migration job includes steps for dependency installation, connection preparation and masking, connection testing using Docker, and migration execution using Prisma, ensuring robust and safe migration for each instance.

**Workflow dependency and cleanup:**

* The main

<img width="1208" height="534" alt="image" src="https://github.com/user-attachments/assets/fcd51663-7a39-4ff2-be12-d4eebf7d7854" />
