### PR TITLE
fix: handle wildcard origins in embedded authentication

### DIFF
--- a/apps/builder/src/features/embedded-auth/embedded-auth.ts
+++ b/apps/builder/src/features/embedded-auth/embedded-auth.ts
@@ -57,8 +57,20 @@ const handleAuthError = (
       targetOrigin
     )
   } else {
-    // Fallback: try all allowed origins
-    getAllowedOrigins().forEach((origin) => {
+    // Fallback: try all allowed origins, but filter out wildcard patterns since postMessage doesn't support them
+    const allowedOrigins = getAllowedOrigins()
+    const nonWildcardOrigins = allowedOrigins.filter(
+      (origin) => !origin.includes('*')
+    )
+
+    if (nonWildcardOrigins.length === 0) {
+      console.error(
+        '❌ No valid target origins for AUTH_ERROR (all contain wildcards)'
+      )
+      return false
+    }
+
+    nonWildcardOrigins.forEach((origin) => {
       window.parent.postMessage(
         {
           type: 'AUTH_ERROR',


### PR DESCRIPTION
- Use document.referrer when available for specific origin targeting
- Filter out wildcard patterns from postMessage targets since they're not supported
- Maintain wildcard validation for incoming messages
- Fixes authentication issues with subdomains like coalize.app.cloudhumans.com