### PR TITLE
Melhoria nas toasts de success e error, aumentando duração para 30seg + barra de progressão

### DIFF
--- a/apps/builder/src/components/Toast.tsx
+++ b/apps/builder/src/components/Toast.tsx
@@ -4,6 +4,7 @@ import {
   AccordionIcon,
   AccordionItem,
   AccordionPanel,
+  Box,
   Flex,
   HStack,
   IconButton,
@@ -11,6 +12,7 @@ import {
   Text,
   useColorModeValue,
 } from '@chakra-ui/react'
+import { useEffect, useState } from 'react'
 import { AlertIcon, CloseIcon, InfoIcon, SmileIcon } from './icons'
 import { CodeEditor } from './inputs/CodeEditor'
 import { LanguageName } from '@uiw/codemirror-extensions-langs'
@@ -26,6 +28,7 @@ export type ToastProps = {
   icon?: React.ReactNode
   primaryButton?: React.ReactNode
   secondaryButton?: React.ReactNode
+  duration?: number | null | undefined
   onClose: () => void
 }
 
@@ -37,10 +40,17 @@ export const Toast = ({
   icon,
   primaryButton,
   secondaryButton,
+  duration,
   onClose,
 }: ToastProps) => {
   const bgColor = useColorModeValue('white', 'gray.800')
   const detailsLabelColor = useColorModeValue('gray.600', 'gray.400')
+  const [scale, setScale] = useState(1)
+  useEffect(() => {
+    if (!duration) return
+    const raf = requestAnimationFrame(() => setScale(0))
+    return () => cancelAnimationFrame(raf)
+  }, [duration])
 
   return (
     <Flex
@@ -51,6 +61,7 @@ export const Toast = ({
       shadow="sm"
       fontSize="sm"
       pos="relative"
+      zIndex={9999}
       maxW={details ? '450px' : '300px'}
     >
       <HStack alignItems="flex-start" pr="7" spacing="3" w="full">
@@ -105,6 +116,31 @@ export const Toast = ({
         top={1}
         right={1}
       />
+
+      {duration ? (
+        <Box
+          pos="absolute"
+          left={0}
+          right={0}
+          bottom={0}
+          height="3px"
+          bg="transparent"
+        >
+          <Box
+            pos="absolute"
+            left={0}
+            right={0}
+            top={0}
+            bottom={0}
+            bgColor={`${parseColor(status)}.500`}
+            style={{
+              transformOrigin: 'right',
+              transform: `scaleX(${scale})`,
+              transition: `transform ${duration}ms linear`,
+            }}
+          />
+        </Box>
+      ) : null}
     </Flex>
   )
 }

--- a/apps/builder/src/components/Toast.tsx
+++ b/apps/builder/src/components/Toast.tsx
@@ -8,14 +8,20 @@ import {
   Flex,
   HStack,
   IconButton,
+  keyframes,
   Stack,
   Text,
   useColorModeValue,
 } from '@chakra-ui/react'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { AlertIcon, CloseIcon, InfoIcon, SmileIcon } from './icons'
 import { CodeEditor } from './inputs/CodeEditor'
 import { LanguageName } from '@uiw/codemirror-extensions-langs'
+
+const shrink = keyframes`
+  from { transform: scaleX(1); }
+  to { transform: scaleX(0); }
+`
 
 export type ToastProps = {
   title?: string
@@ -45,12 +51,7 @@ export const Toast = ({
 }: ToastProps) => {
   const bgColor = useColorModeValue('white', 'gray.800')
   const detailsLabelColor = useColorModeValue('gray.600', 'gray.400')
-  const [scale, setScale] = useState(1)
-  useEffect(() => {
-    if (!duration) return
-    const raf = requestAnimationFrame(() => setScale(0))
-    return () => cancelAnimationFrame(raf)
-  }, [duration])
+  const [isExpanded, setIsExpanded] = useState(false)
 
   return (
     <Flex
@@ -73,7 +74,16 @@ export const Toast = ({
           </Stack>
 
           {details && (
-            <Accordion allowToggle>
+            <Accordion
+              allowToggle
+              onChange={(expandedIndex) =>
+                setIsExpanded(
+                  Array.isArray(expandedIndex)
+                    ? expandedIndex.length > 0
+                    : expandedIndex !== -1
+                )
+              }
+            >
               <AccordionItem>
                 <AccordionButton
                   justifyContent="space-between"
@@ -125,6 +135,7 @@ export const Toast = ({
           bottom={0}
           height="3px"
           bg="transparent"
+          overflow="hidden"
         >
           <Box
             pos="absolute"
@@ -133,10 +144,11 @@ export const Toast = ({
             top={0}
             bottom={0}
             bgColor={`${parseColor(status)}.500`}
-            style={{
-              transformOrigin: 'right',
-              transform: `scaleX(${scale})`,
-              transition: `transform ${duration}ms linear`,
+            transformOrigin="right"
+            onAnimationEnd={onClose}
+            sx={{
+              animation: `${shrink} ${duration}ms linear forwards`,
+              animationPlayState: isExpanded ? 'paused' : 'running',
             }}
           />
         </Box>

--- a/apps/builder/src/components/Toast.tsx
+++ b/apps/builder/src/components/Toast.tsx
@@ -62,7 +62,7 @@ export const Toast = ({
       shadow="sm"
       fontSize="sm"
       pos="relative"
-      zIndex={9999}
+      zIndex="toast"
       maxW={details ? '450px' : '300px'}
     >
       <HStack alignItems="flex-start" pr="7" spacing="3" w="full">

--- a/apps/builder/src/hooks/useToast.tsx
+++ b/apps/builder/src/hooks/useToast.tsx
@@ -15,9 +15,17 @@ export const useToast = () => {
       primaryButton,
       secondaryButton,
     }: Omit<ToastProps, 'onClose'>) => {
+      let duration: number | null | undefined
+
+      if (status === 'error' || status === 'success') {
+        duration = 30000 // 30 segundos
+      } else {
+        duration = undefined // Default
+      }
+
       toast({
         position: 'top-right',
-        duration: details && status === 'error' ? null : undefined,
+        duration,
         render: ({ onClose }) => (
           <Toast
             title={title}
@@ -25,6 +33,7 @@ export const useToast = () => {
             status={status}
             icon={icon}
             details={details}
+            duration={duration}
             onClose={onClose}
             primaryButton={primaryButton}
             secondaryButton={secondaryButton}

--- a/apps/builder/src/hooks/useToast.tsx
+++ b/apps/builder/src/hooks/useToast.tsx
@@ -15,6 +15,11 @@ export const useToast = () => {
       primaryButton,
       secondaryButton,
     }: Omit<ToastProps, 'onClose'>) => {
+      // `duration` alimenta a barra de progresso e o auto-fechamento
+      // controlado pela própria Toast (via onAnimationEnd). Quando definido,
+      // passamos `null` ao Chakra para que ele não feche a toast em paralelo —
+      // assim a barra e o fechamento ficam sempre em sincronia e podem pausar
+      // enquanto o "Details" está expandido.
       let duration: number | null | undefined
 
       if (status === 'error' || status === 'success') {
@@ -25,7 +30,7 @@ export const useToast = () => {
 
       toast({
         position: 'top-right',
-        duration,
+        duration: duration ? null : undefined,
         render: ({ onClose }) => (
           <Toast
             title={title}

--- a/apps/builder/src/hooks/useToast.tsx
+++ b/apps/builder/src/hooks/useToast.tsx
@@ -15,15 +15,15 @@ export const useToast = () => {
       primaryButton,
       secondaryButton,
     }: Omit<ToastProps, 'onClose'>) => {
-      // `duration` alimenta a barra de progresso e o auto-fechamento
-      // controlado pela própria Toast (via onAnimationEnd). Quando definido,
-      // passamos `null` ao Chakra para que ele não feche a toast em paralelo —
-      // assim a barra e o fechamento ficam sempre em sincronia e podem pausar
-      // enquanto o "Details" está expandido.
+      // `duration` drives the progress bar and the auto-dismiss, both handled
+      // by the Toast component itself (via onAnimationEnd). When it is set we
+      // pass `null` to Chakra so it doesn't dismiss the toast in parallel —
+      // that keeps the bar and the dismissal in sync and lets them pause while
+      // the "Details" section is expanded.
       let duration: number | null | undefined
 
       if (status === 'error' || status === 'success') {
-        duration = 30000 // 30 segundos
+        duration = 30000 // 30 seconds
       } else {
         duration = undefined // Default
       }

--- a/apps/builder/src/pages/_app.tsx
+++ b/apps/builder/src/pages/_app.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { AppProps } from 'next/app'
 import { SessionProvider } from 'next-auth/react'
-import { ChakraProvider, useToast as useChakraToast } from '@chakra-ui/react'
+import { ChakraProvider } from '@chakra-ui/react'
 import { customTheme } from '@/lib/theme'
 import { useRouterProgressBar } from '@/lib/routerProgressBar'
 import '@/assets/styles/routerProgressBar.css'
@@ -23,24 +23,24 @@ import { TolgeeProvider, useTolgeeSSR } from '@tolgee/react'
 import { tolgee } from '@/lib/tolgee'
 import { Toaster } from '@/components/Toaster'
 import { EmbeddedAuthWrapper } from '@/features/embedded-auth'
+import { useToast } from '@/hooks/useToast'
 
 // Rendered inside ChakraProvider so it can use the toast context. Shows the
 // Stripe upgrade-success toast that used to rely on a standalone toast
 // container (which duplicated every toast — see git history).
 const StripeUpgradeToast = () => {
   const router = useRouter()
-  const toast = useChakraToast()
+  const { showToast } = useToast()
 
   useEffect(() => {
     const newPlan = router.query.stripe?.toString()
     if (newPlan === Plan.STARTER || newPlan === Plan.PRO)
-      toast({
-        position: 'top-right',
+      showToast({
         status: 'success',
         title: 'Upgrade success!',
         description: `Workspace upgraded to ${toTitleCase(newPlan)} 🎉`,
       })
-  }, [router.query.stripe, toast])
+  }, [router.query.stripe, showToast])
 
   return null
 }

--- a/apps/builder/src/pages/_app.tsx
+++ b/apps/builder/src/pages/_app.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { AppProps } from 'next/app'
 import { SessionProvider } from 'next-auth/react'
-import { ChakraProvider, createStandaloneToast } from '@chakra-ui/react'
+import { ChakraProvider, useToast as useChakraToast } from '@chakra-ui/react'
 import { customTheme } from '@/lib/theme'
 import { useRouterProgressBar } from '@/lib/routerProgressBar'
 import '@/assets/styles/routerProgressBar.css'
@@ -24,7 +24,26 @@ import { tolgee } from '@/lib/tolgee'
 import { Toaster } from '@/components/Toaster'
 import { EmbeddedAuthWrapper } from '@/features/embedded-auth'
 
-const { ToastContainer, toast } = createStandaloneToast(customTheme)
+// Rendered inside ChakraProvider so it can use the toast context. Shows the
+// Stripe upgrade-success toast that used to rely on a standalone toast
+// container (which duplicated every toast — see git history).
+const StripeUpgradeToast = () => {
+  const router = useRouter()
+  const toast = useChakraToast()
+
+  useEffect(() => {
+    const newPlan = router.query.stripe?.toString()
+    if (newPlan === Plan.STARTER || newPlan === Plan.PRO)
+      toast({
+        position: 'top-right',
+        status: 'success',
+        title: 'Upgrade success!',
+        description: `Workspace upgraded to ${toTitleCase(newPlan)} 🎉`,
+      })
+  }, [router.query.stripe, toast])
+
+  return null
+}
 
 const App = ({ Component, pageProps }: AppProps) => {
   const router = useRouter()
@@ -45,24 +64,13 @@ const App = ({ Component, pageProps }: AppProps) => {
     }
   }, [router.pathname])
 
-  useEffect(() => {
-    const newPlan = router.query.stripe?.toString()
-    if (newPlan === Plan.STARTER || newPlan === Plan.PRO)
-      toast({
-        position: 'top-right',
-        status: 'success',
-        title: 'Upgrade success!',
-        description: `Workspace upgraded to ${toTitleCase(newPlan)} 🎉`,
-      })
-  }, [router.query.stripe])
-
   const typebotId = router.query.typebotId?.toString()
 
   return (
     <TolgeeProvider tolgee={ssrTolgee}>
-      <ToastContainer />
       <ChakraProvider theme={customTheme}>
         <Toaster />
+        <StripeUpgradeToast />
         <SessionProvider session={pageProps.session}>
           <EmbeddedAuthWrapper>
             <UserProvider>


### PR DESCRIPTION
Alterei o tempo das toasts de 'success' e 'error' de 5seg para 30seg.

Adicionei uma barra de progressão nas toasts.

<img width="1918" height="994" alt="Screenshot (53)" src="https://github.com/user-attachments/assets/0ba9339b-4440-43c9-9498-a6fb154342a7" />

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

O PR parece seguro para merge.

Nenhuma falha bloqueante permanece.

<sub>Reviews (2): Last reviewed commit: ["fix: toast de upgrade do Stripe usa o ho..."](https://github.com/cloudhumans/typebot.io/commit/d0fa58007ed13a5dff18b7ab2dec0f0778d76705) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46729733)</sub>

<!-- /greptile_comment -->