### PR TITLE
:card_file_box: Replace archiveResults batch loop with direct cascade delete

### DIFF
--- a/apps/builder/src/features/results/api/deleteResults.ts
+++ b/apps/builder/src/features/results/api/deleteResults.ts
@@ -2,6 +2,7 @@ import { authenticatedProcedure } from '@/helpers/server/trpc'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import prisma from '@typebot.io/lib/prisma'
+import { Prisma } from '@typebot.io/prisma'
 import { isWriteTypebotForbidden } from '@/features/typebot/helpers/isWriteTypebotForbidden'
 
 export const deleteResults = authenticatedProcedure
@@ -63,10 +64,25 @@ export const deleteResults = authenticatedProcedure
     if (!typebot || (await isWriteTypebotForbidden(typebot, user)))
       throw new TRPCError({ code: 'NOT_FOUND', message: 'Typebot not found' })
 
-    await prisma.result.deleteMany({
-      where: {
-        typebotId,
-        id: (idsArray?.length ?? 0) > 0 ? { in: idsArray } : undefined,
-      },
-    })
+    await prisma.$transaction([
+      prisma.$executeRaw`
+        DELETE FROM "ChatSession"
+        WHERE id IN (
+          SELECT "lastChatSessionId" FROM "Result"
+          WHERE "typebotId" = ${typebotId}
+          ${
+            idsArray?.length
+              ? Prisma.sql`AND id = ANY(${idsArray}::text[])`
+              : Prisma.empty
+          }
+          AND "lastChatSessionId" IS NOT NULL
+        )
+      `,
+      prisma.result.deleteMany({
+        where: {
+          typebotId,
+          id: (idsArray?.length ?? 0) > 0 ? { in: idsArray } : undefined,
+        },
+      }),
+    ])
   })

--- a/apps/builder/src/features/results/api/deleteResults.ts
+++ b/apps/builder/src/features/results/api/deleteResults.ts
@@ -1,10 +1,8 @@
 import { authenticatedProcedure } from '@/helpers/server/trpc'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
-import { archiveResults } from '@typebot.io/results/archiveResults'
 import prisma from '@typebot.io/lib/prisma'
 import { isWriteTypebotForbidden } from '@/features/typebot/helpers/isWriteTypebotForbidden'
-import { Typebot } from '@typebot.io/schemas'
 
 export const deleteResults = authenticatedProcedure
   .meta({
@@ -40,7 +38,6 @@ export const deleteResults = authenticatedProcedure
         id: typebotId,
       },
       select: {
-        groups: true,
         workspace: {
           select: {
             id: true,
@@ -65,19 +62,11 @@ export const deleteResults = authenticatedProcedure
     })
     if (!typebot || (await isWriteTypebotForbidden(typebot, user)))
       throw new TRPCError({ code: 'NOT_FOUND', message: 'Typebot not found' })
-    const { success } = await archiveResults(prisma)({
-      typebot: {
-        groups: typebot.groups,
-      } as Pick<Typebot, 'groups'>,
-      resultsFilter: {
-        id: (idsArray?.length ?? 0) > 0 ? { in: idsArray } : undefined,
+
+    await prisma.result.deleteMany({
+      where: {
         typebotId,
+        id: (idsArray?.length ?? 0) > 0 ? { in: idsArray } : undefined,
       },
     })
-
-    if (!success)
-      throw new TRPCError({
-        code: 'NOT_FOUND',
-        message: 'Typebot not found',
-      })
   })

--- a/apps/builder/src/features/typebot/api/deleteTypebot.ts
+++ b/apps/builder/src/features/typebot/api/deleteTypebot.ts
@@ -63,11 +63,21 @@ export const deleteTypebot = authenticatedProcedure
     )
       throw new TRPCError({ code: 'NOT_FOUND', message: 'Typebot not found' })
 
-    await prisma.typebotEditQueue.deleteMany({ where: { typebotId } })
-    await prisma.bannedIp.deleteMany({
-      where: { responsibleTypebotId: typebotId },
-    })
-    await prisma.typebot.delete({ where: { id: typebotId } })
+    await prisma.$transaction([
+      prisma.$executeRaw`
+        DELETE FROM "ChatSession"
+        WHERE id IN (
+          SELECT "lastChatSessionId" FROM "Result"
+          WHERE "typebotId" = ${typebotId}
+          AND "lastChatSessionId" IS NOT NULL
+        )
+      `,
+      prisma.typebotEditQueue.deleteMany({ where: { typebotId } }),
+      prisma.bannedIp.deleteMany({
+        where: { responsibleTypebotId: typebotId },
+      }),
+      prisma.typebot.delete({ where: { id: typebotId } }),
+    ])
 
     return {
       message: 'success',

--- a/apps/builder/src/features/typebot/api/deleteTypebot.ts
+++ b/apps/builder/src/features/typebot/api/deleteTypebot.ts
@@ -1,10 +1,8 @@
 import prisma from '@typebot.io/lib/prisma'
 import { authenticatedProcedure } from '@/helpers/server/trpc'
 import { TRPCError } from '@trpc/server'
-import { Typebot } from '@typebot.io/schemas'
 import { z } from 'zod'
 import { isWriteTypebotForbidden } from '../helpers/isWriteTypebotForbidden'
-import { archiveResults } from '@typebot.io/results/archiveResults'
 
 export const deleteTypebot = authenticatedProcedure
   .meta({
@@ -37,7 +35,6 @@ export const deleteTypebot = authenticatedProcedure
       },
       select: {
         id: true,
-        groups: true,
         workspace: {
           select: {
             id: true,
@@ -66,24 +63,12 @@ export const deleteTypebot = authenticatedProcedure
     )
       throw new TRPCError({ code: 'NOT_FOUND', message: 'Typebot not found' })
 
-    const { success } = await archiveResults(prisma)({
-      typebot: {
-        groups: existingTypebot.groups,
-      } as Pick<Typebot, 'groups'>,
-      resultsFilter: { typebotId },
+    await prisma.typebotEditQueue.deleteMany({ where: { typebotId } })
+    await prisma.bannedIp.deleteMany({
+      where: { responsibleTypebotId: typebotId },
     })
-    if (!success)
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message: 'Failed to archive results',
-      })
-    await prisma.publicTypebot.deleteMany({
-      where: { typebotId },
-    })
-    await prisma.typebot.updateMany({
-      where: { id: typebotId },
-      data: { isArchived: true, publicId: null, customDomain: null },
-    })
+    await prisma.typebot.delete({ where: { id: typebotId } })
+
     return {
       message: 'success',
     }


### PR DESCRIPTION
Deleting a typebot or results was hanging in production due to a slow batched query with no suitable index on (typebotId, isArchived). 

Since we don't use S3 and have no restore-from-archive feature, the soft-delete approach adds no value. 

All Result children already have onDelete: Cascade, so a direct typebot delete cleans everything up atomically.

Pre-delete TypebotEditQueue and BannedIp to satisfy their Restrict constraints before deleting the typebot.


print of the slow queries:
<img width="2460" height="1158" alt="image" src="https://github.com/user-attachments/assets/8830a9e8-85b2-4a62-98af-d874da95d6a7" />