### PR TITLE
:wrench: Adiciona Hook para não fazer push no remote upstream, ajusta o docker build para funcionar no macos.

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Pre-push hook: blocks pushes to the upstream (public) typebot.io repository.
+# Prevents accidental exposure of internal secrets and code.
+#
+# Install:
+#   git config core.hooksPath .githooks
+#
+
+BLOCKED_REPOS=(
+  "baptisteArno/typebot.io"
+)
+
+REMOTE_NAME="$1"
+REMOTE_URL="$2"
+
+for repo in "${BLOCKED_REPOS[@]}"; do
+  if echo "$REMOTE_URL" | grep -qi "$repo"; then
+    echo ""
+    echo "  =============================================="
+    echo "  PUSH BLOQUEADO"
+    echo "  =============================================="
+    echo ""
+    echo "  Remote:  $REMOTE_NAME ($REMOTE_URL)"
+    echo "  Motivo:  Push para o repo upstream publico"
+    echo "           nao e permitido."
+    echo ""
+    echo "  Use o remote do fork da CloudHumans."
+    echo ""
+    echo "  =============================================="
+    echo ""
+    exit 1
+  fi
+done
+
+exit 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get -qy update \
     && apt-get -qy --no-install-recommends install \
     openssl \
     curl \
+    python3 make g++ \
     && apt-get autoremove -yq \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -20,7 +21,7 @@ RUN turbo prune --scope=${SCOPE} --docker
 
 FROM base AS builder
 RUN apt-get -qy update \
-    && apt-get -qy --no-install-recommends install git \
+    && apt-get -qy --no-install-recommends install git python3 make g++ \
     && apt-get autoremove -yq \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/apps/builder/src/pages/api/mcp.ts
+++ b/apps/builder/src/pages/api/mcp.ts
@@ -38,6 +38,24 @@ export default async function handler(
     req.headers['tenant'] ||
     req.query.tenant) as string | undefined
 
+  logger.info('MCP request received', {
+    method: req.method,
+    tenant,
+    headers: Object.fromEntries(
+      Object.entries(req.headers).filter(([k]) =>
+        [
+          'x-tenant',
+          'tenant',
+          'content-type',
+          'accept',
+          'authorization',
+          'host',
+        ].includes(k)
+      )
+    ),
+    body: req.method === 'POST' ? req.body?.method : undefined,
+  })
+
   if (req.method === 'GET') {
     // SSE endpoint for server-to-client messages
     res.setHeader('Content-Type', 'text/event-stream')

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "apps/*"
   ],
   "scripts": {
-    "prepare": "husky install",
+    "prepare": "git config core.hooksPath .githooks",
     "docker:up": "docker compose -f docker-compose.dev.yml up -d && node scripts/wait-for-postgres.mjs",
     "docker:nuke": "docker compose -f docker-compose.dev.yml down --volumes --remove-orphans",
     "lint": "turbo run lint",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes runtime logging for the `mcp` API and may inadvertently log sensitive `Authorization` header values; other changes are build/dev tooling only.
> 
> **Overview**
> Prevents accidental pushes to the public upstream by introducing a `.githooks/pre-push` guard and switching `package.json` `prepare` to configure `core.hooksPath` to `.githooks`.
> 
> Updates the `Dockerfile` build stages to include `python3`, `make`, and `g++` (and aligns the builder stage) to avoid native-module build failures on some environments.
> 
> Adds structured `logger.info` diagnostics to `apps/builder`’s `mcp` API handler to record basic request metadata (method, tenant, selected headers, and JSON-RPC method) for troubleshooting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9310f687f5a4f3fdd87edb23fe340c4dcb4781f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Esta PR faz três mudanças independentes: (1) introduz um hook `pre-push` em `.githooks/` que bloqueia envios acidentais ao repositório público upstream `baptisteArno/typebot.io`, substituindo o Husky por `git config core.hooksPath`; (2) adiciona `python3 make g++` ao Dockerfile para permitir a compilação de módulos nativos (node-gyp) no macOS; e (3) adiciona um log de entrada no endpoint MCP para facilitar o diagnóstico.

- **P0 — Segurança**: O novo log de entrada em `mcp.ts` inclui o cabeçalho `authorization` na lista de cabeçalhos registrados, expondo tokens/credenciais em texto simples nos logs. O campo deve ser removido da lista de permissões.
- **P2**: O `builder` stage do Dockerfile reinstala `python3 make g++` que já foi instalado no `base` stage — apenas `git` é necessário no `builder`.
- **P2**: `husky` permanece em `devDependencies` mesmo depois de não ser mais utilizado; pode ser removido.
- **P2**: O hook `pre-push` pode ser contornado com `git push --no-verify`; vale documentar essa limitação.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — the `authorization` header is logged in plaintext on every MCP request, exposing credentials.

The pre-push hook and Dockerfile changes are straightforward and low-risk. However, the logging addition in `mcp.ts` includes the `authorization` header verbatim, which is a P0 security issue that must be fixed before merging. Once that one line is removed from the allow-list, the remaining concerns are minor P2 cleanups.

`apps/builder/src/pages/api/mcp.ts` — remove `authorization` from the logged headers filter before merging.

<details open><summary><h3>Security Review</h3></summary>

- **Credential exposure in logs** (`apps/builder/src/pages/api/mcp.ts`, lines 44–55): The new entry-point log explicitly allow-lists the `authorization` header, meaning Bearer tokens and API keys are written to logs in plaintext on every MCP request. Any team member or system with log read access can harvest valid credentials.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/builder/src/pages/api/mcp.ts | Adds an entry-point log for every MCP request; the filtered headers include `authorization`, exposing credentials in plaintext logs — a P0 security issue. |
| .githooks/pre-push | New git pre-push hook that blocks pushes to the public upstream repo; logic is sound, but the hook can be bypassed with `--no-verify`. |
| Dockerfile | Adds `python3 make g++` to support native module compilation on macOS; the `builder` stage redundantly re-installs packages already present from the `base` stage. |
| package.json | Switches `prepare` from `husky install` to `git config core.hooksPath .githooks`; `husky` remains as an unused `devDependency`. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[git push] --> B{pre-push hook}
    B -->|REMOTE_URL contains baptisteArno/typebot.io| C[❌ PUSH BLOQUEADO - exit 1]
    B -->|Other remote| D[✅ Push proceeds - exit 0]

    E[HTTP Request to /api/mcp] --> F[Log entry-point: method + tenant + headers + body.method]
    F -->|authorization header included in log ⚠️| G[Credentials exposed in logs]
    F --> H{req.method}
    H -->|GET| I[SSE Stream]
    H -->|POST| J{JSON-RPC method}
    H -->|DELETE| K[Session termination]
    J -->|initialize| L[Return capabilities]
    J -->|tools/list| M[getWorkflowTools]
    J -->|tools/call| N[executeWorkflow]
    J -->|notifications/initialized| O[ACK 200]
    J -->|unknown| P[Error -32601]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `package.json`, line 37 ([link](https://github.com/cloudhumans/typebot.io/blob/9310f687f5a4f3fdd87edb23fe340c4dcb4781f4/package.json#L37)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`husky` now unused after switching to `.githooks`**

   The `prepare` script was changed from `husky install` to `git config core.hooksPath .githooks`, but `husky` is still listed in `devDependencies`. It can be safely removed since the hook lifecycle is now managed by the custom `.githooks` directory.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: package.json
   Line: 37

   Comment:
   **`husky` now unused after switching to `.githooks`**

   The `prepare` script was changed from `husky install` to `git config core.hooksPath .githooks`, but `husky` is still listed in `devDependencies`. It can be safely removed since the hook lifecycle is now managed by the custom `.githooks` directory.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20package.json%0ALine%3A%2037%0A%0AComment%3A%0A**%60husky%60%20now%20unused%20after%20switching%20to%20%60.githooks%60**%0A%0AThe%20%60prepare%60%20script%20was%20changed%20from%20%60husky%20install%60%20to%20%60git%20config%20core.hooksPath%20.githooks%60%2C%20but%20%60husky%60%20is%20still%20listed%20in%20%60devDependencies%60.%20It%20can%20be%20safely%20removed%20since%20the%20hook%20lifecycle%20is%20now%20managed%20by%20the%20custom%20%60.githooks%60%20directory.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudhumans%2Ftypebot.io"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20package.json%0ALine%3A%2037%0A%0AComment%3A%0A**%60husky%60%20now%20unused%20after%20switching%20to%20%60.githooks%60**%0A%0AThe%20%60prepare%60%20script%20was%20changed%20from%20%60husky%20install%60%20to%20%60git%20config%20core.hooksPath%20.githooks%60%2C%20but%20%60husky%60%20is%20still%20listed%20in%20%60devDependencies%60.%20It%20can%20be%20safely%20removed%20since%20the%20hook%20lifecycle%20is%20now%20managed%20by%20the%20custom%20%60.githooks%60%20directory.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aapps%2Fbuilder%2Fsrc%2Fpages%2Fapi%2Fmcp.ts%3A44-55%0A**Authorization%20header%20logged%20in%20plaintext**%0A%0AThe%20filtered%20headers%20list%20includes%20%60'authorization'%60%2C%20which%20means%20the%20full%20%60Authorization%60%20header%20value%20%28e.g.%2C%20%60Bearer%20%3Ctoken%3E%60%2C%20API%20keys%29%20will%20be%20written%20to%20logs%20on%20every%20MCP%20request.%20This%20exposes%20credentials%20to%20anyone%20with%20log%20access%20and%20creates%20a%20security%20%2F%20compliance%20risk.%0A%0ARemove%20%60authorization%60%20from%20the%20allow-list%2C%20or%20mask%20the%20value%20before%20logging%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20headers%3A%20Object.fromEntries%28%0A%20%20%20%20%20%20Object.entries%28req.headers%29.filter%28%28%5Bk%5D%29%20%3D%3E%0A%20%20%20%20%20%20%20%20%5B%0A%20%20%20%20%20%20%20%20%20%20'x-tenant'%2C%0A%20%20%20%20%20%20%20%20%20%20'tenant'%2C%0A%20%20%20%20%20%20%20%20%20%20'content-type'%2C%0A%20%20%20%20%20%20%20%20%20%20'accept'%2C%0A%20%20%20%20%20%20%20%20%20%20'host'%2C%0A%20%20%20%20%20%20%20%20%5D.includes%28k%29%0A%20%20%20%20%20%20%29%0A%20%20%20%20%29%2C%0A%60%60%60%0A%0A**Rule%20Used%3A**%20What%3A%20Never%20log%20personally%20identifiable%20informatio...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D887ad6df-70dd-4fb2-9ee8-904c5733b6d3%29%29%0A%0A%23%23%23%20Issue%202%20of%204%0Apackage.json%3A37%0A**%60husky%60%20now%20unused%20after%20switching%20to%20%60.githooks%60**%0A%0AThe%20%60prepare%60%20script%20was%20changed%20from%20%60husky%20install%60%20to%20%60git%20config%20core.hooksPath%20.githooks%60%2C%20but%20%60husky%60%20is%20still%20listed%20in%20%60devDependencies%60.%20It%20can%20be%20safely%20removed%20since%20the%20hook%20lifecycle%20is%20now%20managed%20by%20the%20custom%20%60.githooks%60%20directory.%0A%0A%23%23%23%20Issue%203%20of%204%0ADockerfile%3A24%0A**Redundant%20package%20installation%20in%20%60builder%60%20stage**%0A%0AThe%20%60builder%60%20stage%20inherits%20from%20%60base%60%2C%20which%20already%20installs%20%60python3%20make%20g%2B%2B%60%20%28line%2010%29.%20Re-installing%20them%20here%20is%20harmless%20but%20adds%20an%20unnecessary%20%60apt-get%20update%60%20cycle%20and%20increases%20build%20time.%20Consider%20installing%20only%20the%20additional%20package%20%28%60git%60%29%20needed%20by%20this%20stage%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%26%26%20apt-get%20-qy%20--no-install-recommends%20install%20git%20%5C%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0A.githooks%2Fpre-push%3A17-19%0A**Hook%20can%20be%20bypassed%20with%20%60--no-verify%60**%0A%0A%60git%20push%20--no-verify%60%20skips%20all%20pre-push%20hooks%2C%20so%20this%20protection%20can%20be%20circumvented%20accidentally%20or%20intentionally.%20Consider%20documenting%20this%20limitation%20in%20the%20hook's%20header%20comment%20so%20the%20team%20is%20aware%2C%20or%20supplementing%20the%20local%20hook%20with%20a%20server-side%20branch%20protection%20rule%20on%20the%20upstream%20repo.%0A%0A&repo=cloudhumans%2Ftypebot.io"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aapps%2Fbuilder%2Fsrc%2Fpages%2Fapi%2Fmcp.ts%3A44-55%0A**Authorization%20header%20logged%20in%20plaintext**%0A%0AThe%20filtered%20headers%20list%20includes%20%60'authorization'%60%2C%20which%20means%20the%20full%20%60Authorization%60%20header%20value%20%28e.g.%2C%20%60Bearer%20%3Ctoken%3E%60%2C%20API%20keys%29%20will%20be%20written%20to%20logs%20on%20every%20MCP%20request.%20This%20exposes%20credentials%20to%20anyone%20with%20log%20access%20and%20creates%20a%20security%20%2F%20compliance%20risk.%0A%0ARemove%20%60authorization%60%20from%20the%20allow-list%2C%20or%20mask%20the%20value%20before%20logging%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20headers%3A%20Object.fromEntries%28%0A%20%20%20%20%20%20Object.entries%28req.headers%29.filter%28%28%5Bk%5D%29%20%3D%3E%0A%20%20%20%20%20%20%20%20%5B%0A%20%20%20%20%20%20%20%20%20%20'x-tenant'%2C%0A%20%20%20%20%20%20%20%20%20%20'tenant'%2C%0A%20%20%20%20%20%20%20%20%20%20'content-type'%2C%0A%20%20%20%20%20%20%20%20%20%20'accept'%2C%0A%20%20%20%20%20%20%20%20%20%20'host'%2C%0A%20%20%20%20%20%20%20%20%5D.includes%28k%29%0A%20%20%20%20%20%20%29%0A%20%20%20%20%29%2C%0A%60%60%60%0A%0A**Rule%20Used%3A**%20What%3A%20Never%20log%20personally%20identifiable%20informatio...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D887ad6df-70dd-4fb2-9ee8-904c5733b6d3%29%29%0A%0A%23%23%23%20Issue%202%20of%204%0Apackage.json%3A37%0A**%60husky%60%20now%20unused%20after%20switching%20to%20%60.githooks%60**%0A%0AThe%20%60prepare%60%20script%20was%20changed%20from%20%60husky%20install%60%20to%20%60git%20config%20core.hooksPath%20.githooks%60%2C%20but%20%60husky%60%20is%20still%20listed%20in%20%60devDependencies%60.%20It%20can%20be%20safely%20removed%20since%20the%20hook%20lifecycle%20is%20now%20managed%20by%20the%20custom%20%60.githooks%60%20directory.%0A%0A%23%23%23%20Issue%203%20of%204%0ADockerfile%3A24%0A**Redundant%20package%20installation%20in%20%60builder%60%20stage**%0A%0AThe%20%60builder%60%20stage%20inherits%20from%20%60base%60%2C%20which%20already%20installs%20%60python3%20make%20g%2B%2B%60%20%28line%2010%29.%20Re-installing%20them%20here%20is%20harmless%20but%20adds%20an%20unnecessary%20%60apt-get%20update%60%20cycle%20and%20increases%20build%20time.%20Consider%20installing%20only%20the%20additional%20package%20%28%60git%60%29%20needed%20by%20this%20stage%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%26%26%20apt-get%20-qy%20--no-install-recommends%20install%20git%20%5C%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0A.githooks%2Fpre-push%3A17-19%0A**Hook%20can%20be%20bypassed%20with%20%60--no-verify%60**%0A%0A%60git%20push%20--no-verify%60%20skips%20all%20pre-push%20hooks%2C%20so%20this%20protection%20can%20be%20circumvented%20accidentally%20or%20intentionally.%20Consider%20documenting%20this%20limitation%20in%20the%20hook's%20header%20comment%20so%20the%20team%20is%20aware%2C%20or%20supplementing%20the%20local%20hook%20with%20a%20server-side%20branch%20protection%20rule%20on%20the%20upstream%20repo.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/builder/src/pages/api/mcp.ts
Line: 44-55

Comment:
**Authorization header logged in plaintext**

The filtered headers list includes `'authorization'`, which means the full `Authorization` header value (e.g., `Bearer <token>`, API keys) will be written to logs on every MCP request. This exposes credentials to anyone with log access and creates a security / compliance risk.

Remove `authorization` from the allow-list, or mask the value before logging:

```suggestion
    headers: Object.fromEntries(
      Object.entries(req.headers).filter(([k]) =>
        [
          'x-tenant',
          'tenant',
          'content-type',
          'accept',
          'host',
        ].includes(k)
      )
    ),
```

**Rule Used:** What: Never log personally identifiable informatio... ([source](https://app.greptile.com/review/custom-context?memory=887ad6df-70dd-4fb2-9ee8-904c5733b6d3))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: package.json
Line: 37

Comment:
**`husky` now unused after switching to `.githooks`**

The `prepare` script was changed from `husky install` to `git config core.hooksPath .githooks`, but `husky` is still listed in `devDependencies`. It can be safely removed since the hook lifecycle is now managed by the custom `.githooks` directory.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: Dockerfile
Line: 24

Comment:
**Redundant package installation in `builder` stage**

The `builder` stage inherits from `base`, which already installs `python3 make g++` (line 10). Re-installing them here is harmless but adds an unnecessary `apt-get update` cycle and increases build time. Consider installing only the additional package (`git`) needed by this stage:

```suggestion
    && apt-get -qy --no-install-recommends install git \
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .githooks/pre-push
Line: 17-19

Comment:
**Hook can be bypassed with `--no-verify`**

`git push --no-verify` skips all pre-push hooks, so this protection can be circumvented accidentally or intentionally. Consider documenting this limitation in the hook's header comment so the team is aware, or supplementing the local hook with a server-side branch protection rule on the upstream repo.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: replace husky with .githooks for ..."](https://github.com/cloudhumans/typebot.io/commit/9310f687f5a4f3fdd87edb23fe340c4dcb4781f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28209953)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Rule used - What: Never log personally identifiable informatio... ([source](https://app.greptile.com/review/custom-context?memory=887ad6df-70dd-4fb2-9ee8-904c5733b6d3))

<!-- /greptile_comment -->