### PR TITLE
feat: implement search on main dashboard to navigate and highlight items

### DIFF
--- a/apps/builder/src/features/dashboard/components/DashboardPage.tsx
+++ b/apps/builder/src/features/dashboard/components/DashboardPage.tsx
@@ -16,6 +16,8 @@ import { ParentModalProvider } from '@/features/graph/providers/ParentModalProvi
 import { trpc } from '@/lib/trpc'
 import { guessIfUserIsEuropean } from '@typebot.io/billing/helpers/guessIfUserIsEuropean'
 import { useTranslate } from '@tolgee/react'
+import { DashboardSearchProvider } from '../providers/DashboardSearchProvider'
+import { DashboardSearchPanel } from './DashboardSearchPanel'
 
 export const DashboardPage = () => {
   const { t } = useTranslate()
@@ -57,29 +59,32 @@ export const DashboardPage = () => {
   }, [createCustomCheckoutSession, router.query, user, workspace])
 
   return (
-    <Stack minH="100vh">
-      <Seo title={workspace?.name ?? t('dashboard.title')} />
-      <DashboardHeader />
-      {!workspace?.stripeId && (
-        <ParentModalProvider>
-          <PreCheckoutModal
-            selectedSubscription={preCheckoutPlan}
-            existingEmail={user?.email ?? undefined}
-            existingCompany={workspace?.name ?? undefined}
-            onClose={() => setPreCheckoutPlan(undefined)}
-          />
-        </ParentModalProvider>
-      )}
-      <TypebotDndProvider>
-        {isLoading ? (
-          <VStack w="full" justifyContent="center" pt="10" spacing={6}>
-            <Text>{t('dashboard.redirectionMessage')}</Text>
-            <Spinner />
-          </VStack>
-        ) : (
-          <FolderContent folder={null} />
+    <DashboardSearchProvider>
+      <Stack minH="100vh">
+        <Seo title={workspace?.name ?? t('dashboard.title')} />
+        <DashboardHeader />
+        {!workspace?.stripeId && (
+          <ParentModalProvider>
+            <PreCheckoutModal
+              selectedSubscription={preCheckoutPlan}
+              existingEmail={user?.email ?? undefined}
+              existingCompany={workspace?.name ?? undefined}
+              onClose={() => setPreCheckoutPlan(undefined)}
+            />
+          </ParentModalProvider>
         )}
-      </TypebotDndProvider>
-    </Stack>
+        <TypebotDndProvider>
+          {isLoading ? (
+            <VStack w="full" justifyContent="center" pt="10" spacing={6}>
+              <Text>{t('dashboard.redirectionMessage')}</Text>
+              <Spinner />
+            </VStack>
+          ) : (
+            <FolderContent folder={null} />
+          )}
+        </TypebotDndProvider>
+        <DashboardSearchPanel />
+      </Stack>
+    </DashboardSearchProvider>
   )
 }

--- a/apps/builder/src/features/dashboard/components/DashboardSearchPanel.tsx
+++ b/apps/builder/src/features/dashboard/components/DashboardSearchPanel.tsx
@@ -1,0 +1,160 @@
+import {
+  Box,
+  Flex,
+  HStack,
+  IconButton,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  Text,
+  useColorModeValue,
+  VStack,
+  Fade,
+} from '@chakra-ui/react'
+import { useRef, useEffect } from 'react'
+import { useDashboardSearch } from '../providers/DashboardSearchProvider'
+import { CloseIcon, SearchIcon } from '@/components/icons'
+import { useTranslate } from '@tolgee/react'
+import { useRouter } from 'next/router'
+import { EmojiOrImageIcon } from '@/components/EmojiOrImageIcon'
+
+export const DashboardSearchPanel = () => {
+  const bg = useColorModeValue('white', 'gray.800')
+  const borderColor = useColorModeValue('gray.200', 'gray.600')
+  const resultHoverBg = useColorModeValue('gray.100', 'gray.700')
+
+  const { t } = useTranslate()
+  const router = useRouter()
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const {
+    isSearchOpen,
+    searchQuery,
+    setSearchQuery,
+    searchResults,
+    closeSearch,
+  } = useDashboardSearch()
+
+  useEffect(() => {
+    if (isSearchOpen && inputRef.current) {
+      inputRef.current.focus()
+      inputRef.current.select()
+    }
+  }, [isSearchOpen])
+
+  if (!isSearchOpen) return null
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value)
+  }
+
+  const handleResultClick = async (
+    typebotId: string,
+    folderId?: string | null
+  ) => {
+    closeSearch()
+
+    // Navigate to the folder containing the typebot with hit parameterized
+    if (folderId) {
+      await router.push(`/typebots/folders/${folderId}?hit=${typebotId}`)
+    } else {
+      await router.push(`/typebots?hit=${typebotId}`)
+    }
+
+    // Scroll to the highlighted element after navigation
+    setTimeout(() => {
+      const el = document.getElementById(`typebot-${typebotId}`)
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      }
+    }, 500)
+  }
+
+  return (
+    <Fade in={isSearchOpen}>
+      <Box
+        position="fixed"
+        top="100px"
+        left="50%"
+        transform="translateX(-50%)"
+        zIndex={1400}
+        bg={bg}
+        borderRadius="lg"
+        boxShadow="2xl"
+        border="1px solid"
+        borderColor={borderColor}
+        minW="400px"
+        maxW="500px"
+        w="40%"
+      >
+        <HStack p={2} spacing={1}>
+          <InputGroup size="sm">
+            <InputLeftElement>
+              <SearchIcon color="gray.400" boxSize={4} />
+            </InputLeftElement>
+            <Input
+              id="dashboard-search-input"
+              ref={inputRef}
+              placeholder={t('editor.search.placeholder')}
+              value={searchQuery}
+              onChange={handleInputChange}
+              borderRadius="md"
+            />
+          </InputGroup>
+
+          <IconButton
+            aria-label={t('editor.search.closeSearch')}
+            icon={<CloseIcon />}
+            size="sm"
+            variant="ghost"
+            onClick={closeSearch}
+          />
+        </HStack>
+
+        {searchQuery.trim().length > 0 && (
+          <VStack
+            align="stretch"
+            spacing={0}
+            maxH="400px"
+            overflowY="auto"
+            borderTop="1px solid"
+            borderColor={borderColor}
+          >
+            {searchResults.length === 0 ? (
+              <Box p={4} textAlign="center">
+                <Text color="gray.500" fontSize="sm">
+                  {t('editor.search.noResults')}
+                </Text>
+              </Box>
+            ) : (
+              searchResults.map((typebot) => (
+                <Flex
+                  key={typebot.id}
+                  p={3}
+                  cursor="pointer"
+                  _hover={{ bg: resultHoverBg }}
+                  onClick={() =>
+                    handleResultClick(typebot.id, typebot.folderId)
+                  }
+                  align="center"
+                  gap={3}
+                >
+                  <EmojiOrImageIcon
+                    icon={typebot.icon}
+                    boxSize="20px"
+                    emojiFontSize="20px"
+                  />
+                  <VStack align="start" spacing={0} flex={1} minW={0}>
+                    <Text fontSize="sm" fontWeight="medium" noOfLines={1}>
+                      {typebot.name}
+                    </Text>
+                  </VStack>
+                </Flex>
+              ))
+            )}
+          </VStack>
+        )}
+      </Box>
+    </Fade>
+  )
+}

--- a/apps/builder/src/features/dashboard/providers/DashboardSearchProvider.tsx
+++ b/apps/builder/src/features/dashboard/providers/DashboardSearchProvider.tsx
@@ -1,0 +1,142 @@
+import {
+  createContext,
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+import { useWorkspace } from '@/features/workspace/WorkspaceProvider'
+import { useTypebots } from '../hooks/useTypebots'
+import { useDebounce } from 'use-debounce'
+import { TypebotInDashboard } from '../types'
+import { useRouter } from 'next/router'
+
+type DashboardSearchContextType = {
+  isSearchOpen: boolean
+  setIsSearchOpen: Dispatch<SetStateAction<boolean>>
+  searchQuery: string
+  setSearchQuery: Dispatch<SetStateAction<string>>
+  searchResults: TypebotInDashboard[]
+  closeSearch: () => void
+  highlightedTypebotId: string | null
+  setHighlightedTypebotId: Dispatch<SetStateAction<string | null>>
+}
+
+const dashboardSearchContext = createContext<DashboardSearchContextType>({
+  isSearchOpen: false,
+  setIsSearchOpen: () => {},
+  searchQuery: '',
+  setSearchQuery: () => {},
+  searchResults: [],
+  closeSearch: () => {},
+  highlightedTypebotId: null,
+  setHighlightedTypebotId: () => {},
+})
+
+export const DashboardSearchProvider = ({
+  children,
+}: {
+  children: ReactNode
+}) => {
+  const router = useRouter()
+  const { workspace } = useWorkspace()
+  const [isSearchOpen, setIsSearchOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [highlightedTypebotId, setHighlightedTypebotId] = useState<
+    string | null
+  >(null)
+
+  // Sync highlight from URL and clean URL up
+  useEffect(() => {
+    if (router.query.hit) {
+      setHighlightedTypebotId(router.query.hit as string)
+      const newQuery = { ...router.query }
+      delete newQuery.hit
+      router.replace(
+        { pathname: router.pathname, query: newQuery },
+        undefined,
+        { shallow: true }
+      )
+    }
+  }, [router.query.hit, router.pathname, router])
+
+  const [debouncedQuery] = useDebounce(searchQuery, 300)
+
+  const { typebots } = useTypebots({
+    workspaceId: workspace?.id,
+    // Omitting folderId to get all typebots (Deep Search)
+    onError: () => {},
+  })
+
+  const searchResults = useMemo(() => {
+    if (!typebots || debouncedQuery.trim().length === 0) return []
+    const normalizedQuery = debouncedQuery.toLowerCase().trim()
+    return typebots.filter((typebot) =>
+      typebot.name.toLowerCase().includes(normalizedQuery)
+    )
+  }, [typebots, debouncedQuery])
+
+  const closeSearch = useCallback(() => {
+    setIsSearchOpen(false)
+    setSearchQuery('')
+  }, [])
+
+  // Clear highlight after 4 seconds
+  useEffect(() => {
+    if (!highlightedTypebotId) return
+    const timer = setTimeout(() => setHighlightedTypebotId(null), 4000)
+    return () => clearTimeout(timer)
+  }, [highlightedTypebotId])
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+        const activeElement = document.activeElement
+        const isInput =
+          activeElement?.tagName === 'INPUT' ||
+          activeElement?.tagName === 'TEXTAREA' ||
+          (activeElement as HTMLElement)?.isContentEditable
+
+        if (
+          isInput &&
+          activeElement !== document.getElementById('dashboard-search-input')
+        ) {
+          return
+        }
+
+        e.preventDefault()
+        setIsSearchOpen(true)
+      }
+
+      if (e.key === 'Escape' && isSearchOpen) {
+        closeSearch()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isSearchOpen, closeSearch])
+
+  return (
+    <dashboardSearchContext.Provider
+      value={{
+        isSearchOpen,
+        setIsSearchOpen,
+        searchQuery,
+        setSearchQuery,
+        searchResults,
+        closeSearch,
+        highlightedTypebotId,
+        setHighlightedTypebotId,
+      }}
+    >
+      {children}
+    </dashboardSearchContext.Provider>
+  )
+}
+
+export const useDashboardSearch = () => useContext(dashboardSearchContext)

--- a/apps/builder/src/features/dashboard/types.ts
+++ b/apps/builder/src/features/dashboard/types.ts
@@ -2,4 +2,5 @@ import { Typebot } from '@typebot.io/schemas'
 
 export type TypebotInDashboard = Pick<Typebot, 'id' | 'name' | 'icon'> & {
   publishedTypebotId?: string
+  folderId?: string | null
 }

--- a/apps/builder/src/features/folders/components/FolderPage.tsx
+++ b/apps/builder/src/features/folders/components/FolderPage.tsx
@@ -8,6 +8,8 @@ import { TypebotDndProvider } from '../TypebotDndProvider'
 import { FolderContent } from './FolderContent'
 import { trpc } from '@/lib/trpc'
 import { useWorkspace } from '@/features/workspace/WorkspaceProvider'
+import { DashboardSearchProvider } from '@/features/dashboard/providers/DashboardSearchProvider'
+import { DashboardSearchPanel } from '@/features/dashboard/components/DashboardSearchPanel'
 
 export const FolderPage = () => {
   const { t } = useTranslate()
@@ -34,18 +36,21 @@ export const FolderPage = () => {
   )
 
   return (
-    <Stack minH="100vh">
-      <Seo title={t('dashboard.title')} />
-      <DashboardHeader />
-      <TypebotDndProvider>
-        {!folder ? (
-          <Flex flex="1">
-            <Spinner mx="auto" />
-          </Flex>
-        ) : (
-          <FolderContent folder={folder} />
-        )}
-      </TypebotDndProvider>
-    </Stack>
+    <DashboardSearchProvider>
+      <Stack minH="100vh">
+        <Seo title={t('dashboard.title')} />
+        <DashboardHeader />
+        <TypebotDndProvider>
+          {!folder ? (
+            <Flex flex="1">
+              <Spinner mx="auto" />
+            </Flex>
+          ) : (
+            <FolderContent folder={folder} />
+          )}
+        </TypebotDndProvider>
+        <DashboardSearchPanel />
+      </Stack>
+    </DashboardSearchProvider>
   )
 }

--- a/apps/builder/src/features/folders/components/TypebotButton.tsx
+++ b/apps/builder/src/features/folders/components/TypebotButton.tsx
@@ -9,6 +9,7 @@ import {
   Stack,
   Tag,
   Text,
+  useColorModeValue,
   useDisclosure,
   VStack,
   WrapItem,
@@ -29,6 +30,7 @@ import {
   NodePosition,
   useDragDistance,
 } from '@/features/graph/providers/GraphDndProvider'
+import { useDashboardSearch } from '@/features/dashboard/providers/DashboardSearchProvider'
 
 type Props = {
   typebot: TypebotInDashboard
@@ -60,6 +62,18 @@ const TypebotButton = ({
     onDrag,
     deps: [],
   })
+
+  const { highlightedTypebotId } = useDashboardSearch()
+  const isHighlighted = highlightedTypebotId === typebot.id
+
+  const searchHighlightBorderColor = useColorModeValue(
+    'orange.400',
+    'orange.300'
+  )
+  const searchHighlightShadow = useColorModeValue(
+    '0 0 0 3px var(--chakra-colors-orange-400)',
+    '0 0 0 3px var(--chakra-colors-orange-300)'
+  )
 
   const { showToast } = useToast()
 
@@ -148,6 +162,11 @@ const TypebotButton = ({
       whiteSpace="normal"
       opacity={draggedTypebot ? 0.3 : 1}
       cursor="pointer"
+      id={`typebot-${typebot.id}`}
+      borderColor={isHighlighted ? searchHighlightBorderColor : undefined}
+      borderWidth={isHighlighted ? '2px' : undefined}
+      boxShadow={isHighlighted ? searchHighlightShadow : undefined}
+      transition="border-color 0.2s, box-shadow 0.2s"
     >
       {typebot.publishedTypebotId && (
         <Tag
@@ -235,13 +254,4 @@ const TypebotButton = ({
   )
 }
 
-export default memo(
-  TypebotButton,
-  (prev, next) =>
-    prev.draggedTypebot?.id === next.draggedTypebot?.id &&
-    prev.typebot.id === next.typebot.id &&
-    prev.isReadOnly === next.isReadOnly &&
-    prev.typebot.name === next.typebot.name &&
-    prev.typebot.icon === next.typebot.icon &&
-    prev.typebot.publishedTypebotId === next.typebot.publishedTypebotId
-)
+export default memo(TypebotButton)

--- a/apps/builder/src/features/typebot/api/listTypebots.ts
+++ b/apps/builder/src/features/typebot/api/listTypebots.ts
@@ -36,7 +36,12 @@ export const listTypebots = authenticatedProcedure
             icon: true,
             id: true,
           })
-          .merge(z.object({ publishedTypebotId: z.string().optional() }))
+          .merge(
+            z.object({
+              publishedTypebotId: z.string().optional(),
+              folderId: z.string().nullable().optional(),
+            })
+          )
       ),
     })
   )
@@ -82,8 +87,9 @@ export const listTypebots = authenticatedProcedure
         publishedTypebot: { select: { id: true } },
         id: true,
         icon: true,
+        folderId: true,
       },
-    })) as (Pick<Typebot, 'name' | 'id' | 'icon'> & {
+    })) as (Pick<Typebot, 'name' | 'id' | 'icon' | 'folderId'> & {
       publishedTypebot: Pick<PublicTypebot, 'id'>
     })[]
 


### PR DESCRIPTION
## Contexto ou Problema

Atualmente, usuários com muitos bots e pastas no Dashboard tinham dificuldade em localizar rapidamente um fluxo específico. Além disso, ao encontrar um bot via busca, não havia uma indicação visual clara de qual item foi selecionado após a navegação automática para a pasta de destino.

## 🧾 Descrição da solução

Foi implementado um sistema de busca global e destaque visual para o Dashboard: