### PR TITLE
feat: Hub v2 Cognito auth, seed data & MCP includeDrafts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# CLAUDE.md — Typebot
+
+## What this is
+
+Visual chatbot builder (fork of Typebot.io). pnpm monorepo with two Next.js apps:
+
+- **builder** (port 3002) — Chatbot flow editor + MCP endpoint (`/api/mcp`)
+- **viewer** (port 3003) — Chatbot flow executor
+
+## MCP endpoint
+
+`POST /api/mcp` on the builder exposes tool-type typebots as MCP tools, filtered by `x-tenant` header. Key behaviors:
+
+- **Published vs draft tools:** By default, only published typebots appear. The `X-Include-Drafts: true` HTTP header (set by claudia web-api when proxying from the Tools page) includes unpublished tools with `_meta.isPublished: false`.
+- **Tool typebots:** Special typebot flows that act as AI agent tools. Created via `typebot.createTypebot` tRPC mutation.
+- **Known gotchas:** `outgoingEdgeId` is required on blocks, `publicId` must be set for publishing, Script blocks need specific format, `bodyPath` for array params, array values must be stringified.
+
+## Auth
+
+- Magic link authentication via email (captured by Mailhog locally)
+- Seeded user: `claudia@acme.inc`
+- Cognito SSO for embedded mode inside CloudChat (JWT verification in `verifyCognitoToken`)
+- API token auth populates `cognitoClaims` for admin users
+
+### Embedded auth — critical race condition
+
+When typebot is embedded inside CloudChat, the `UserProvider` has a full early-return bypass for embedded mode (`if (isEmbedded) return`). **Do not narrow this bypass.** The Cognito JWT → NextAuth session handoff has a transient window where `session.user` is undefined. If the logout/redirect logic runs during this window, it causes a signin loop. Any changes to `UserProvider`, session handling, or embedded bypass must be tested against the actual embedded auth flow — code-level review reasoning alone is not sufficient.
+
+## Stack
+
+- TypeScript, Next.js, pnpm 8, tRPC, Prisma, PostgreSQL, React
+- Monorepo: `apps/` (builder, viewer, docs) + `packages/` (shared libs)
+- Dev: `pnpm turbo dev` for both builder and viewer
+
+## Running
+
+All docker compose commands from the composezao root (`/home/fabio/workspace/composezao-da-massa`):
+
+```bash
+# Dev (runs via docker compose with HMR)
+docker compose up typebot-builder typebot-viewer -d
+
+# Access builder
+open http://localhost:3002
+
+# Sign in: enter claudia@acme.inc, get magic link from Mailhog at http://localhost:8025
+```

--- a/apps/builder/src/features/account/UserProvider.tsx
+++ b/apps/builder/src/features/account/UserProvider.tsx
@@ -75,7 +75,9 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
     const isEmbedded = router.query.embedded === 'true'
     if (isSignInPath || isPathPublicFriendly) return
 
-    if (!isEmbedded && !user && status === 'unauthenticated') {
+    if (isEmbedded) return
+
+    if (!user && status === 'unauthenticated') {
       router.replace({
         pathname: '/signin',
         query: {

--- a/apps/builder/src/features/account/UserProvider.tsx
+++ b/apps/builder/src/features/account/UserProvider.tsx
@@ -72,7 +72,8 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
     const isPathPublicFriendly = /\/typebots\/.+\/(edit|theme|settings)/.test(
       router.pathname
     )
-    if (isSignInPath || isPathPublicFriendly) return
+    const isEmbedded = router.query.embedded === 'true'
+    if (isSignInPath || isPathPublicFriendly || isEmbedded) return
 
     if (!user && status === 'unauthenticated') {
       router.replace({

--- a/apps/builder/src/features/account/UserProvider.tsx
+++ b/apps/builder/src/features/account/UserProvider.tsx
@@ -73,9 +73,9 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
       router.pathname
     )
     const isEmbedded = router.query.embedded === 'true'
-    if (isSignInPath || isPathPublicFriendly || isEmbedded) return
+    if (isSignInPath || isPathPublicFriendly) return
 
-    if (!user && status === 'unauthenticated') {
+    if (!isEmbedded && !user && status === 'unauthenticated') {
       router.replace({
         pathname: '/signin',
         query: {

--- a/apps/builder/src/features/auth/helpers/getAuthenticatedUser.ts
+++ b/apps/builder/src/features/auth/helpers/getAuthenticatedUser.ts
@@ -5,6 +5,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import { getServerSession } from 'next-auth'
 import { env } from '@typebot.io/env'
 import { mockedUser } from '@typebot.io/lib/mockedUser'
+import { emailIsCloudhumans } from '@typebot.io/lib'
 import { DatabaseUserWithCognito } from '../types/cognito'
 import { verifyCognitoToken } from './verifyCognitoToken'
 import logger from '@/helpers/logger'
@@ -67,6 +68,16 @@ const authenticateByToken = async (
   })) as DatabaseUserWithCognito | null
   if (!user) return
   Sentry.setUser({ id: user.id })
+
+  // Populate cognitoClaims for admin users so that API token auth
+  // gets the same workspace access as session-based auth.
+  if (emailIsCloudhumans(user.email)) {
+    user.cognitoClaims = {
+      'custom:hub_role': 'ADMIN',
+      'custom:eddie_workspaces': '',
+    }
+  }
+
   return user
 }
 

--- a/apps/builder/src/features/auth/helpers/verifyCognitoToken.ts
+++ b/apps/builder/src/features/auth/helpers/verifyCognitoToken.ts
@@ -1,6 +1,13 @@
 import { createRemoteJWKSet, jwtVerify, JWTPayload } from 'jose'
 import { CognitoJWTPayload } from '../types/cognito'
 
+/**
+ * In development, skip real JWKS verification and decode the JWT payload directly.
+ * The token is expected to be a standard JWT (header.payload.signature) where the
+ * payload contains at least { email, ... }. Signature is not verified.
+ *
+ * In production, full Cognito JWKS verification is performed.
+ */
 export const verifyCognitoToken = async ({
   cognitoAppClientId,
   cognitoIssuerUrl,
@@ -10,6 +17,22 @@ export const verifyCognitoToken = async ({
   cognitoIssuerUrl: string
   cognitoAppClientId: string
 }): Promise<JWTPayload & CognitoJWTPayload> => {
+  if (process.env.NODE_ENV === 'development') {
+    // Dev bypass: decode JWT payload without signature verification
+    const parts = cognitoToken.split('.')
+    if (parts.length === 3) {
+      const payload = JSON.parse(
+        Buffer.from(parts[1], 'base64url').toString('utf-8')
+      )
+      return payload as JWTPayload & CognitoJWTPayload
+    }
+    // Fallback: treat the whole token as a base64-encoded JSON payload
+    const payload = JSON.parse(
+      Buffer.from(cognitoToken, 'base64url').toString('utf-8')
+    )
+    return payload as JWTPayload & CognitoJWTPayload
+  }
+
   const jwks = createRemoteJWKSet(
     new URL(`${cognitoIssuerUrl}/.well-known/jwks.json`)
   )

--- a/apps/builder/src/features/auth/helpers/verifyCognitoToken.ts
+++ b/apps/builder/src/features/auth/helpers/verifyCognitoToken.ts
@@ -19,18 +19,22 @@ export const verifyCognitoToken = async ({
 }): Promise<JWTPayload & CognitoJWTPayload> => {
   if (process.env.NODE_ENV === 'development') {
     // Dev bypass: decode JWT payload without signature verification
-    const parts = cognitoToken.split('.')
-    if (parts.length === 3) {
+    try {
+      const parts = cognitoToken.split('.')
+      if (parts.length === 3) {
+        const payload = JSON.parse(
+          Buffer.from(parts[1], 'base64url').toString('utf-8')
+        )
+        return payload as JWTPayload & CognitoJWTPayload
+      }
+      // Fallback: treat the whole token as a base64-encoded JSON payload
       const payload = JSON.parse(
-        Buffer.from(parts[1], 'base64url').toString('utf-8')
+        Buffer.from(cognitoToken, 'base64url').toString('utf-8')
       )
       return payload as JWTPayload & CognitoJWTPayload
+    } catch (e) {
+      throw new Error(`[dev] Failed to decode token payload: ${e}`)
     }
-    // Fallback: treat the whole token as a base64-encoded JSON payload
-    const payload = JSON.parse(
-      Buffer.from(cognitoToken, 'base64url').toString('utf-8')
-    )
-    return payload as JWTPayload & CognitoJWTPayload
   }
 
   const jwks = createRemoteJWKSet(

--- a/apps/builder/src/features/dashboard/components/DashboardHeader.tsx
+++ b/apps/builder/src/features/dashboard/components/DashboardHeader.tsx
@@ -4,6 +4,7 @@ import { HardDriveIcon, SettingsIcon } from '@/components/icons'
 import { useUser } from '@/features/account/hooks/useUser'
 import { isNotDefined } from '@typebot.io/lib'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 import { EmojiOrImageIcon } from '@/components/EmojiOrImageIcon'
 import { useTranslate } from '@tolgee/react'
 import { useWorkspace } from '@/features/workspace/WorkspaceProvider'
@@ -14,6 +15,10 @@ export const DashboardHeader = () => {
   const { t } = useTranslate()
   const { user, logOut } = useUser()
   const { workspace, switchWorkspace, createWorkspace } = useWorkspace()
+  const router = useRouter()
+
+  const isEmbedded =
+    user?.cloudChatAuthorization || router.query.embedded === 'true'
 
   const { isOpen, onOpen, onClose } = useDisclosure()
 
@@ -29,7 +34,7 @@ export const DashboardHeader = () => {
         maxW="1000px"
         flex="1"
       >
-        {!user?.cloudChatAuthorization && (
+        {!isEmbedded && (
           <Link href="/typebots" data-testid="typebot-logo">
             <EmojiOrImageIcon
               boxSize="30px"
@@ -47,7 +52,7 @@ export const DashboardHeader = () => {
               workspace={workspace}
             />
           )}
-          {!workspace?.isPastDue && !user?.cloudChatAuthorization && (
+          {!workspace?.isPastDue && !isEmbedded && (
             <Button
               leftIcon={<SettingsIcon />}
               onClick={onOpen}

--- a/apps/builder/src/features/dashboard/components/DashboardHeader.tsx
+++ b/apps/builder/src/features/dashboard/components/DashboardHeader.tsx
@@ -4,7 +4,6 @@ import { HardDriveIcon, SettingsIcon } from '@/components/icons'
 import { useUser } from '@/features/account/hooks/useUser'
 import { isNotDefined } from '@typebot.io/lib'
 import Link from 'next/link'
-import { useRouter } from 'next/router'
 import { EmojiOrImageIcon } from '@/components/EmojiOrImageIcon'
 import { useTranslate } from '@tolgee/react'
 import { useWorkspace } from '@/features/workspace/WorkspaceProvider'
@@ -15,10 +14,8 @@ export const DashboardHeader = () => {
   const { t } = useTranslate()
   const { user, logOut } = useUser()
   const { workspace, switchWorkspace, createWorkspace } = useWorkspace()
-  const router = useRouter()
 
-  const isEmbedded =
-    user?.cloudChatAuthorization || router.query.embedded === 'true'
+  const isEmbedded = user?.cloudChatAuthorization === true
 
   const { isOpen, onOpen, onClose } = useDisclosure()
 

--- a/apps/builder/src/features/dashboard/components/DashboardHeader.tsx
+++ b/apps/builder/src/features/dashboard/components/DashboardHeader.tsx
@@ -14,9 +14,6 @@ export const DashboardHeader = () => {
   const { t } = useTranslate()
   const { user, logOut } = useUser()
   const { workspace, switchWorkspace, createWorkspace } = useWorkspace()
-
-  const isEmbedded = user?.cloudChatAuthorization === true
-
   const { isOpen, onOpen, onClose } = useDisclosure()
 
   const handleCreateNewWorkspace = () =>
@@ -31,7 +28,7 @@ export const DashboardHeader = () => {
         maxW="1000px"
         flex="1"
       >
-        {!isEmbedded && (
+        {!user?.cloudChatAuthorization && (
           <Link href="/typebots" data-testid="typebot-logo">
             <EmojiOrImageIcon
               boxSize="30px"
@@ -49,7 +46,7 @@ export const DashboardHeader = () => {
               workspace={workspace}
             />
           )}
-          {!workspace?.isPastDue && !isEmbedded && (
+          {!workspace?.isPastDue && !user?.cloudChatAuthorization && (
             <Button
               leftIcon={<SettingsIcon />}
               onClick={onOpen}

--- a/apps/builder/src/features/mcp/helpers/transformToMCPTool.ts
+++ b/apps/builder/src/features/mcp/helpers/transformToMCPTool.ts
@@ -3,6 +3,12 @@ import type { WorkflowTool } from '../types'
 
 /**
  * Transform a Typebot workflow tool to MCP tool format.
+ *
+ * The `_meta.isPublished` field is exposed so UI layers can render a
+ * "not yet published" warning next to tools that were created but
+ * haven't been published in the flow editor. Agents ignore this field
+ * (and by default only receive published tools; see
+ * `getWorkflowTools({ includeDrafts })`).
  */
 export function transformToMCPTool(tool: WorkflowTool) {
   const properties: Record<string, { type: string; description: string }> = {}
@@ -29,6 +35,7 @@ export function transformToMCPTool(tool: WorkflowTool) {
     annotations: {},
     _meta: {
       workflowId: tool.id,
+      isPublished: tool.isPublished,
     },
   }
 }

--- a/apps/builder/src/features/mcp/services/getWorkflowTools.ts
+++ b/apps/builder/src/features/mcp/services/getWorkflowTools.ts
@@ -7,22 +7,42 @@ type JsonValue = any
 
 interface GetWorkflowToolsParams {
   tenant: string
+  /**
+   * When true, include draft (unpublished) typebots in the result set.
+   * Each tool's `isPublished` field still reflects its true state so the
+   * caller can mark drafts in the UI. Defaults to false so agents keep
+   * receiving only published tools — drafts would fail at runtime anyway
+   * because `executeWorkflow` requires a public flow.
+   *
+   * The claudia-app Tools page sets this to true so users can see the
+   * tools they've created but haven't published yet, with a warning
+   * badge. The agents path (claudia supervisor → MCP) leaves it false.
+   */
+  includeDrafts?: boolean
 }
 
 /**
- * Retrieve all published TOOL-type typebots for a given tenant.
+ * Retrieve all TOOL-type typebots for a given tenant.
  * Extracts variable definitions from Declare Variables blocks.
+ *
+ * By default only published typebots are returned. Pass `includeDrafts:
+ * true` to include drafts as well — useful for UIs that want to show
+ * unpublished work-in-progress tools.
  */
 export async function getWorkflowTools({
   tenant,
+  includeDrafts = false,
 }: GetWorkflowToolsParams): Promise<GetWorkflowToolsResult> {
-  logger.debug('getWorkflowTools: querying typebots', { tenant })
+  logger.debug('getWorkflowTools: querying typebots', { tenant, includeDrafts })
   const typebots = await prisma.typebot.findMany({
     where: {
       tenant,
       isArchived: { not: true },
       toolDescription: { not: null },
-      publishedTypebot: { isNot: null },
+      // Filter out drafts by default. The `isPublished` field on each
+      // returned tool always reflects reality, so opting into drafts is
+      // a one-line flag flip on the caller's side.
+      ...(includeDrafts ? {} : { publishedTypebot: { isNot: null } }),
     },
     select: {
       id: true,

--- a/apps/builder/src/features/templates/components/CreateNewTypebotButtons.tsx
+++ b/apps/builder/src/features/templates/components/CreateNewTypebotButtons.tsx
@@ -35,13 +35,6 @@ export const CreateNewTypebotButtons = () => {
 
   const { showToast } = useToast()
 
-  const buildEditQuery = () => {
-    const query: Record<string, string> = {}
-    if (router.query.isFirstBot === 'true') query.isFirstBot = 'true'
-    if (router.query.embedded === 'true') query.embedded = 'true'
-    return query
-  }
-
   const { mutate: createTypebot } = trpc.typebot.createTypebot.useMutation({
     onMutate: () => {
       setIsLoading(true)
@@ -55,7 +48,12 @@ export const CreateNewTypebotButtons = () => {
     onSuccess: (data) => {
       router.push({
         pathname: `/typebots/${data.typebot.id}/edit`,
-        query: buildEditQuery(),
+        query:
+          router.query.isFirstBot === 'true'
+            ? {
+                isFirstBot: 'true',
+              }
+            : {},
       })
     },
     onSettled: () => {
@@ -76,7 +74,12 @@ export const CreateNewTypebotButtons = () => {
     onSuccess: (data) => {
       router.push({
         pathname: `/typebots/${data.typebot.id}/edit`,
-        query: buildEditQuery(),
+        query:
+          router.query.isFirstBot === 'true'
+            ? {
+                isFirstBot: 'true',
+              }
+            : {},
       })
     },
     onSettled: () => {

--- a/apps/builder/src/features/templates/components/CreateNewTypebotButtons.tsx
+++ b/apps/builder/src/features/templates/components/CreateNewTypebotButtons.tsx
@@ -35,6 +35,13 @@ export const CreateNewTypebotButtons = () => {
 
   const { showToast } = useToast()
 
+  const buildEditQuery = () => {
+    const query: Record<string, string> = {}
+    if (router.query.isFirstBot === 'true') query.isFirstBot = 'true'
+    if (router.query.embedded === 'true') query.embedded = 'true'
+    return query
+  }
+
   const { mutate: createTypebot } = trpc.typebot.createTypebot.useMutation({
     onMutate: () => {
       setIsLoading(true)
@@ -48,12 +55,7 @@ export const CreateNewTypebotButtons = () => {
     onSuccess: (data) => {
       router.push({
         pathname: `/typebots/${data.typebot.id}/edit`,
-        query:
-          router.query.isFirstBot === 'true'
-            ? {
-                isFirstBot: 'true',
-              }
-            : {},
+        query: buildEditQuery(),
       })
     },
     onSettled: () => {
@@ -74,12 +76,7 @@ export const CreateNewTypebotButtons = () => {
     onSuccess: (data) => {
       router.push({
         pathname: `/typebots/${data.typebot.id}/edit`,
-        query:
-          router.query.isFirstBot === 'true'
-            ? {
-                isFirstBot: 'true',
-              }
-            : {},
+        query: buildEditQuery(),
       })
     },
     onSettled: () => {

--- a/apps/builder/src/features/workspace/helpers/cognitoUtils.test.ts
+++ b/apps/builder/src/features/workspace/helpers/cognitoUtils.test.ts
@@ -414,4 +414,15 @@ describe('getCognitoAccessibleWorkspaceIds', () => {
       ids: ['ws-123'],
     })
   })
+
+  it('should return { type: "admin" } when cognitoClaims is populated with ADMIN role (API token auth for admin)', () => {
+    const user = {
+      cognitoClaims: {
+        'custom:hub_role': 'ADMIN' as const,
+        'custom:eddie_workspaces': '',
+      },
+    }
+
+    expect(getCognitoAccessibleWorkspaceIds(user)).toEqual({ type: 'admin' })
+  })
 })

--- a/apps/builder/src/pages/api/mcp.ts
+++ b/apps/builder/src/pages/api/mcp.ts
@@ -26,7 +26,7 @@ export default async function handler(
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS')
   res.setHeader(
     'Access-Control-Allow-Headers',
-    'Content-Type, x-tenant, tenant, mcp-session-id, Authorization, X-MCP-Access-Token'
+    'Content-Type, x-tenant, tenant, mcp-session-id, Authorization, X-MCP-Access-Token, x-include-drafts'
   )
 
   if (req.method === 'OPTIONS') {
@@ -103,7 +103,9 @@ export default async function handler(
         // true so users can spot their work-in-progress tools in the
         // list with a "not published" badge. Each returned tool's
         // `_meta.isPublished` reflects the true state regardless.
-        const includeDrafts = params?.includeDrafts === true
+        const includeDrafts =
+          params?.includeDrafts === true ||
+          req.headers['x-include-drafts'] === 'true'
 
         logger.info('MCP tools/list', { tenant, includeDrafts, requestId: id })
         const { tools } = await getWorkflowTools({ tenant, includeDrafts })

--- a/apps/builder/src/pages/api/mcp.ts
+++ b/apps/builder/src/pages/api/mcp.ts
@@ -97,15 +97,10 @@ export default async function handler(
         }
 
         // `includeDrafts` opts the caller into receiving unpublished
-        // tools too. Agents leave this undefined/false so they never
-        // see drafts (which would fail at runtime anyway — executeWorkflow
-        // requires a public flow). The claudia-app Tools page passes
-        // true so users can spot their work-in-progress tools in the
-        // list with a "not published" badge. Each returned tool's
-        // `_meta.isPublished` reflects the true state regardless.
-        const includeDrafts =
-          params?.includeDrafts === true ||
-          req.headers['x-include-drafts'] === 'true'
+        // tools too. Only honoured via the `x-include-drafts` header
+        // (set by claudia web-api when proxying from the Tools page).
+        // Agents never set this header so they only see published tools.
+        const includeDrafts = req.headers['x-include-drafts'] === 'true'
 
         logger.info('MCP tools/list', { tenant, includeDrafts, requestId: id })
         const { tools } = await getWorkflowTools({ tenant, includeDrafts })

--- a/apps/builder/src/pages/api/mcp.ts
+++ b/apps/builder/src/pages/api/mcp.ts
@@ -96,12 +96,22 @@ export default async function handler(
           })
         }
 
-        logger.info('MCP tools/list', { tenant, requestId: id })
-        const { tools } = await getWorkflowTools({ tenant })
+        // `includeDrafts` opts the caller into receiving unpublished
+        // tools too. Agents leave this undefined/false so they never
+        // see drafts (which would fail at runtime anyway — executeWorkflow
+        // requires a public flow). The claudia-app Tools page passes
+        // true so users can spot their work-in-progress tools in the
+        // list with a "not published" badge. Each returned tool's
+        // `_meta.isPublished` reflects the true state regardless.
+        const includeDrafts = params?.includeDrafts === true
+
+        logger.info('MCP tools/list', { tenant, includeDrafts, requestId: id })
+        const { tools } = await getWorkflowTools({ tenant, includeDrafts })
 
         const mcpTools = tools.map(transformToMCPTool)
         logger.info('MCP tools/list completed', {
           tenant,
+          includeDrafts,
           toolCount: mcpTools.length,
           requestId: id,
         })

--- a/packages/scripts/seed.sql
+++ b/packages/scripts/seed.sql
@@ -6,11 +6,21 @@ WHERE NOT EXISTS (SELECT 1 FROM "User" WHERE email = 'claudia@acme.inc');
 
 -- 1b. Create additional users matching CloudChat seed (for embedded auth in dev)
 INSERT INTO "User" (id, email, name, "emailVerified", "onboardingCategories")
-SELECT 'john-user-id', 'john@acme.inc', 'John', NOW(), '[]'::jsonb
+SELECT
+  'john-user-id'  AS id,
+  'john@acme.inc' AS email,
+  'John'          AS name,
+  NOW()           AS "emailVerified",
+  '[]'::jsonb     AS "onboardingCategories"
 WHERE NOT EXISTS (SELECT 1 FROM "User" WHERE email = 'john@acme.inc');
 
 INSERT INTO "User" (id, email, name, "emailVerified", "onboardingCategories")
-SELECT 'olivia-user-id', 'olivia@acme.inc', 'Olivia', NOW(), '[]'::jsonb
+SELECT
+  'olivia-user-id'  AS id,
+  'olivia@acme.inc' AS email,
+  'Olivia'          AS name,
+  NOW()             AS "emailVerified",
+  '[]'::jsonb       AS "onboardingCategories"
 WHERE NOT EXISTS (SELECT 1 FROM "User" WHERE email = 'olivia@acme.inc');
 
 -- 2. Create workspace if not exists
@@ -28,14 +38,20 @@ WHERE NOT EXISTS (
 
 -- 3b. Add CloudChat users to workspace
 INSERT INTO "MemberInWorkspace" ("userId", "workspaceId", role)
-SELECT 'john-user-id', 'claudia-workspace-id', 'ADMIN'
+SELECT
+  'john-user-id'         AS "userId",
+  'claudia-workspace-id' AS "workspaceId",
+  'ADMIN'                AS role
 WHERE NOT EXISTS (
   SELECT 1 FROM "MemberInWorkspace"
   WHERE "userId" = 'john-user-id' AND "workspaceId" = 'claudia-workspace-id'
 );
 
 INSERT INTO "MemberInWorkspace" ("userId", "workspaceId", role)
-SELECT 'olivia-user-id', 'claudia-workspace-id', 'ADMIN'
+SELECT
+  'olivia-user-id'       AS "userId",
+  'claudia-workspace-id' AS "workspaceId",
+  'ADMIN'                AS role
 WHERE NOT EXISTS (
   SELECT 1 FROM "MemberInWorkspace"
   WHERE "userId" = 'olivia-user-id' AND "workspaceId" = 'claudia-workspace-id'

--- a/packages/scripts/seed.sql
+++ b/packages/scripts/seed.sql
@@ -4,6 +4,15 @@ INSERT INTO "User" (id, email, name, "emailVerified", "onboardingCategories")
 SELECT 'claudia-user-id', 'claudia@acme.inc', 'Claudia System User', NOW(), '[]'::jsonb
 WHERE NOT EXISTS (SELECT 1 FROM "User" WHERE email = 'claudia@acme.inc');
 
+-- 1b. Create additional users matching CloudChat seed (for embedded auth in dev)
+INSERT INTO "User" (id, email, name, "emailVerified", "onboardingCategories")
+SELECT 'john-user-id', 'john@acme.inc', 'John', NOW(), '[]'::jsonb
+WHERE NOT EXISTS (SELECT 1 FROM "User" WHERE email = 'john@acme.inc');
+
+INSERT INTO "User" (id, email, name, "emailVerified", "onboardingCategories")
+SELECT 'olivia-user-id', 'olivia@acme.inc', 'Olivia', NOW(), '[]'::jsonb
+WHERE NOT EXISTS (SELECT 1 FROM "User" WHERE email = 'olivia@acme.inc');
+
 -- 2. Create workspace if not exists
 INSERT INTO "Workspace" (id, name, plan)
 SELECT 'claudia-workspace-id', 'claudia_project', 'FREE'
@@ -15,6 +24,21 @@ SELECT 'claudia-user-id', 'claudia-workspace-id', 'ADMIN'
 WHERE NOT EXISTS (
   SELECT 1 FROM "MemberInWorkspace"
   WHERE "userId" = 'claudia-user-id' AND "workspaceId" = 'claudia-workspace-id'
+);
+
+-- 3b. Add CloudChat users to workspace
+INSERT INTO "MemberInWorkspace" ("userId", "workspaceId", role)
+SELECT 'john-user-id', 'claudia-workspace-id', 'ADMIN'
+WHERE NOT EXISTS (
+  SELECT 1 FROM "MemberInWorkspace"
+  WHERE "userId" = 'john-user-id' AND "workspaceId" = 'claudia-workspace-id'
+);
+
+INSERT INTO "MemberInWorkspace" ("userId", "workspaceId", role)
+SELECT 'olivia-user-id', 'claudia-workspace-id', 'ADMIN'
+WHERE NOT EXISTS (
+  SELECT 1 FROM "MemberInWorkspace"
+  WHERE "userId" = 'olivia-user-id' AND "workspaceId" = 'claudia-workspace-id'
 );
 
 -- 3a. Create API token for claudia user matching docker-compose config


### PR DESCRIPTION
## Summary
- Add `verifyCognitoToken` helper for CloudChat SSO integration (dev-mode bypass for local development)
- Populate `cognitoClaims` for admin users authenticated via API token
- Update seed.sql with additional workspace users for local dev
- Simplify template creation buttons and propagate embedded/isFirstBot query params
- Support `includeDrafts` param and `X-Include-Drafts` header in MCP `tools/list` endpoint, allowing Hub v2 to list unpublished tool-type typebots
- Annotate MCP tool results with `_meta.isPublished` metadata

## Test plan
- [ ] Verify typebot builder authenticates with Cognito token in embedded mode
- [ ] Verify seed data creates workspace and API token on fresh setup
- [ ] Verify `tools/list` returns only published tools by default
- [ ] Verify `tools/list` returns draft tools when `includeDrafts: true` param or `X-Include-Drafts: true` header is sent
- [ ] Verify `_meta.isPublished` is correctly set on each tool result

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication behavior (embedded mode redirect bypass, API-token-derived admin claims, and dev-mode Cognito JWT verification bypass) and expands MCP tool listing to optionally include unpublished tools, which could affect access control and client compatibility.
> 
> **Overview**
> Improves embedded/Hub v2 auth paths by skipping builder redirect/logout enforcement when `?embedded=true`, adding a development-only Cognito JWT *decode* path in `verifyCognitoToken`, and populating `cognitoClaims` for Cloudhumans admin users authenticated via API token (with a new `cognitoUtils` regression test).
> 
> Extends the MCP `tools/list` endpoint to optionally include unpublished TOOL-type typebots via the `x-include-drafts: true` header, and annotates returned tools with `_meta.isPublished` so UIs can warn on drafts (default behavior remains published-only).
> 
> Updates local `seed.sql` to create additional dev users and workspace memberships, and adds a `CLAUDE.md` note documenting MCP/auth behavior and embedded-mode gotchas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22f0cb3019def3aeec8972b2177be85bb0ae4b5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces Hub v2 Cognito SSO integration, MCP draft-tool visibility, and dev seed data expansion. The major areas of change are: embedded-mode auth bypass in the builder (narrowed to sign-in redirect only), dev-mode JWKS bypass in `verifyCognitoToken`, `cognitoClaims` population for API-token-authenticated Cloudhumans admin users, an `includeDrafts` opt-in for the MCP `tools/list` endpoint via the `x-include-drafts` header, `_meta.isPublished` annotation on MCP tool objects, and expanded `seed.sql` for local dev users.

- **Auth flow**: `UserProvider` correctly narrows the `isEmbedded` bypass to the sign-in redirect only; the stale-session logout still fires unconditionally — previous concern resolved.
- **Cognito dev bypass**: `verifyCognitoToken` skips JWKS validation in `NODE_ENV=development`, now wrapped in a try/catch with a descriptive error message — previous concern resolved.
- **cognitoClaims injection**: API-token auth now populates ADMIN claims for Cloudhumans users, with a matching regression test in `cognitoUtils.test.ts`.
- **MCP `includeDrafts`**: Accepted only via the `x-include-drafts` HTTP header (not JSON-RPC body params) — a deliberate security choice that prevents agents from self-enabling draft visibility.
- **`_meta.isPublished`**: Non-standard extension of the MCP `Tool` schema; could cause compatibility issues with strict MCP clients.
- **`tools/call` gap**: Draft tools listed via `includeDrafts` are un-callable (correct), but the error is a generic \"Tool not found\" with no hint the tool exists but is unpublished.
- **Seed data**: Properly formatted multiline `SELECT` with explicit `AS` aliases — previous formatting concern resolved.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all previously blocking concerns have been resolved and remaining issues are non-critical P2 suggestions.

All three previously raised concerns (auth bypass scope, JSON.parse error handling, SQL formatting) have been addressed. The two remaining comments are P2: the non-standard _meta placement on Tool objects (low risk for an internally-consumed endpoint) and the opaque error message when calling a draft tool. Neither blocks the primary user path.

apps/builder/src/features/mcp/helpers/transformToMCPTool.ts — _meta placement may need revisiting if external MCP clients are onboarded in the future.

<details open><summary><h3>Vulnerabilities</h3></summary>

- **`x-include-drafts` header accepted from any origin**: The MCP endpoint has `Access-Control-Allow-Origin: *` and exposes `x-include-drafts` in the CORS allowed headers — any cross-origin client can request draft tool metadata. Intentional design trade-off, worth tracking as the surface grows.
- **Dev-mode JWKS bypass (`verifyCognitoToken`)**: Signature verification is skipped in `NODE_ENV=development`, appropriately documented and safely guarded.
- No new secrets exposure, injection vectors, or PII logging introduced by this PR.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/builder/src/features/mcp/helpers/transformToMCPTool.ts | Adds _meta with isPublished to individual Tool objects — non-standard placement per MCP spec; may cause issues with strict MCP clients. |
| apps/builder/src/pages/api/mcp.ts | Adds includeDrafts via x-include-drafts header only (intentional security choice). tools/call still fetches published-only tools, which can produce opaque errors for draft tools. |
| apps/builder/src/features/auth/helpers/getAuthenticatedUser.ts | Populates cognitoClaims for Cloudhumans API token users; mutates Prisma result in-place, which is acceptable. |
| apps/builder/src/features/auth/helpers/verifyCognitoToken.ts | Adds dev-mode JWT bypass with try/catch error handling (addressing previous review). Production path unchanged. |
| apps/builder/src/features/mcp/services/getWorkflowTools.ts | Clean Prisma filter addition for includeDrafts; isPublished correctly reflects publishedTypebot presence. |
| apps/builder/src/features/account/UserProvider.tsx | Correctly narrows embedded bypass to sign-in redirect only; stale-session logout still runs unconditionally (previous concern resolved). |
| packages/scripts/seed.sql | Adds john/olivia dev users and workspace memberships using multiline SELECT with explicit AS aliases (previous formatting concern resolved). |
| apps/builder/src/features/workspace/helpers/cognitoUtils.test.ts | Adds regression test verifying ADMIN cognitoClaims path returns { type: 'admin' }; correct and well-formed. |
| apps/builder/src/features/dashboard/components/DashboardHeader.tsx | Trivial: removes a blank line. No functional change. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Hub v2 UI (claudia-app)
    participant MCP as /api/mcp
    participant DB as Prisma / DB
    participant Agent as MCP Agent

    Note over UI,Agent: tools/list — Hub v2 Tools Page (includeDrafts=true)
    UI->>MCP: POST tools/list x-include-drafts: true
    MCP->>DB: getWorkflowTools({ tenant, includeDrafts: true })
    DB-->>MCP: published + draft tools
    MCP-->>UI: tools[] with _meta.isPublished per tool

    Note over UI,Agent: tools/list — Agent path (includeDrafts=false)
    Agent->>MCP: POST tools/list (no x-include-drafts header)
    MCP->>DB: getWorkflowTools({ tenant, includeDrafts: false })
    DB-->>MCP: published tools only
    MCP-->>Agent: tools[] (all isPublished: true)

    Note over UI,Agent: tools/call (always published-only lookup)
    Agent->>MCP: POST tools/call { name: some-tool }
    MCP->>DB: getWorkflowTools({ tenant }) no includeDrafts
    DB-->>MCP: published tools only
    MCP-->>Agent: result or Tool not found

    Note over UI,Agent: Embedded Auth (apiGateway=true)
    UI->>MCP: POST Bearer cognitoToken
    MCP->>MCP: verifyCognitoToken dev decode only prod JWKS verify
    MCP->>DB: findUnique by email
    DB-->>MCP: user + cognitoClaims
    MCP-->>UI: authenticated user
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/builder/src/pages/api/mcp.ts`, line 139-140 ([link](https://github.com/cloudhumans/typebot.io/blob/cafd19821a10b834acb214cd1e19325ac874a4dd/apps/builder/src/pages/api/mcp.ts#L139-L140)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`tools/call` retorna "Tool not found" genérico para ferramentas rascunho**

   Quando o Hub v2 lista ferramentas com `includeDrafts: true` e o usuário (ou um agente) tenta chamar uma ferramenta não publicada via `tools/call`, o código consulta `getWorkflowTools({ tenant })` sem `includeDrafts`, portanto a ferramenta não é encontrada no lookup e o cliente recebe `"Tool 'xxx' not found"` — mensagem que não ajuda a diagnosticar o problema real.

   Considere distinguir o caso retornando um erro mais descritivo:

   ```ts
   const { tools: allTools } = await getWorkflowTools({ tenant, includeDrafts: true })
   const tool = allTools.find((t) => sanitizeToolName(t.name) === name)
   if (tool && !tool.isPublished) {
     return res.status(200).json({
       jsonrpc: '2.0',
       error: { code: -32601, message: `Tool '${name}' exists but is not published yet` },
       id,
     })
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/builder/src/pages/api/mcp.ts
   Line: 139-140

   Comment:
   **`tools/call` retorna "Tool not found" genérico para ferramentas rascunho**

   Quando o Hub v2 lista ferramentas com `includeDrafts: true` e o usuário (ou um agente) tenta chamar uma ferramenta não publicada via `tools/call`, o código consulta `getWorkflowTools({ tenant })` sem `includeDrafts`, portanto a ferramenta não é encontrada no lookup e o cliente recebe `"Tool 'xxx' not found"` — mensagem que não ajuda a diagnosticar o problema real.

   Considere distinguir o caso retornando um erro mais descritivo:

   ```ts
   const { tools: allTools } = await getWorkflowTools({ tenant, includeDrafts: true })
   const tool = allTools.find((t) => sanitizeToolName(t.name) === name)
   if (tool && !tool.isPublished) {
     return res.status(200).json({
       jsonrpc: '2.0',
       error: { code: -32601, message: `Tool '${name}' exists but is not published yet` },
       id,
     })
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fbuilder%2Fsrc%2Fpages%2Fapi%2Fmcp.ts%0ALine%3A%20139-140%0A%0AComment%3A%0A**%60tools%2Fcall%60%20retorna%20%22Tool%20not%20found%22%20gen%C3%A9rico%20para%20ferramentas%20rascunho**%0A%0AQuando%20o%20Hub%20v2%20lista%20ferramentas%20com%20%60includeDrafts%3A%20true%60%20e%20o%20usu%C3%A1rio%20%28ou%20um%20agente%29%20tenta%20chamar%20uma%20ferramenta%20n%C3%A3o%20publicada%20via%20%60tools%2Fcall%60%2C%20o%20c%C3%B3digo%20consulta%20%60getWorkflowTools%28%7B%20tenant%20%7D%29%60%20sem%20%60includeDrafts%60%2C%20portanto%20a%20ferramenta%20n%C3%A3o%20%C3%A9%20encontrada%20no%20lookup%20e%20o%20cliente%20recebe%20%60%22Tool%20'xxx'%20not%20found%22%60%20%E2%80%94%20mensagem%20que%20n%C3%A3o%20ajuda%20a%20diagnosticar%20o%20problema%20real.%0A%0AConsidere%20distinguir%20o%20caso%20retornando%20um%20erro%20mais%20descritivo%3A%0A%0A%60%60%60ts%0Aconst%20%7B%20tools%3A%20allTools%20%7D%20%3D%20await%20getWorkflowTools%28%7B%20tenant%2C%20includeDrafts%3A%20true%20%7D%29%0Aconst%20tool%20%3D%20allTools.find%28%28t%29%20%3D%3E%20sanitizeToolName%28t.name%29%20%3D%3D%3D%20name%29%0Aif%20%28tool%20%26%26%20!tool.isPublished%29%20%7B%0A%20%20return%20res.status%28200%29.json%28%7B%0A%20%20%20%20jsonrpc%3A%20'2.0'%2C%0A%20%20%20%20error%3A%20%7B%20code%3A%20-32601%2C%20message%3A%20%60Tool%20'%24%7Bname%7D'%20exists%20but%20is%20not%20published%20yet%60%20%7D%2C%0A%20%20%20%20id%2C%0A%20%20%7D%29%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudhumans%2Ftypebot.io"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=1" height="20"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fbuilder%2Fsrc%2Fpages%2Fapi%2Fmcp.ts%0ALine%3A%20139-140%0A%0AComment%3A%0A**%60tools%2Fcall%60%20retorna%20%22Tool%20not%20found%22%20gen%C3%A9rico%20para%20ferramentas%20rascunho**%0A%0AQuando%20o%20Hub%20v2%20lista%20ferramentas%20com%20%60includeDrafts%3A%20true%60%20e%20o%20usu%C3%A1rio%20%28ou%20um%20agente%29%20tenta%20chamar%20uma%20ferramenta%20n%C3%A3o%20publicada%20via%20%60tools%2Fcall%60%2C%20o%20c%C3%B3digo%20consulta%20%60getWorkflowTools%28%7B%20tenant%20%7D%29%60%20sem%20%60includeDrafts%60%2C%20portanto%20a%20ferramenta%20n%C3%A3o%20%C3%A9%20encontrada%20no%20lookup%20e%20o%20cliente%20recebe%20%60%22Tool%20'xxx'%20not%20found%22%60%20%E2%80%94%20mensagem%20que%20n%C3%A3o%20ajuda%20a%20diagnosticar%20o%20problema%20real.%0A%0AConsidere%20distinguir%20o%20caso%20retornando%20um%20erro%20mais%20descritivo%3A%0A%0A%60%60%60ts%0Aconst%20%7B%20tools%3A%20allTools%20%7D%20%3D%20await%20getWorkflowTools%28%7B%20tenant%2C%20includeDrafts%3A%20true%20%7D%29%0Aconst%20tool%20%3D%20allTools.find%28%28t%29%20%3D%3E%20sanitizeToolName%28t.name%29%20%3D%3D%3D%20name%29%0Aif%20%28tool%20%26%26%20!tool.isPublished%29%20%7B%0A%20%20return%20res.status%28200%29.json%28%7B%0A%20%20%20%20jsonrpc%3A%20'2.0'%2C%0A%20%20%20%20error%3A%20%7B%20code%3A%20-32601%2C%20message%3A%20%60Tool%20'%24%7Bname%7D'%20exists%20but%20is%20not%20published%20yet%60%20%7D%2C%0A%20%20%20%20id%2C%0A%20%20%7D%29%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=1" height="20"></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fmcp%2Fhelpers%2FtransformToMCPTool.ts%3A36-40%0A**%60_meta%60%20em%20objetos%20%60Tool%60%20%C3%A9%20extens%C3%A3o%20fora%20do%20padr%C3%A3o%20MCP**%0A%0AO%20campo%20%60_meta%60%20%C3%A9%20definido%20pelo%20protocolo%20MCP%20como%20metadado%20de%20n%C3%ADvel%20de%20resultado%20%28%60Result._meta%60%29%2C%20n%C3%A3o%20de%20n%C3%ADvel%20de%20objeto%20%60Tool%60%20individual.%20O%20schema%20%60Tool%60%20%28protocol%20version%20%602024-11-05%60%2C%20referenciado%20no%20%60initialize%60%20handler%29%20reconhece%20apenas%20%60name%60%2C%20%60description%60%2C%20%60inputSchema%60%20e%20%60annotations%60.%0A%0AClientes%20MCP%20estritos%20que%20validam%20com%20%60additionalProperties%3A%20false%60%20podem%20rejeitar%20o%20payload%20ou%20ignorar%20silenciosamente%20o%20campo.%20O%20campo%20padr%C3%A3o%20para%20metadados%20de%20ferramenta%20no%20MCP%20%C3%A9%20%60annotations%60.%0A%0AConsidere%20mover%20%60isPublished%60%20e%20%60workflowId%60%20para%20dentro%20de%20%60annotations%60%2C%20ou%20documentar%20que%20este%20endpoint%20n%C3%A3o%20segue%20o%20schema%20MCP%20padr%C3%A3o%20%28pois%20%C3%A9%20consumido%20exclusivamente%20pelo%20Hub%20v2%29%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20annotations%3A%20%7B%0A%20%20%20%20%20%20workflowId%3A%20tool.id%2C%0A%20%20%20%20%20%20isPublished%3A%20tool.isPublished%2C%0A%20%20%20%20%7D%2C%0A%20%20%20%20_meta%3A%20%7B%0A%20%20%20%20%20%20workflowId%3A%20tool.id%2C%0A%20%20%20%20%20%20isPublished%3A%20tool.isPublished%2C%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fbuilder%2Fsrc%2Fpages%2Fapi%2Fmcp.ts%3A139-140%0A**%60tools%2Fcall%60%20retorna%20%22Tool%20not%20found%22%20gen%C3%A9rico%20para%20ferramentas%20rascunho**%0A%0AQuando%20o%20Hub%20v2%20lista%20ferramentas%20com%20%60includeDrafts%3A%20true%60%20e%20o%20usu%C3%A1rio%20%28ou%20um%20agente%29%20tenta%20chamar%20uma%20ferramenta%20n%C3%A3o%20publicada%20via%20%60tools%2Fcall%60%2C%20o%20c%C3%B3digo%20consulta%20%60getWorkflowTools%28%7B%20tenant%20%7D%29%60%20sem%20%60includeDrafts%60%2C%20portanto%20a%20ferramenta%20n%C3%A3o%20%C3%A9%20encontrada%20no%20lookup%20e%20o%20cliente%20recebe%20%60%22Tool%20'xxx'%20not%20found%22%60%20%E2%80%94%20mensagem%20que%20n%C3%A3o%20ajuda%20a%20diagnosticar%20o%20problema%20real.%0A%0AConsidere%20distinguir%20o%20caso%20retornando%20um%20erro%20mais%20descritivo%3A%0A%0A%60%60%60ts%0Aconst%20%7B%20tools%3A%20allTools%20%7D%20%3D%20await%20getWorkflowTools%28%7B%20tenant%2C%20includeDrafts%3A%20true%20%7D%29%0Aconst%20tool%20%3D%20allTools.find%28%28t%29%20%3D%3E%20sanitizeToolName%28t.name%29%20%3D%3D%3D%20name%29%0Aif%20%28tool%20%26%26%20!tool.isPublished%29%20%7B%0A%20%20return%20res.status%28200%29.json%28%7B%0A%20%20%20%20jsonrpc%3A%20'2.0'%2C%0A%20%20%20%20error%3A%20%7B%20code%3A%20-32601%2C%20message%3A%20%60Tool%20'%24%7Bname%7D'%20exists%20but%20is%20not%20published%20yet%60%20%7D%2C%0A%20%20%20%20id%2C%0A%20%20%7D%29%0A%7D%0A%60%60%60%0A%0A&repo=cloudhumans%2Ftypebot.io"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fmcp%2Fhelpers%2FtransformToMCPTool.ts%3A36-40%0A**%60_meta%60%20em%20objetos%20%60Tool%60%20%C3%A9%20extens%C3%A3o%20fora%20do%20padr%C3%A3o%20MCP**%0A%0AO%20campo%20%60_meta%60%20%C3%A9%20definido%20pelo%20protocolo%20MCP%20como%20metadado%20de%20n%C3%ADvel%20de%20resultado%20%28%60Result._meta%60%29%2C%20n%C3%A3o%20de%20n%C3%ADvel%20de%20objeto%20%60Tool%60%20individual.%20O%20schema%20%60Tool%60%20%28protocol%20version%20%602024-11-05%60%2C%20referenciado%20no%20%60initialize%60%20handler%29%20reconhece%20apenas%20%60name%60%2C%20%60description%60%2C%20%60inputSchema%60%20e%20%60annotations%60.%0A%0AClientes%20MCP%20estritos%20que%20validam%20com%20%60additionalProperties%3A%20false%60%20podem%20rejeitar%20o%20payload%20ou%20ignorar%20silenciosamente%20o%20campo.%20O%20campo%20padr%C3%A3o%20para%20metadados%20de%20ferramenta%20no%20MCP%20%C3%A9%20%60annotations%60.%0A%0AConsidere%20mover%20%60isPublished%60%20e%20%60workflowId%60%20para%20dentro%20de%20%60annotations%60%2C%20ou%20documentar%20que%20este%20endpoint%20n%C3%A3o%20segue%20o%20schema%20MCP%20padr%C3%A3o%20%28pois%20%C3%A9%20consumido%20exclusivamente%20pelo%20Hub%20v2%29%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20annotations%3A%20%7B%0A%20%20%20%20%20%20workflowId%3A%20tool.id%2C%0A%20%20%20%20%20%20isPublished%3A%20tool.isPublished%2C%0A%20%20%20%20%7D%2C%0A%20%20%20%20_meta%3A%20%7B%0A%20%20%20%20%20%20workflowId%3A%20tool.id%2C%0A%20%20%20%20%20%20isPublished%3A%20tool.isPublished%2C%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fbuilder%2Fsrc%2Fpages%2Fapi%2Fmcp.ts%3A139-140%0A**%60tools%2Fcall%60%20retorna%20%22Tool%20not%20found%22%20gen%C3%A9rico%20para%20ferramentas%20rascunho**%0A%0AQuando%20o%20Hub%20v2%20lista%20ferramentas%20com%20%60includeDrafts%3A%20true%60%20e%20o%20usu%C3%A1rio%20%28ou%20um%20agente%29%20tenta%20chamar%20uma%20ferramenta%20n%C3%A3o%20publicada%20via%20%60tools%2Fcall%60%2C%20o%20c%C3%B3digo%20consulta%20%60getWorkflowTools%28%7B%20tenant%20%7D%29%60%20sem%20%60includeDrafts%60%2C%20portanto%20a%20ferramenta%20n%C3%A3o%20%C3%A9%20encontrada%20no%20lookup%20e%20o%20cliente%20recebe%20%60%22Tool%20'xxx'%20not%20found%22%60%20%E2%80%94%20mensagem%20que%20n%C3%A3o%20ajuda%20a%20diagnosticar%20o%20problema%20real.%0A%0AConsidere%20distinguir%20o%20caso%20retornando%20um%20erro%20mais%20descritivo%3A%0A%0A%60%60%60ts%0Aconst%20%7B%20tools%3A%20allTools%20%7D%20%3D%20await%20getWorkflowTools%28%7B%20tenant%2C%20includeDrafts%3A%20true%20%7D%29%0Aconst%20tool%20%3D%20allTools.find%28%28t%29%20%3D%3E%20sanitizeToolName%28t.name%29%20%3D%3D%3D%20name%29%0Aif%20%28tool%20%26%26%20!tool.isPublished%29%20%7B%0A%20%20return%20res.status%28200%29.json%28%7B%0A%20%20%20%20jsonrpc%3A%20'2.0'%2C%0A%20%20%20%20error%3A%20%7B%20code%3A%20-32601%2C%20message%3A%20%60Tool%20'%24%7Bname%7D'%20exists%20but%20is%20not%20published%20yet%60%20%7D%2C%0A%20%20%20%20id%2C%0A%20%20%7D%29%0A%7D%0A%60%60%60%0A%0A"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/builder/src/features/mcp/helpers/transformToMCPTool.ts
Line: 36-40

Comment:
**`_meta` em objetos `Tool` é extensão fora do padrão MCP**

O campo `_meta` é definido pelo protocolo MCP como metadado de nível de resultado (`Result._meta`), não de nível de objeto `Tool` individual. O schema `Tool` (protocol version `2024-11-05`, referenciado no `initialize` handler) reconhece apenas `name`, `description`, `inputSchema` e `annotations`.

Clientes MCP estritos que validam com `additionalProperties: false` podem rejeitar o payload ou ignorar silenciosamente o campo. O campo padrão para metadados de ferramenta no MCP é `annotations`.

Considere mover `isPublished` e `workflowId` para dentro de `annotations`, ou documentar que este endpoint não segue o schema MCP padrão (pois é consumido exclusivamente pelo Hub v2):

```suggestion
    annotations: {
      workflowId: tool.id,
      isPublished: tool.isPublished,
    },
    _meta: {
      workflowId: tool.id,
      isPublished: tool.isPublished,
    },
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/builder/src/pages/api/mcp.ts
Line: 139-140

Comment:
**`tools/call` retorna "Tool not found" genérico para ferramentas rascunho**

Quando o Hub v2 lista ferramentas com `includeDrafts: true` e o usuário (ou um agente) tenta chamar uma ferramenta não publicada via `tools/call`, o código consulta `getWorkflowTools({ tenant })` sem `includeDrafts`, portanto a ferramenta não é encontrada no lookup e o cliente recebe `"Tool 'xxx' not found"` — mensagem que não ajuda a diagnosticar o problema real.

Considere distinguir o caso retornando um erro mais descritivo:

```ts
const { tools: allTools } = await getWorkflowTools({ tenant, includeDrafts: true })
const tool = allTools.find((t) => sanitizeToolName(t.name) === name)
if (tool && !tool.isPublished) {
  return res.status(200).json({
    jsonrpc: '2.0',
    error: { code: -32601, message: `Tool '${name}' exists but is not published yet` },
    id,
  })
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(DashboardHeader): inline cloudChatAu..."](https://github.com/cloudhumans/typebot.io/commit/cafd19821a10b834acb214cd1e19325ac874a4dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27761253)</sub>

<!-- /greptile_comment -->