### PR TITLE
Adiciona botão de FAQ Eddie na barra superior do Typebot.

### DIFF
--- a/apps/builder/src/features/editor/components/TypebotHeader.tsx
+++ b/apps/builder/src/features/editor/components/TypebotHeader.tsx
@@ -401,6 +401,19 @@ const TypebotNav = ({
           {t('editor.header.resultsButton.label')}
         </Button>
       )}
+      {router.query.embedded !== 'true' && (
+        <Button
+          as={Link}
+          href={t(
+            'editor.gettingStartedModal.editorBasics.list.faq-by-language'
+          )}
+          target="_blank"
+          rel="noopener noreferrer"
+          size="sm"
+        >
+          {t('FAQ')}
+        </Button>
+      )}
     </HStack>
   )
 }

--- a/apps/builder/src/i18n/en.json
+++ b/apps/builder/src/i18n/en.json
@@ -578,5 +578,6 @@
   "blocks.logic.wait.settings.input.label": "Seconds to wait (max {max}s):",
   "blocks.logic.wait.settings.toast.maxReached.title": "Maximum limit reached",
   "blocks.logic.wait.settings.toast.maxReached.description": "The maximum waiting time allowed is {max} seconds.",
-  "blocks.logic.wait.validation.secondsOrVariable": "Must be a number or a variable in {{}}"
+  "blocks.logic.wait.validation.secondsOrVariable": "Must be a number or a variable in {{}}",
+  "editor.gettingStartedModal.editorBasics.list.faq-by-language": "https://cloudchat.cloudhumans.com/hc/claudia/en/"
 }

--- a/apps/builder/src/i18n/en.json
+++ b/apps/builder/src/i18n/en.json
@@ -579,5 +579,5 @@
   "blocks.logic.wait.settings.toast.maxReached.title": "Maximum limit reached",
   "blocks.logic.wait.settings.toast.maxReached.description": "The maximum waiting time allowed is {max} seconds.",
   "blocks.logic.wait.validation.secondsOrVariable": "Must be a number or a variable in {{}}",
-  "editor.gettingStartedModal.editorBasics.list.faq-by-language": "https://cloudchat.cloudhumans.com/hc/claudia/en/"
+  "editor.gettingStartedModal.editorBasics.list.faq-by-language": "https://cloudchat.cloudhumans.com/hc/fluxos-controlados-e-tools/en"
 }

--- a/apps/builder/src/i18n/es.json
+++ b/apps/builder/src/i18n/es.json
@@ -577,5 +577,6 @@
   "blocks.logic.wait.seconds": "segundos",
   "blocks.logic.wait.settings.input.label": "Segundos de espera (máx {max}s):",
   "blocks.logic.wait.settings.toast.maxReached.title": "Límite máximo alcanzado",
-  "blocks.logic.wait.settings.toast.maxReached.description": "El tiempo máximo de espera permitido es {max} segundos."
+  "blocks.logic.wait.settings.toast.maxReached.description": "El tiempo máximo de espera permitido es {max} segundos.",
+  "editor.gettingStartedModal.editorBasics.list.faq-by-language": "https://cloudchat.cloudhumans.com/hc/claudia/es/"
 }

--- a/apps/builder/src/i18n/es.json
+++ b/apps/builder/src/i18n/es.json
@@ -578,5 +578,5 @@
   "blocks.logic.wait.settings.input.label": "Segundos de espera (máx {max}s):",
   "blocks.logic.wait.settings.toast.maxReached.title": "Límite máximo alcanzado",
   "blocks.logic.wait.settings.toast.maxReached.description": "El tiempo máximo de espera permitido es {max} segundos.",
-  "editor.gettingStartedModal.editorBasics.list.faq-by-language": "https://cloudchat.cloudhumans.com/hc/claudia/es/"
+  "editor.gettingStartedModal.editorBasics.list.faq-by-language": "https://cloudchat.cloudhumans.com/hc/fluxos-controlados-e-tools/es"
 }

--- a/apps/builder/src/i18n/pt-BR.json
+++ b/apps/builder/src/i18n/pt-BR.json
@@ -578,5 +578,6 @@
   "blocks.logic.wait.settings.input.label": "Segundos de espera (máx {max}s):",
   "blocks.logic.wait.settings.toast.maxReached.title": "Limite máximo atingido",
   "blocks.logic.wait.settings.toast.maxReached.description": "O tempo máximo de espera permitido é {max} segundos.",
-  "blocks.logic.wait.validation.secondsOrVariable": "Deve ser um número ou uma variável em {{}}"
+  "blocks.logic.wait.validation.secondsOrVariable": "Deve ser um número ou uma variável em {{}}",
+  "editor.gettingStartedModal.editorBasics.list.faq-by-language": "https://cloudchat.cloudhumans.com/hc/claudia/pt_BR/"
 }

--- a/apps/builder/src/i18n/pt-BR.json
+++ b/apps/builder/src/i18n/pt-BR.json
@@ -579,5 +579,5 @@
   "blocks.logic.wait.settings.toast.maxReached.title": "Limite máximo atingido",
   "blocks.logic.wait.settings.toast.maxReached.description": "O tempo máximo de espera permitido é {max} segundos.",
   "blocks.logic.wait.validation.secondsOrVariable": "Deve ser um número ou uma variável em {{}}",
-  "editor.gettingStartedModal.editorBasics.list.faq-by-language": "https://cloudchat.cloudhumans.com/hc/claudia/pt_BR/"
+  "editor.gettingStartedModal.editorBasics.list.faq-by-language": "https://cloudchat.cloudhumans.com/hc/fluxos-controlados-e-tools"
 }


### PR DESCRIPTION
Ajustado também para as FAQs nas linguagens inglês e espanhol.

<img width="1915" height="987" alt="Eddie - ajuste 2" src="https://github.com/user-attachments/assets/baa5f7bf-3dd8-49c0-a1c1-1fac84a822ae" />

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

O PR parece seguro para merge, sem falhas concretas identificadas nas alterações.

O novo botão é omitido no modo embedded, abre uma URL fixa correspondente ao idioma e aplica as proteções apropriadas para links em nova aba.

<sub>Reviews (1): Last reviewed commit: ["Ajusta link do botão FAQ para fluxos-con..."](https://github.com/cloudhumans/typebot.io/commit/4c5c57bf78fb38a0785489b140911dabe99611cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46698796)</sub>

<!-- /greptile_comment -->