### PR TITLE
Fix API token auth: grant admin users full workspace access

### DIFF
--- a/apps/builder/src/features/auth/helpers/getAuthenticatedUser.ts
+++ b/apps/builder/src/features/auth/helpers/getAuthenticatedUser.ts
@@ -5,6 +5,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import { getServerSession } from 'next-auth'
 import { env } from '@typebot.io/env'
 import { mockedUser } from '@typebot.io/lib/mockedUser'
+import { emailIsCloudhumans } from '@typebot.io/lib'
 import { DatabaseUserWithCognito } from '../types/cognito'
 import { verifyCognitoToken } from './verifyCognitoToken'
 import logger from '@/helpers/logger'
@@ -67,6 +68,16 @@ const authenticateByToken = async (
   })) as DatabaseUserWithCognito | null
   if (!user) return
   Sentry.setUser({ id: user.id })
+
+  // Populate cognitoClaims for admin users so that API token auth
+  // gets the same workspace access as session-based auth.
+  if (emailIsCloudhumans(user.email)) {
+    user.cognitoClaims = {
+      'custom:hub_role': 'ADMIN',
+      'custom:eddie_workspaces': '',
+    }
+  }
+
   return user
 }
 

--- a/apps/builder/src/features/workspace/helpers/cognitoUtils.test.ts
+++ b/apps/builder/src/features/workspace/helpers/cognitoUtils.test.ts
@@ -414,4 +414,15 @@ describe('getCognitoAccessibleWorkspaceIds', () => {
       ids: ['ws-123'],
     })
   })
+
+  it('should return { type: "admin" } when cognitoClaims is populated with ADMIN role (API token auth for admin)', () => {
+    const user = {
+      cognitoClaims: {
+        'custom:hub_role': 'ADMIN' as const,
+        'custom:eddie_workspaces': '',
+      },
+    }
+
+    expect(getCognitoAccessibleWorkspaceIds(user)).toEqual({ type: 'admin' })
+  })
 })


### PR DESCRIPTION
## Summary
- API token authentication (`authenticateByToken`) now populates `cognitoClaims` for admin users (identified by `emailIsCloudhumans`)
- This gives admin API token users the same full workspace access they get with session-based auth
- Previously, admin users with API tokens could only see ~178 workspaces (those with explicit `MemberInWorkspace` records) instead of all workspaces

## Root Cause
`authenticateByToken()` looked up the user by API token but never set `cognitoClaims`. This caused `getCognitoAccessibleWorkspaceIds()` to return `{ type: 'none' }`, falling back to membership-only filtering.

## Test plan
- [ ] Verify existing tests pass (`cognitoUtils.test.ts`)
- [ ] New test covers the API token auth admin scenario
- [ ] Manual: authenticate as `tech@cloudhumans.com` via API token and verify `GET /api/v1/workspaces` returns all workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authorization behavior for API-token-authenticated users by granting admin-level workspace visibility based on an email check, so mistakes could broaden access if the admin-identification logic is wrong.
> 
> **Overview**
> Aligns API token authentication with session-based access by **injecting Cognito admin claims** in `authenticateByToken` for Cloudhumans admin users (via `emailIsCloudhumans`), so workspace listing and filtering treat these users as `admin`.
> 
> Adds a focused `cognitoUtils` test to cover the API-token admin scenario where `cognitoClaims` includes `custom:hub_role: 'ADMIN'` with an empty `custom:eddie_workspaces`, asserting `getCognitoAccessibleWorkspaceIds` returns `{ type: 'admin' }`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dacefc89896be686bb2a1a65b097979af571fe4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes API token authentication for admin users by populating `cognitoClaims` in `authenticateByToken()` when the user's email is identified as a Cloudhumans admin (via `emailIsCloudhumans`). Previously, API-token-authenticated admins fell through to membership-only filtering because `cognitoClaims` was never set, causing `getCognitoAccessibleWorkspaceIds` to return `{ type: 'none' }`. The fix is minimal, targeted, and comes with a new unit test confirming the admin path now returns `{ type: 'admin' }`.

- `getAuthenticatedUser.ts`: Adds the `emailIsCloudhumans` guard and synthesizes hardcoded `cognitoClaims` on the Prisma-returned user object for admin API token users.
- `cognitoUtils.test.ts`: Adds one test case covering the new admin API-token scenario.
- The empty string `''` for `'custom:eddie_workspaces'` is intentional and safe — `extractCognitoUserClaims` only proceeds when `hasHubRole` is truthy, which `'ADMIN'` satisfies.
- Note that `emailIsCloudhumans` returns `true` for **any** string email in non-production environments (`NODE_ENV !== 'production'`), which is pre-existing behaviour but now also applies to API token auth.

<h3>Confidence Score: 4/5</h3>

Safe to merge in production; the fix is correct and well-tested, with only minor non-critical style concerns.

The logic is sound: `emailIsCloudhumans` + setting `cognitoClaims` correctly routes admin API-token users through the `{ type: 'admin' }` path. The new test validates the exact scenario. The two P2 comments (non-production scope and object mutation) are housekeeping, not blockers.

No files require blocking attention; `getAuthenticatedUser.ts` lines 74-79 merit a comment about non-production scope if the team finds staging data sensitivity relevant.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/builder/src/features/auth/helpers/getAuthenticatedUser.ts | Adds admin `cognitoClaims` injection for API-token auth; correct fix, minor mutation style concern and non-production scope worth noting. |
| apps/builder/src/features/workspace/helpers/cognitoUtils.test.ts | Adds a well-formed test covering the new admin API-token scenario; assertion and setup are correct. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API as Next.js API Route
    participant ABT as authenticateByToken
    participant Prisma
    participant EIC as emailIsCloudhumans
    participant GCAWI as getCognitoAccessibleWorkspaceIds

    Client->>API: GET /api/v1/workspaces<br/>Authorization: Bearer &lt;api-token&gt;
    API->>ABT: apiToken
    ABT->>Prisma: findFirst(apiTokens.some.token)
    Prisma-->>ABT: user
    ABT->>EIC: user.email
    EIC-->>ABT: true (admin)
    ABT->>ABT: user.cognitoClaims = { hub_role: ADMIN, eddie_workspaces: '' }
    ABT-->>API: user (with cognitoClaims)
    API->>GCAWI: user
    GCAWI-->>API: { type: 'admin' }
    API-->>Client: All workspaces
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fauth%2Fhelpers%2FgetAuthenticatedUser.ts%3A74-79%0A**Non-production%20blast%20radius%3A%20every%20API%20token%20becomes%20admin**%0A%0A%60emailIsCloudhumans%60%20evaluates%20to%20%60true%60%20for%20**any**%20string%20email%20when%20%60process.env.NODE_ENV%20!%3D%3D%20'production'%60%20%28it's%20an%20OR%20in%20the%20predicate%29.%20This%20means%20that%20on%20staging%20or%20local%20dev%2C%20every%20user%20who%20authenticates%20with%20an%20API%20token%20will%20now%20receive%20%60ADMIN%60%20%60cognitoClaims%60%20and%20see%20all%20workspaces.%0A%0AThis%20is%20pre-existing%20behaviour%20of%20%60emailIsCloudhumans%60%2C%20but%20extending%20it%20to%20API-token%20auth%20is%20a%20new%20surface.%20It's%20worth%20an%20explicit%20acknowledgement%20%28comment%20or%20ticket%29%20that%20this%20is%20intentional%20and%20that%20no%20staging%20token%20can%20inadvertently%20expose%20all%20workspace%20data%20to%20unintended%20parties.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fauth%2Fhelpers%2FgetAuthenticatedUser.ts%3A75-78%0A**Mutating%20the%20Prisma-returned%20object**%0A%0A%60user%60%20is%20the%20object%20returned%20directly%20by%20%60prisma.user.findFirst%28%29%60.%20Assigning%20%60user.cognitoClaims%20%3D%20%7B...%7D%60%20mutates%20it%20in%20place.%20While%20harmless%20here%20%28Prisma%20returns%20plain%20JS%20objects%29%2C%20returning%20a%20new%20object%20is%20safer%20and%20communicates%20intent%20more%20clearly%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20return%20%7B%0A%20%20%20%20%20%20...user%2C%0A%20%20%20%20%20%20cognitoClaims%3A%20%7B%0A%20%20%20%20%20%20%20%20'custom%3Ahub_role'%3A%20'ADMIN'%2C%0A%20%20%20%20%20%20%20%20'custom%3Aeddie_workspaces'%3A%20''%2C%0A%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%28You%20can%20then%20remove%20the%20standalone%20%60return%20user%60%20on%20line%2081%20since%20this%20suggestion%20already%20returns.%29%0A%0A&repo=cloudhumans%2Ftypebot.io"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fauth%2Fhelpers%2FgetAuthenticatedUser.ts%3A74-79%0A**Non-production%20blast%20radius%3A%20every%20API%20token%20becomes%20admin**%0A%0A%60emailIsCloudhumans%60%20evaluates%20to%20%60true%60%20for%20**any**%20string%20email%20when%20%60process.env.NODE_ENV%20!%3D%3D%20'production'%60%20%28it's%20an%20OR%20in%20the%20predicate%29.%20This%20means%20that%20on%20staging%20or%20local%20dev%2C%20every%20user%20who%20authenticates%20with%20an%20API%20token%20will%20now%20receive%20%60ADMIN%60%20%60cognitoClaims%60%20and%20see%20all%20workspaces.%0A%0AThis%20is%20pre-existing%20behaviour%20of%20%60emailIsCloudhumans%60%2C%20but%20extending%20it%20to%20API-token%20auth%20is%20a%20new%20surface.%20It's%20worth%20an%20explicit%20acknowledgement%20%28comment%20or%20ticket%29%20that%20this%20is%20intentional%20and%20that%20no%20staging%20token%20can%20inadvertently%20expose%20all%20workspace%20data%20to%20unintended%20parties.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fauth%2Fhelpers%2FgetAuthenticatedUser.ts%3A75-78%0A**Mutating%20the%20Prisma-returned%20object**%0A%0A%60user%60%20is%20the%20object%20returned%20directly%20by%20%60prisma.user.findFirst%28%29%60.%20Assigning%20%60user.cognitoClaims%20%3D%20%7B...%7D%60%20mutates%20it%20in%20place.%20While%20harmless%20here%20%28Prisma%20returns%20plain%20JS%20objects%29%2C%20returning%20a%20new%20object%20is%20safer%20and%20communicates%20intent%20more%20clearly%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20return%20%7B%0A%20%20%20%20%20%20...user%2C%0A%20%20%20%20%20%20cognitoClaims%3A%20%7B%0A%20%20%20%20%20%20%20%20'custom%3Ahub_role'%3A%20'ADMIN'%2C%0A%20%20%20%20%20%20%20%20'custom%3Aeddie_workspaces'%3A%20''%2C%0A%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%28You%20can%20then%20remove%20the%20standalone%20%60return%20user%60%20on%20line%2081%20since%20this%20suggestion%20already%20returns.%29%0A%0A"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/builder/src/features/auth/helpers/getAuthenticatedUser.ts
Line: 74-79

Comment:
**Non-production blast radius: every API token becomes admin**

`emailIsCloudhumans` evaluates to `true` for **any** string email when `process.env.NODE_ENV !== 'production'` (it's an OR in the predicate). This means that on staging or local dev, every user who authenticates with an API token will now receive `ADMIN` `cognitoClaims` and see all workspaces.

This is pre-existing behaviour of `emailIsCloudhumans`, but extending it to API-token auth is a new surface. It's worth an explicit acknowledgement (comment or ticket) that this is intentional and that no staging token can inadvertently expose all workspace data to unintended parties.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/builder/src/features/auth/helpers/getAuthenticatedUser.ts
Line: 75-78

Comment:
**Mutating the Prisma-returned object**

`user` is the object returned directly by `prisma.user.findFirst()`. Assigning `user.cognitoClaims = {...}` mutates it in place. While harmless here (Prisma returns plain JS objects), returning a new object is safer and communicates intent more clearly:

```suggestion
    return {
      ...user,
      cognitoClaims: {
        'custom:hub_role': 'ADMIN',
        'custom:eddie_workspaces': '',
      },
    }
```

(You can then remove the standalone `return user` on line 81 since this suggestion already returns.)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix: populate cognitoClaims for admin us..."](https://github.com/cloudhumans/typebot.io/commit/dacefc89896be686bb2a1a65b097979af571fe4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27600736)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->