### PR TITLE
✨feature: add CX metrics panel and analytics badges on graph blocks

### DIFF
--- a/apps/builder/src/components/icons.tsx
+++ b/apps/builder/src/components/icons.tsx
@@ -744,6 +744,37 @@ export const ValidateCnpjIcon = (props: IconProps) => (
   </Icon>
 )
 
+export const BarChart2Icon = (props: IconProps) => (
+  <Icon viewBox="0 0 24 24" {...featherIconsBaseProps} {...props}>
+    <line x1="18" y1="20" x2="18" y2="10" />
+    <line x1="12" y1="20" x2="12" y2="4" />
+    <line x1="6" y1="20" x2="6" y2="14" />
+  </Icon>
+)
+
+export const TargetIcon = (props: IconProps) => (
+  <Icon viewBox="0 0 24 24" {...featherIconsBaseProps} {...props}>
+    <circle cx="12" cy="12" r="10" />
+    <circle cx="12" cy="12" r="6" />
+    <circle cx="12" cy="12" r="2" />
+  </Icon>
+)
+
+export const ClockIcon = (props: IconProps) => (
+  <Icon viewBox="0 0 24 24" {...featherIconsBaseProps} {...props}>
+    <circle cx="12" cy="12" r="10" />
+    <polyline points="12 6 12 12 16 14" />
+  </Icon>
+)
+
+export const LogInIcon = (props: IconProps) => (
+  <Icon viewBox="0 0 24 24" {...featherIconsBaseProps} {...props}>
+    <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
+    <polyline points="10 17 15 12 10 7" />
+    <line x1="15" y1="12" x2="3" y2="12" />
+  </Icon>
+)
+
 export const NativeVariablesIcon = (props: IconProps) => (
   <Icon viewBox="0 0 24 24" {...props}>
     <path

--- a/apps/builder/src/features/analytics/api/getAnalyticsStats.ts
+++ b/apps/builder/src/features/analytics/api/getAnalyticsStats.ts
@@ -1,0 +1,367 @@
+import prisma from '@typebot.io/lib/prisma'
+import { Prisma } from '@typebot.io/prisma'
+import { authenticatedProcedure } from '@/helpers/server/trpc'
+import { TRPCError } from '@trpc/server'
+import { z } from 'zod'
+import { canReadTypebots } from '@/helpers/databaseRules'
+import { defaultTimeFilter, timeFilterValues } from '../constants'
+import {
+  parseFromDateFromTimeFilter,
+  parseToDateFromTimeFilter,
+} from '../helpers/parseDateFromTimeFilter'
+
+const analyticsInputSchema = z.object({
+  typebotId: z.string(),
+  timeFilter: z.enum(timeFilterValues).default(defaultTimeFilter),
+  timeZone: z.string().optional(),
+})
+
+type AnalyticsInput = z.infer<typeof analyticsInputSchema>
+
+const resolveTypebotAndDateFilter = async (
+  input: AnalyticsInput,
+  user: { id: string }
+) => {
+  const typebot = await prisma.typebot.findFirst({
+    where: canReadTypebots(input.typebotId, user),
+    select: { id: true },
+  })
+  if (!typebot)
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Typebot not found' })
+
+  const fromDate = parseFromDateFromTimeFilter(input.timeFilter, input.timeZone)
+  const toDate = parseToDateFromTimeFilter(input.timeFilter, input.timeZone)
+
+  const dateFilter = fromDate
+    ? { gte: fromDate, ...(toDate ? { lte: toDate } : {}) }
+    : undefined
+
+  const baseWhere = {
+    typebotId: typebot.id,
+    isArchived: false as const,
+    createdAt: dateFilter,
+  }
+
+  return { typebot, baseWhere }
+}
+
+type TypebotGroup = {
+  id: string
+  blocks: Array<{
+    id: string
+    type: string
+    options?: { action?: string }
+  }>
+}
+
+const loadTypebotGroups = async (
+  typebotId: string
+): Promise<TypebotGroup[]> => {
+  const typebotFull = await prisma.typebot.findUnique({
+    where: { id: typebotId },
+    select: { groups: true },
+  })
+  if (!typebotFull?.groups || !Array.isArray(typebotFull.groups)) return []
+  return typebotFull.groups as TypebotGroup[]
+}
+
+// ---------------------------------------------------------------------------
+// getBlockVisitStats
+// ---------------------------------------------------------------------------
+
+const groupStatsSchema = z.object({
+  groupId: z.string(),
+  visits: z.number(),
+  visitPercentage: z.number(),
+})
+
+const blockIssueSchema = z.object({
+  blockId: z.string(),
+  groupId: z.string(),
+  type: z.enum(['abandoned', 'error']),
+  count: z.number(),
+  percentage: z.number(),
+})
+
+export const getBlockVisitStats = authenticatedProcedure
+  .input(analyticsInputSchema)
+  .output(
+    z.object({
+      totalSessions: z.number(),
+      groupStats: z.array(groupStatsSchema),
+      blockIssues: z.array(blockIssueSchema),
+    })
+  )
+  .query(async ({ input, ctx: { user } }) => {
+    const { typebot, baseWhere } = await resolveTypebotAndDateFilter(
+      input,
+      user
+    )
+
+    const totalSessions = await prisma.result.count({ where: baseWhere })
+    if (totalSessions === 0)
+      return { totalSessions: 0, groupStats: [], blockIssues: [] }
+
+    const groups = await loadTypebotGroups(typebot.id)
+    const claudiaBlockIds = new Set<string>()
+    for (const group of groups) {
+      for (const block of group.blocks) {
+        if (block.type === 'claudia') claudiaBlockIds.add(block.id)
+      }
+    }
+
+    const groupVisits = new Map<string, number>()
+    const blockIssuesMap = new Map<
+      string,
+      {
+        blockId: string
+        groupId: string
+        type: 'abandoned' | 'error'
+        count: number
+      }
+    >()
+
+    const BATCH_SIZE = 1000
+    let cursor: string | undefined
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const batch = await prisma.result.findMany({
+        where: {
+          ...baseWhere,
+          NOT: { visitedBlocks: { equals: Prisma.JsonNull } },
+        },
+        select: { id: true, visitedBlocks: true, status: true },
+        take: BATCH_SIZE,
+        ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+        orderBy: { id: 'asc' },
+      })
+      if (batch.length === 0) break
+
+      for (const result of batch) {
+        const blocks = Array.isArray(result.visitedBlocks)
+          ? (result.visitedBlocks as Array<{
+              blockId: string
+              groupId: string
+              status: string
+            }>)
+          : []
+
+        if (blocks.length === 0) continue
+
+        const visitedGroupIds = new Set<string>()
+        for (const block of blocks) {
+          visitedGroupIds.add(block.groupId)
+        }
+        for (const gid of visitedGroupIds) {
+          groupVisits.set(gid, (groupVisits.get(gid) ?? 0) + 1)
+        }
+
+        const lastBlock = blocks[blocks.length - 1]
+
+        if (claudiaBlockIds.has(lastBlock.blockId)) continue
+
+        const isError =
+          lastBlock.status === 'dead_end' ||
+          lastBlock.status === 'error' ||
+          result.status === 'error'
+        const isAbandoned =
+          !isError &&
+          (lastBlock.status === 'abandoned' || result.status === 'abandoned')
+
+        if (isError || isAbandoned) {
+          const type = isError ? 'error' : 'abandoned'
+          const key = `${lastBlock.blockId}::${lastBlock.groupId}::${type}`
+          const entry = blockIssuesMap.get(key) ?? {
+            blockId: lastBlock.blockId,
+            groupId: lastBlock.groupId,
+            type,
+            count: 0,
+          }
+          entry.count++
+          blockIssuesMap.set(key, entry)
+        }
+      }
+
+      cursor = batch[batch.length - 1].id
+      if (batch.length < BATCH_SIZE) break
+    }
+
+    const groupStats = Array.from(groupVisits.entries()).map(
+      ([groupId, visits]) => ({
+        groupId,
+        visits,
+        visitPercentage:
+          totalSessions > 0
+            ? Math.round((visits / totalSessions) * 100)
+            : 0,
+      })
+    )
+
+    const blockIssues = Array.from(blockIssuesMap.values()).map((entry) => ({
+      ...entry,
+      percentage:
+        totalSessions > 0
+          ? Math.round((entry.count / totalSessions) * 100)
+          : 0,
+    }))
+
+    return { totalSessions, groupStats, blockIssues }
+  })
+
+// ---------------------------------------------------------------------------
+// getCxStats
+// ---------------------------------------------------------------------------
+
+const cxStatsSchema = z.object({
+  totalSessions: z.number(),
+  completed: z.number(),
+  errors: z.number(),
+  abandoned: z.number(),
+  completionRate: z.number(),
+  forwardToHumansN2: z.number(),
+  endFlowN1: z.number(),
+  answerTicket: z.number(),
+  closeTicket: z.number(),
+  avgSessionDurationMs: z.number().nullable(),
+  volumeByDay: z.array(
+    z.object({
+      date: z.string(),
+      count: z.number(),
+    })
+  ),
+})
+
+export const getCxStats = authenticatedProcedure
+  .meta({
+    openapi: {
+      method: 'GET',
+      path: '/v1/typebots/{typebotId}/analytics/cx-stats',
+      protect: true,
+      summary: 'Get CX analytics stats',
+      tags: ['Analytics'],
+    },
+  })
+  .input(analyticsInputSchema)
+  .output(z.object({ cxStats: cxStatsSchema }))
+  .query(async ({ input, ctx: { user } }) => {
+    const { typebot, baseWhere } = await resolveTypebotAndDateFilter(
+      input,
+      user
+    )
+
+    const [totalSessions, completed, errors, abandoned] =
+      await prisma.$transaction([
+        prisma.result.count({ where: baseWhere }),
+        prisma.result.count({
+          where: { ...baseWhere, status: 'completed' },
+        }),
+        prisma.result.count({ where: { ...baseWhere, status: 'error' } }),
+        prisma.result.count({
+          where: { ...baseWhere, status: 'abandoned' },
+        }),
+      ])
+
+    const completionRate =
+      totalSessions > 0
+        ? Math.round((completed / totalSessions) * 10000) / 100
+        : 0
+
+    const groups = await loadTypebotGroups(typebot.id)
+    const claudiaActionByBlockId = new Map<string, string>()
+    for (const group of groups) {
+      for (const block of group.blocks) {
+        if (block.type === 'claudia' && block.options?.action) {
+          claudiaActionByBlockId.set(block.id, block.options.action)
+        }
+      }
+    }
+
+    const claudiaActionToMetric: Record<string, string> = {
+      'Forward to Human [N2]': 'forwardToHumansN2',
+      'End Flow [N1]': 'endFlowN1',
+      'Answer Ticket [N1]': 'answerTicket',
+      'Close Ticket [N1]': 'closeTicket',
+    }
+
+    const metricCounters = new Map<string, number>()
+    let totalDurationMs = 0
+    let durationCount = 0
+    const volumeMap = new Map<string, number>()
+
+    const BATCH_SIZE = 1000
+    let cursor: string | undefined
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const batch = await prisma.result.findMany({
+        where: baseWhere,
+        select: {
+          id: true,
+          visitedBlocks: true,
+          createdAt: true,
+        },
+        take: BATCH_SIZE,
+        ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+        orderBy: { id: 'asc' },
+      })
+      if (batch.length === 0) break
+
+      for (const result of batch) {
+        const day = result.createdAt.toISOString().split('T')[0]
+        volumeMap.set(day, (volumeMap.get(day) ?? 0) + 1)
+
+        const blocks = Array.isArray(result.visitedBlocks)
+          ? (result.visitedBlocks as Array<{
+              blockId: string
+              groupId: string
+              timestamp: string
+              status: string
+            }>)
+          : []
+
+        for (const block of blocks) {
+          const action = claudiaActionByBlockId.get(block.blockId)
+          if (!action) continue
+          const metric = claudiaActionToMetric[action]
+          if (metric)
+            metricCounters.set(metric, (metricCounters.get(metric) ?? 0) + 1)
+        }
+
+        if (blocks.length > 0) {
+          const start = result.createdAt.getTime()
+          const lastTs = new Date(
+            blocks[blocks.length - 1].timestamp
+          ).getTime()
+          if (lastTs > start) {
+            totalDurationMs += lastTs - start
+            durationCount++
+          }
+        }
+      }
+
+      cursor = batch[batch.length - 1].id
+      if (batch.length < BATCH_SIZE) break
+    }
+
+    const avgSessionDurationMs =
+      durationCount > 0 ? Math.round(totalDurationMs / durationCount) : null
+
+    const volumeByDay = Array.from(volumeMap.entries())
+      .map(([date, count]) => ({ date, count }))
+      .sort((a, b) => a.date.localeCompare(b.date))
+
+    return {
+      cxStats: {
+        totalSessions,
+        completed,
+        errors,
+        abandoned,
+        completionRate,
+        forwardToHumansN2: metricCounters.get('forwardToHumansN2') ?? 0,
+        endFlowN1: metricCounters.get('endFlowN1') ?? 0,
+        answerTicket: metricCounters.get('answerTicket') ?? 0,
+        closeTicket: metricCounters.get('closeTicket') ?? 0,
+        avgSessionDurationMs,
+        volumeByDay,
+      },
+    }
+  })

--- a/apps/builder/src/features/analytics/api/router.ts
+++ b/apps/builder/src/features/analytics/api/router.ts
@@ -1,8 +1,11 @@
 import { router } from '@/helpers/server/trpc'
 import { getStats } from './getStats'
 import { getInDepthAnalyticsData } from './getInDepthAnalyticsData'
+import { getCxStats, getBlockVisitStats } from './getAnalyticsStats'
 
 export const analyticsRouter = router({
   getInDepthAnalyticsData,
   getStats,
+  getCxStats,
+  getBlockVisitStats,
 })

--- a/apps/builder/src/features/analytics/components/AnalyticsGraphContainer.tsx
+++ b/apps/builder/src/features/analytics/components/AnalyticsGraphContainer.tsx
@@ -5,15 +5,9 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 import { useTypebot } from '@/features/editor/providers/TypebotProvider'
-import {
-  Edge,
-  GroupV6,
-  Stats,
-  TotalAnswers,
-  TotalVisitedEdges,
-} from '@typebot.io/schemas'
-import React, { useMemo } from 'react'
-import { StatsCards } from './StatsCards'
+import { Stats } from '@typebot.io/schemas'
+import React, { useMemo, useState } from 'react'
+import { CxMetricsPanel } from './CxMetricsPanel'
 import { ChangePlanModal } from '@/features/billing/components/ChangePlanModal'
 import { Graph } from '@/features/graph/components/Graph'
 import { GraphProvider } from '@/features/graph/providers/GraphProvider'
@@ -22,7 +16,6 @@ import { trpc } from '@/lib/trpc'
 import { isDefined } from '@typebot.io/lib'
 import { EventsCoordinatesProvider } from '@/features/graph/providers/EventsCoordinateProvider'
 import { timeFilterValues } from '../constants'
-import { blockHasItems, isInputBlock } from '@typebot.io/schemas/helpers'
 
 const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
 
@@ -30,6 +23,20 @@ type Props = {
   timeFilter: (typeof timeFilterValues)[number]
   onTimeFilterChange: (timeFilter: (typeof timeFilterValues)[number]) => void
   stats?: Stats
+}
+
+export type GroupAnalytics = {
+  groupId: string
+  visits: number
+  visitPercentage: number
+}
+
+export type BlockIssue = {
+  blockId: string
+  groupId: string
+  type: 'abandoned' | 'error'
+  count: number
+  percentage: number
 }
 
 export const AnalyticsGraphContainer = ({
@@ -40,163 +47,82 @@ export const AnalyticsGraphContainer = ({
   const { t } = useTranslate()
   const { isOpen, onOpen, onClose } = useDisclosure()
   const { typebot, publishedTypebot } = useTypebot()
-  const { data } = trpc.analytics.getInDepthAnalyticsData.useQuery(
+
+  const { data: blockVisitData } = trpc.analytics.getBlockVisitStats.useQuery(
     {
       typebotId: typebot?.id as string,
       timeFilter,
       timeZone,
     },
-    { enabled: isDefined(publishedTypebot) }
+    { enabled: isDefined(typebot?.id) }
   )
 
-  const totalVisitedEdges = useMemo(() => {
-    if (
-      !publishedTypebot?.edges ||
-      !publishedTypebot.groups ||
-      !publishedTypebot.events ||
-      !data?.totalAnswers ||
-      !stats?.totalViews
-    )
-      return
-    const firstEdgeId = publishedTypebot.events[0].outgoingEdgeId
-    if (!firstEdgeId) return
-    return populateEdgesWithVisitData({
-      edgeId: firstEdgeId,
-      edges: publishedTypebot.edges,
-      groups: publishedTypebot.groups,
-      currentTotalUsers: stats.totalViews,
-      totalVisitedEdges: data.offDefaultPathVisitedEdges
-        ? [...data.offDefaultPathVisitedEdges]
-        : [],
-      totalAnswers: data.totalAnswers,
-      edgeVisitHistory: [],
-    })
-  }, [
-    data?.offDefaultPathVisitedEdges,
-    data?.totalAnswers,
-    publishedTypebot?.edges,
-    publishedTypebot?.groups,
-    publishedTypebot?.events,
-    stats?.totalViews,
-  ])
+  const groupAnalyticsMap = useMemo(() => {
+    if (!blockVisitData?.groupStats) return undefined
+    const map = new Map<string, GroupAnalytics>()
+    for (const gs of blockVisitData.groupStats) {
+      map.set(gs.groupId, gs)
+    }
+    return map
+  }, [blockVisitData?.groupStats])
+
+  const [isMetricsExpanded, setIsMetricsExpanded] = useState(true)
+
+  const graphBgColor = useColorModeValue('#f4f5f8', 'gray.850')
+  const graphBgImage = useColorModeValue(
+    'radial-gradient(#c6d0e1 1px, transparent 0)',
+    'radial-gradient(#2f2f39 1px, transparent 0)'
+  )
 
   return (
-    <Flex
-      w="full"
-      pos="relative"
-      bgColor={useColorModeValue('#f4f5f8', 'gray.850')}
-      backgroundImage={useColorModeValue(
-        'radial-gradient(#c6d0e1 1px, transparent 0)',
-        'radial-gradient(#2f2f39 1px, transparent 0)'
-      )}
-      backgroundSize="40px 40px"
-      backgroundPosition="-19px -19px"
-      h="full"
-      justifyContent="center"
-    >
-      {publishedTypebot && stats ? (
-        <GraphProvider isReadOnly isAnalytics>
-          <EventsCoordinatesProvider events={publishedTypebot?.events}>
-            <Graph
-              flex="1"
-              typebot={publishedTypebot}
-              onUnlockProPlanClick={onOpen}
-              totalAnswers={data?.totalAnswers}
-              totalVisitedEdges={totalVisitedEdges}
-            />
-          </EventsCoordinatesProvider>
-        </GraphProvider>
-      ) : (
-        <Flex
-          justify="center"
-          align="center"
-          boxSize="full"
-          bgColor="rgba(255, 255, 255, 0.5)"
-        >
-          <Spinner color="gray" />
-        </Flex>
-      )}
-      <ChangePlanModal
-        onClose={onClose}
-        isOpen={isOpen}
-        type={t('billing.limitMessage.analytics')}
-        excludedPlans={['STARTER']}
-      />
-      <StatsCards
-        stats={stats}
-        pos="absolute"
+    <Flex w="full" direction="column" h="full" overflow="hidden">
+      <CxMetricsPanel
         timeFilter={timeFilter}
         onTimeFilterChange={onTimeFilterChange}
+        isExpanded={isMetricsExpanded}
+        onToggle={() => setIsMetricsExpanded((prev) => !prev)}
       />
+      <Flex
+        w="full"
+        pos="relative"
+        bgColor={graphBgColor}
+        backgroundImage={graphBgImage}
+        backgroundSize="40px 40px"
+        backgroundPosition="-19px -19px"
+        flex="1"
+        minH="0"
+        justifyContent="center"
+        overflow="hidden"
+      >
+        {publishedTypebot ? (
+          <GraphProvider isReadOnly isAnalytics>
+            <EventsCoordinatesProvider events={publishedTypebot?.events}>
+              <Graph
+                flex="1"
+                typebot={publishedTypebot}
+                onUnlockProPlanClick={onOpen}
+                groupAnalyticsMap={groupAnalyticsMap}
+                blockIssues={blockVisitData?.blockIssues}
+              />
+            </EventsCoordinatesProvider>
+          </GraphProvider>
+        ) : (
+          <Flex
+            justify="center"
+            align="center"
+            boxSize="full"
+            bgColor="rgba(255, 255, 255, 0.5)"
+          >
+            <Spinner color="gray" />
+          </Flex>
+        )}
+        <ChangePlanModal
+          onClose={onClose}
+          isOpen={isOpen}
+          type={t('billing.limitMessage.analytics')}
+          excludedPlans={['STARTER']}
+        />
+      </Flex>
     </Flex>
   )
-}
-
-const populateEdgesWithVisitData = ({
-  edgeId,
-  edges,
-  groups,
-  currentTotalUsers,
-  totalVisitedEdges,
-  totalAnswers,
-  edgeVisitHistory,
-}: {
-  edgeId: string
-  edges: Edge[]
-  groups: GroupV6[]
-  currentTotalUsers: number
-  totalVisitedEdges: TotalVisitedEdges[]
-  totalAnswers: TotalAnswers[]
-  edgeVisitHistory: string[]
-}): TotalVisitedEdges[] => {
-  if (edgeVisitHistory.find((e) => e === edgeId)) return totalVisitedEdges
-  totalVisitedEdges.push({
-    edgeId,
-    total: currentTotalUsers,
-  })
-  edgeVisitHistory.push(edgeId)
-  const edge = edges.find((edge) => edge.id === edgeId)
-  if (!edge) return totalVisitedEdges
-  const group = groups.find((group) => edge?.to.groupId === group.id)
-  if (!group) return totalVisitedEdges
-  for (const block of edge.to.blockId
-    ? group.blocks.slice(
-        group.blocks.findIndex((b) => b.id === edge.to.blockId)
-      )
-    : group.blocks) {
-    if (blockHasItems(block)) {
-      for (const item of block.items) {
-        if (item.outgoingEdgeId) {
-          totalVisitedEdges = populateEdgesWithVisitData({
-            edgeId: item.outgoingEdgeId,
-            edges,
-            groups,
-            currentTotalUsers:
-              totalVisitedEdges.find(
-                (tve) => tve.edgeId === item.outgoingEdgeId
-              )?.total ?? 0,
-            totalVisitedEdges,
-            totalAnswers,
-            edgeVisitHistory,
-          })
-        }
-      }
-    }
-    if (block.outgoingEdgeId) {
-      const totalUsers = isInputBlock(block)
-        ? totalAnswers.find((a) => a.blockId === block.id)?.total
-        : currentTotalUsers
-      totalVisitedEdges = populateEdgesWithVisitData({
-        edgeId: block.outgoingEdgeId,
-        edges,
-        groups,
-        currentTotalUsers: totalUsers ?? 0,
-        totalVisitedEdges,
-        totalAnswers,
-        edgeVisitHistory,
-      })
-    }
-  }
-
-  return totalVisitedEdges
 }

--- a/apps/builder/src/features/analytics/components/CxMetricsPanel.tsx
+++ b/apps/builder/src/features/analytics/components/CxMetricsPanel.tsx
@@ -1,0 +1,289 @@
+import {
+  Box,
+  Collapse,
+  Flex,
+  IconProps,
+  SimpleGrid,
+  Skeleton,
+  Text,
+  Tooltip,
+  useColorModeValue,
+  HStack,
+} from '@chakra-ui/react'
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  BarChart2Icon,
+  CheckIcon,
+  TargetIcon,
+  AlertIcon,
+  LogOutIcon,
+  UserIcon,
+  FlagIcon,
+  ChatIcon,
+  LockedIcon,
+  ClockIcon,
+} from '@/components/icons'
+import React from 'react'
+import { trpc } from '@/lib/trpc'
+import { useTypebot } from '@/features/editor/providers/TypebotProvider'
+import { isDefined } from '@typebot.io/lib'
+import { timeFilterValues } from '../constants'
+import { TimeFilterDropdown } from './TimeFilterDropdown'
+
+const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+type Props = {
+  timeFilter: (typeof timeFilterValues)[number]
+  onTimeFilterChange: (timeFilter: (typeof timeFilterValues)[number]) => void
+  isExpanded: boolean
+  onToggle: () => void
+}
+
+const formatDuration = (ms: number | null): string => {
+  if (ms === null) return '—'
+  const totalSecs = Math.round(ms / 1000)
+  const mins = Math.floor(totalSecs / 60)
+  const secs = totalSecs % 60
+  if (mins === 0) return `${secs}s`
+  return `${mins}m ${secs}s`
+}
+
+type MetricCardProps = {
+  label: string
+  value: string | number | undefined
+  accent: string
+  accentLight: string
+  IconComponent: (props: IconProps) => JSX.Element
+}
+
+const MetricCard = ({ label, value, accent, accentLight, IconComponent }: MetricCardProps) => {
+  const bg = useColorModeValue('white', 'gray.800')
+  const borderColor = useColorModeValue('gray.100', 'gray.700')
+  const labelColor = useColorModeValue('gray.500', 'gray.400')
+  const valueColor = useColorModeValue('gray.800', 'white')
+
+  return (
+    <Flex
+      bg={bg}
+      border="1px solid"
+      borderColor={borderColor}
+      rounded="xl"
+      p="4"
+      align="center"
+      gap="3"
+      transition="all 0.15s"
+      _hover={{ shadow: 'md', borderColor: accent }}
+    >
+      <Flex
+        w="40px"
+        h="40px"
+        rounded="lg"
+        bg={accentLight}
+        align="center"
+        justify="center"
+        flexShrink={0}
+      >
+        <IconComponent color={accent} boxSize="18px" />
+      </Flex>
+      <Box flex="1" minW="0">
+        <Text fontSize="xs" color={labelColor} fontWeight="medium" noOfLines={1}>
+          {label}
+        </Text>
+        {isDefined(value) ? (
+          <Text fontSize="xl" fontWeight="bold" color={valueColor} lineHeight="1.2">
+            {value}
+          </Text>
+        ) : (
+          <Skeleton w="60%" h="20px" mt="1" rounded="md" />
+        )}
+      </Box>
+    </Flex>
+  )
+}
+
+export const CxMetricsPanel = ({
+  timeFilter,
+  onTimeFilterChange,
+  isExpanded,
+  onToggle,
+}: Props) => {
+  const { typebot } = useTypebot()
+  const panelBg = useColorModeValue('gray.50', 'gray.900')
+  const chartBg = useColorModeValue('white', 'gray.800')
+  const chartBorder = useColorModeValue('gray.100', 'gray.700')
+  const toggleBg = useColorModeValue('white', 'gray.800')
+  const toggleBorder = useColorModeValue('gray.200', 'gray.700')
+  const toggleText = useColorModeValue('gray.600', 'gray.300')
+  const toggleHoverBg = useColorModeValue('gray.50', 'gray.700')
+  const barColor = useColorModeValue('blue.400', 'blue.300')
+
+  const { data } = trpc.analytics.getCxStats.useQuery(
+    {
+      typebotId: typebot?.id as string,
+      timeFilter,
+      timeZone,
+    },
+    { enabled: isDefined(typebot?.id) }
+  )
+
+  const stats = data?.cxStats
+
+  const mainCards: MetricCardProps[] = [
+    { label: 'Volume total', value: stats?.totalSessions, accent: 'blue.500', accentLight: 'blue.50', IconComponent: BarChart2Icon },
+    { label: 'Concluídas', value: stats?.completed, accent: 'green.500', accentLight: 'green.50', IconComponent: CheckIcon },
+    { label: 'Taxa de conclusão', value: stats ? `${stats.completionRate}%` : undefined, accent: 'teal.500', accentLight: 'teal.50', IconComponent: TargetIcon },
+    { label: 'Erros', value: stats?.errors, accent: 'red.500', accentLight: 'red.50', IconComponent: AlertIcon },
+    { label: 'Abandonos', value: stats?.abandoned, accent: 'purple.500', accentLight: 'purple.50', IconComponent: LogOutIcon },
+  ]
+
+  const cxCards: MetricCardProps[] = [
+    { label: 'Forward to Humans N2', value: stats?.forwardToHumansN2, accent: 'orange.500', accentLight: 'orange.50', IconComponent: UserIcon },
+    { label: 'End Flow N1', value: stats?.endFlowN1, accent: 'cyan.600', accentLight: 'cyan.50', IconComponent: FlagIcon },
+    { label: 'Answer Ticket N1', value: stats?.answerTicket, accent: 'blue.500', accentLight: 'blue.50', IconComponent: ChatIcon },
+    { label: 'Close Ticket', value: stats?.closeTicket, accent: 'green.500', accentLight: 'green.50', IconComponent: LockedIcon },
+    { label: 'Tempo médio', value: stats ? formatDuration(stats.avgSessionDurationMs) : undefined, accent: 'gray.500', accentLight: 'gray.100', IconComponent: ClockIcon },
+  ]
+
+  const volumeByDay = stats?.volumeByDay ?? []
+  const maxVolume = Math.max(...volumeByDay.map((d) => d.count), 1)
+
+  const ChevronIcon = isExpanded ? ChevronUpIcon : ChevronDownIcon
+
+  return (
+    <Box w="full" flexShrink={0}>
+      <Collapse in={isExpanded} animateOpacity>
+        <Box px="5" pb="4" pt="4" bg={panelBg} overflowY="auto" maxH="480px">
+          <Text fontSize="xs" fontWeight="bold" textTransform="uppercase" letterSpacing="wider" color="gray.400" mb="3">
+            Visão geral
+          </Text>
+          <SimpleGrid columns={{ base: 2, md: 5 }} spacing="3" mb="5">
+            {mainCards.map((card) => (
+              <MetricCard key={card.label} {...card} />
+            ))}
+          </SimpleGrid>
+
+          <Text fontSize="xs" fontWeight="bold" textTransform="uppercase" letterSpacing="wider" color="gray.400" mb="3">
+            Ações da Claudia
+          </Text>
+          <SimpleGrid columns={{ base: 2, md: 5 }} spacing="3" mb="5">
+            {cxCards.map((card) => (
+              <MetricCard key={card.label} {...card} />
+            ))}
+          </SimpleGrid>
+
+          {volumeByDay.length > 0 && (
+            <Box
+              bg={chartBg}
+              border="1px solid"
+              borderColor={chartBorder}
+              p="5"
+              rounded="xl"
+            >
+              <HStack justify="space-between" mb="4">
+                <Text fontWeight="semibold" fontSize="sm" color="gray.600">
+                  Volume por dia
+                </Text>
+                <Text fontSize="xs" color="gray.400">
+                  {volumeByDay.length} dias
+                </Text>
+              </HStack>
+              <Flex align="flex-end" gap="1.5" h="160px" pb="6">
+                {volumeByDay.map((day) => {
+                  const heightPct = (day.count / maxVolume) * 100
+                  return (
+                    <Tooltip
+                      key={day.date}
+                      label={`${day.date}: ${day.count} sessões`}
+                      placement="top"
+                      hasArrow
+                      bg="gray.700"
+                      color="white"
+                      rounded="md"
+                      px="3"
+                      py="1.5"
+                      fontSize="xs"
+                    >
+                      <Flex
+                        direction="column"
+                        align="center"
+                        minW="24px"
+                        flex="1"
+                        h="full"
+                        justify="flex-end"
+                      >
+                        <Text
+                          fontSize="2xs"
+                          fontWeight="bold"
+                          color={barColor}
+                          mb="1"
+                        >
+                          {day.count > 0 ? day.count : ''}
+                        </Text>
+                        <Box
+                          w="18px"
+                          bgGradient="linear(to-t, blue.500, blue.300)"
+                          rounded="md"
+                          h={`${Math.max(heightPct, 4)}%`}
+                          transition="all 0.2s"
+                          _hover={{
+                            bgGradient: 'linear(to-t, blue.600, blue.400)',
+                            transform: 'scaleX(1.15)',
+                          }}
+                        />
+                        <Text
+                          fontSize="2xs"
+                          color="gray.400"
+                          mt="1.5"
+                          whiteSpace="nowrap"
+                        >
+                          {day.date.slice(5)}
+                        </Text>
+                      </Flex>
+                    </Tooltip>
+                  )
+                })}
+              </Flex>
+            </Box>
+          )}
+        </Box>
+      </Collapse>
+
+      <Flex
+        w="full"
+        align="center"
+        py="2"
+        px="5"
+        bg={toggleBg}
+        borderTopWidth="1px"
+        borderBottomWidth="1px"
+        borderColor={toggleBorder}
+      >
+        <TimeFilterDropdown
+          timeFilter={timeFilter}
+          onTimeFilterChange={onTimeFilterChange}
+          size="xs"
+        />
+        <Flex
+          as="button"
+          onClick={onToggle}
+          flex="1"
+          justify="center"
+          align="center"
+          gap="2"
+          cursor="pointer"
+          rounded="md"
+          py="1"
+          _hover={{ bg: toggleHoverBg }}
+          transition="all 0.15s"
+        >
+          <ChevronIcon boxSize="4" color={toggleText} />
+          <Text fontSize="xs" fontWeight="semibold" color={toggleText}>
+            {isExpanded ? 'Recolher métricas do fluxo' : 'Métricas do fluxo'}
+          </Text>
+          <ChevronIcon boxSize="4" color={toggleText} />
+        </Flex>
+      </Flex>
+    </Box>
+  )
+}

--- a/apps/builder/src/features/graph/components/AnalyticsBadges.tsx
+++ b/apps/builder/src/features/graph/components/AnalyticsBadges.tsx
@@ -1,0 +1,148 @@
+import { Box, Flex, Tag, Tooltip, useColorModeValue } from '@chakra-ui/react'
+import React from 'react'
+import type {
+  GroupAnalytics,
+  BlockIssue,
+} from '@/features/analytics/components/AnalyticsGraphContainer'
+import { useGroupsStore } from '../hooks/useGroupsStore'
+import { useShallow } from 'zustand/react/shallow'
+import { useEndpoints } from '../providers/EndpointsProvider'
+import { groupWidth } from '../constants'
+
+type GroupAnalyticsBadgeProps = {
+  groupId: string
+  analytics?: GroupAnalytics
+}
+
+export const GroupAnalyticsBadge = ({
+  groupId,
+  analytics,
+}: GroupAnalyticsBadgeProps) => {
+  const groupCoordinates = useGroupsStore(
+    useShallow((state) =>
+      state.groupsCoordinates ? state.groupsCoordinates[groupId] : undefined
+    )
+  )
+
+  const visitBg = useColorModeValue('blue.500', 'blue.400')
+  const arrowColor = useColorModeValue('blue.500', 'blue.400')
+
+  if (!groupCoordinates || !analytics) return null
+  if (analytics.visits === 0) return null
+
+  return (
+    <Flex
+      pos="absolute"
+      style={{
+        transform: `translate(${groupCoordinates.x}px, ${groupCoordinates.y - 76}px)`,
+      }}
+      w={`${groupWidth}px`}
+      direction="column"
+      align="center"
+      pointerEvents="all"
+    >
+      <Tooltip
+        label={`${analytics.visits} sessões passaram por este grupo (${analytics.visitPercentage}% do total)`}
+        placement="top"
+        hasArrow
+      >
+        <Tag
+          bgColor={visitBg}
+          color="white"
+          fontWeight="extrabold"
+          fontSize="2xl"
+          borderRadius="xl"
+          px="7"
+          py="3.5"
+          cursor="default"
+          minH="58px"
+          boxShadow="xl"
+          letterSpacing="wide"
+        >
+          {analytics.visitPercentage}% passaram
+        </Tag>
+      </Tooltip>
+
+      <Box
+        w="0"
+        h="0"
+        borderLeft="12px solid transparent"
+        borderRight="12px solid transparent"
+        borderTop="14px solid"
+        borderTopColor={arrowColor}
+        mt="1px"
+      />
+    </Flex>
+  )
+}
+
+type BlockIssueBadgeProps = {
+  issue: BlockIssue
+}
+
+export const BlockIssueBadge = ({ issue }: BlockIssueBadgeProps) => {
+  const groupCoordinates = useGroupsStore(
+    useShallow((state) =>
+      state.groupsCoordinates
+        ? state.groupsCoordinates[issue.groupId]
+        : undefined
+    )
+  )
+  const { sourceEndpointYOffsets, targetEndpointYOffsets } = useEndpoints()
+  const blockEndpoint =
+    sourceEndpointYOffsets.get(issue.blockId) ??
+    targetEndpointYOffsets.get(issue.blockId)
+
+  const errorBg = useColorModeValue('red.500', 'red.400')
+  const abandonBg = useColorModeValue('orange.500', 'orange.400')
+  const arrowColor = issue.type === 'error' ? errorBg : abandonBg
+
+  if (!groupCoordinates || !blockEndpoint) return null
+  if (issue.count === 0) return null
+
+  const bg = issue.type === 'error' ? errorBg : abandonBg
+  const icon = issue.type === 'error' ? '⚠' : '↓'
+  const label =
+    issue.type === 'error'
+      ? `${issue.count} sessões com erro neste bloco (${issue.percentage}%)`
+      : `${issue.count} sessões abandonaram neste bloco (${issue.percentage}%)`
+
+  const badgeX = groupCoordinates.x + groupWidth + 16
+  const badgeY = blockEndpoint.y - 32
+
+  return (
+    <Flex
+      pos="absolute"
+      style={{ transform: `translate(${badgeX}px, ${badgeY}px)` }}
+      align="center"
+      pointerEvents="all"
+    >
+      <Flex
+        w="0"
+        h="0"
+        borderTop="12px solid transparent"
+        borderBottom="12px solid transparent"
+        borderRight="14px solid"
+        borderRightColor={arrowColor}
+      />
+      <Tooltip label={label} placement="right" hasArrow>
+        <Tag
+          bgColor={bg}
+          color="white"
+          fontWeight="extrabold"
+          fontSize="2xl"
+          borderRadius="xl"
+          px="7"
+          py="3.5"
+          cursor="default"
+          minH="58px"
+          whiteSpace="nowrap"
+          boxShadow="xl"
+          letterSpacing="wide"
+        >
+          {icon} {issue.percentage}%
+        </Tag>
+      </Tooltip>
+    </Flex>
+  )
+}

--- a/apps/builder/src/features/graph/components/Graph.tsx
+++ b/apps/builder/src/features/graph/components/Graph.tsx
@@ -12,10 +12,7 @@ import { graphPositionDefaultValue } from '../constants'
 import { useBlockDnd } from '../providers/GraphDndProvider'
 import { useGraph } from '../providers/GraphProvider'
 import { Coordinates } from '../types'
-import {
-  TotalAnswers,
-  TotalVisitedEdges,
-} from '@typebot.io/schemas/features/analytics'
+import type { GroupAnalytics, BlockIssue } from '@/features/analytics/components/AnalyticsGraphContainer'
 import { SelectBox } from './SelectBox'
 import { computeSelectBoxDimensions } from '../helpers/computeSelectBoxDimensions'
 import { GroupSelectionMenu } from './GroupSelectionMenu'
@@ -50,15 +47,17 @@ const getZoomStepForScale = (scale: number) => {
 
 export const Graph = ({
   typebot,
-  totalAnswers,
-  totalVisitedEdges,
+  groupAnalyticsMap,
+  blockIssues,
   onUnlockProPlanClick,
+  highlightedEdges,
   ...props
 }: {
   typebot: TypebotV6 | PublicTypebotV6
-  totalVisitedEdges?: TotalVisitedEdges[]
-  totalAnswers?: TotalAnswers[]
+  groupAnalyticsMap?: Map<string, GroupAnalytics>
+  blockIssues?: BlockIssue[]
   onUnlockProPlanClick?: () => void
+  highlightedEdges?: Map<string, string>
 } & FlexProps) => {
   const {
     draggedBlockType,
@@ -403,7 +402,11 @@ export const Graph = ({
         </>
       )}
 
-      <ZoomButtons onZoomInClick={zoomIn} onZoomOutClick={zoomOut} />
+      <ZoomButtons
+        onZoomInClick={zoomIn}
+        onZoomOutClick={zoomOut}
+        isInsideModal={!!highlightedEdges}
+      />
       <Flex
         flex="1"
         w="full"
@@ -423,9 +426,10 @@ export const Graph = ({
           edges={typebot.edges}
           groups={typebot.groups}
           events={typebot.events}
-          totalAnswers={totalAnswers}
-          totalVisitedEdges={totalVisitedEdges}
+          groupAnalyticsMap={groupAnalyticsMap}
+          blockIssues={blockIssues}
           onUnlockProPlanClick={onUnlockProPlanClick}
+          highlightedEdges={highlightedEdges}
         />
       </Flex>
     </Flex>

--- a/apps/builder/src/features/graph/components/GraphElements.tsx
+++ b/apps/builder/src/features/graph/components/GraphElements.tsx
@@ -1,51 +1,56 @@
 import { Edge, GroupV6, TEvent } from '@typebot.io/schemas'
-import {
-  TotalAnswers,
-  TotalVisitedEdges,
-} from '@typebot.io/schemas/features/analytics'
+import type {
+  GroupAnalytics,
+  BlockIssue,
+} from '@/features/analytics/components/AnalyticsGraphContainer'
 import React, { memo } from 'react'
 import { EndpointsProvider } from '../providers/EndpointsProvider'
 import { Edges } from './edges/Edges'
 import { GroupNode } from './nodes/group/GroupNode'
-import { isInputBlock } from '@typebot.io/schemas/helpers'
 import { EventNode } from './nodes/event'
+import { GroupAnalyticsBadge, BlockIssueBadge } from './AnalyticsBadges'
 
 type Props = {
   edges: Edge[]
   groups: GroupV6[]
   events: TEvent[]
-  totalVisitedEdges?: TotalVisitedEdges[]
-  totalAnswers?: TotalAnswers[]
+  groupAnalyticsMap?: Map<string, GroupAnalytics>
+  blockIssues?: BlockIssue[]
   onUnlockProPlanClick?: () => void
+  highlightedEdges?: Map<string, string>
 }
 const GroupNodes = ({
   edges,
   groups,
   events,
-  totalVisitedEdges,
-  totalAnswers,
+  groupAnalyticsMap,
+  blockIssues,
   onUnlockProPlanClick,
+  highlightedEdges,
 }: Props) => {
-  const inputBlockIds = groups
-    .flatMap((g) => g.blocks)
-    .filter(isInputBlock)
-    .map((b) => b.id)
-
   return (
     <EndpointsProvider>
       <Edges
         edges={edges}
         groups={groups}
-        totalAnswers={totalAnswers}
-        totalVisitedEdges={totalVisitedEdges}
-        inputBlockIds={inputBlockIds}
-        onUnlockProPlanClick={onUnlockProPlanClick}
+        highlightedEdges={highlightedEdges}
       />
       {events.map((event, idx) => (
         <EventNode event={event} key={event.id} eventIndex={idx} />
       ))}
       {groups.map((group, idx) => (
-        <GroupNode group={group} groupIndex={idx} key={group.id} />
+        <React.Fragment key={group.id}>
+          <GroupNode group={group} groupIndex={idx} />
+          {groupAnalyticsMap && (
+            <GroupAnalyticsBadge
+              groupId={group.id}
+              analytics={groupAnalyticsMap.get(group.id)}
+            />
+          )}
+        </React.Fragment>
+      ))}
+      {blockIssues?.map((issue) => (
+        <BlockIssueBadge key={`${issue.blockId}-${issue.type}`} issue={issue} />
       ))}
     </EndpointsProvider>
   )

--- a/apps/builder/src/features/graph/components/ZoomButtons.tsx
+++ b/apps/builder/src/features/graph/components/ZoomButtons.tsx
@@ -5,18 +5,20 @@ import { headerHeight } from '@/features/editor/constants'
 type Props = {
   onZoomInClick: () => void
   onZoomOutClick: () => void
+  isInsideModal?: boolean
 }
 export const ZoomButtons = ({
   onZoomInClick: onZoomIn,
   onZoomOutClick: onZoomOut,
+  isInsideModal,
 }: Props) => (
   <Stack
-    pos="fixed"
-    top={`calc(${headerHeight}px + 70px)`}
-    right="40px"
+    pos={isInsideModal ? 'absolute' : 'fixed'}
+    top={isInsideModal ? '16px' : `calc(${headerHeight}px + 70px)`}
+    right={isInsideModal ? '16px' : '40px'}
     bgColor={useColorModeValue('white', 'gray.900')}
     rounded="md"
-    zIndex={1}
+    zIndex={10}
     spacing="0"
     shadow="lg"
   >

--- a/apps/builder/src/features/graph/components/edges/Edge.tsx
+++ b/apps/builder/src/features/graph/components/edges/Edge.tsx
@@ -16,9 +16,10 @@ import { useShallow } from 'zustand/react/shallow'
 type Props = {
   edge: EdgeProps
   fromGroupId: string | undefined
+  highlightColor?: string
 }
 
-export const Edge = ({ edge, fromGroupId }: Props) => {
+export const Edge = ({ edge, fromGroupId, highlightColor }: Props) => {
   const isDark = useColorMode().colorMode === 'dark'
   const { deleteEdge } = useTypebot()
   const { previewingEdge, graphPosition, isReadOnly, setPreviewingEdge } =
@@ -129,16 +130,25 @@ export const Edge = ({ edge, fromGroupId }: Props) => {
       />
       <path
         data-testid="edge"
+        data-edge-id={edge.id}
         d={path}
         stroke={
-          isPreviewing
+          highlightColor
+            ? highlightColor
+            : isPreviewing
             ? colors.blue[400]
             : isDark
             ? colors.gray[700]
             : colors.gray[400]
         }
-        strokeWidth="2px"
-        markerEnd={isPreviewing ? 'url(#blue-arrow)' : 'url(#arrow)'}
+        strokeWidth={highlightColor ? '3px' : '2px'}
+        markerEnd={
+          highlightColor
+            ? `url(#arrow-${highlightColor})`
+            : isPreviewing
+            ? 'url(#blue-arrow)'
+            : 'url(#arrow)'
+        }
         fill="none"
         pointerEvents="none"
       />

--- a/apps/builder/src/features/graph/components/edges/Edges.tsx
+++ b/apps/builder/src/features/graph/components/edges/Edges.tsx
@@ -3,30 +3,19 @@ import { colors } from '@/lib/theme'
 import { BlockSource, Edge as EdgeProps, GroupV6 } from '@typebot.io/schemas'
 import React from 'react'
 import { DrawingEdge } from './DrawingEdge'
-import { DropOffEdge } from './DropOffEdge'
 import { Edge } from './Edge'
-import {
-  TotalAnswers,
-  TotalVisitedEdges,
-} from '@typebot.io/schemas/features/analytics'
 import { useGraph } from '../../providers/GraphProvider'
 
 type Props = {
   edges: EdgeProps[]
   groups: GroupV6[]
-  inputBlockIds: string[]
-  totalVisitedEdges?: TotalVisitedEdges[]
-  totalAnswers?: TotalAnswers[]
-  onUnlockProPlanClick?: () => void
+  highlightedEdges?: Map<string, string>
 }
 
 export const Edges = ({
   edges,
   groups,
-  inputBlockIds,
-  totalVisitedEdges,
-  totalAnswers,
-  onUnlockProPlanClick,
+  highlightedEdges,
 }: Props) => {
   const { connectingIds } = useGraph()
   const isDark = useColorMode().colorMode === 'dark'
@@ -54,19 +43,9 @@ export const Edges = ({
                 )?.id
               : undefined
           }
+          highlightColor={highlightedEdges?.get(edge.id)}
         />
       ))}
-      {totalVisitedEdges &&
-        totalAnswers &&
-        inputBlockIds.map((blockId) => (
-          <DropOffEdge
-            key={blockId}
-            blockId={blockId}
-            totalVisitedEdges={totalVisitedEdges}
-            totalAnswers={totalAnswers}
-            onUnlockProPlanClick={onUnlockProPlanClick}
-          />
-        ))}
       <marker
         id={'arrow'}
         refX="8"
@@ -97,6 +76,25 @@ export const Edges = ({
           fill={colors.blue[400]}
         />
       </marker>
+      {highlightedEdges &&
+        Array.from(new Set(highlightedEdges.values())).map((color) => (
+          <marker
+            key={`arrow-${color}`}
+            id={`arrow-${color}`}
+            refX="8"
+            refY="4"
+            orient="auto"
+            viewBox="0 0 20 20"
+            markerUnits="userSpaceOnUse"
+            markerWidth="20"
+            markerHeight="20"
+          >
+            <path
+              d="M7.07138888,5.50174526 L2.43017246,7.82235347 C1.60067988,8.23709976 0.592024983,7.90088146 0.177278692,7.07138888 C0.0606951226,6.83822174 0,6.58111307 0,6.32042429 L0,1.67920787 C0,0.751806973 0.751806973,0 1.67920787,0 C1.93989666,0 2.19700532,0.0606951226 2.43017246,0.177278692 L7,3 C7.82949258,3.41474629 8.23709976,3.92128809 7.82235347,4.75078067 C7.6598671,5.07575341 7.39636161,5.33925889 7.07138888,5.50174526 Z"
+              fill={color}
+            />
+          </marker>
+        ))}
     </chakra.svg>
   )
 }

--- a/apps/builder/src/features/results/api/getSessionTypebot.ts
+++ b/apps/builder/src/features/results/api/getSessionTypebot.ts
@@ -1,0 +1,63 @@
+import prisma from '@typebot.io/lib/prisma'
+import { authenticatedProcedure } from '@/helpers/server/trpc'
+import { TRPCError } from '@trpc/server'
+import { z } from 'zod'
+import { isReadTypebotForbidden } from '@/features/typebot/helpers/isReadTypebotForbidden'
+
+export const getSessionTypebot = authenticatedProcedure
+  .input(
+    z.object({
+      typebotId: z.string(),
+      resultId: z.string(),
+    })
+  )
+  .output(
+    z.object({
+      typebot: z.any().nullable(),
+    })
+  )
+  .query(async ({ input, ctx: { user } }) => {
+    const typebot = await prisma.typebot.findUnique({
+      where: { id: input.typebotId },
+      select: {
+        id: true,
+        groups: true,
+        workspace: {
+          select: {
+            id: true,
+            isSuspended: true,
+            isPastDue: true,
+            members: { select: { userId: true } },
+          },
+        },
+        collaborators: { select: { userId: true, type: true } },
+      },
+    })
+    if (!typebot || (await isReadTypebotForbidden(typebot, user)))
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Typebot not found' })
+
+    const result = await prisma.result.findFirst({
+      where: { id: input.resultId, typebotId: input.typebotId },
+      select: { lastChatSessionId: true },
+    })
+    if (!result?.lastChatSessionId) return { typebot: null }
+
+    const session = await prisma.chatSession.findUnique({
+      where: { id: result.lastChatSessionId },
+      select: { state: true },
+    })
+    if (!session?.state) return { typebot: null }
+
+    const state = session.state as any
+
+    // v3 and v2 store the typebot in typebotsQueue[0].typebot
+    if (state.typebotsQueue?.[0]?.typebot) {
+      return { typebot: state.typebotsQueue[0].typebot }
+    }
+    // v1 stores it in state.typebot
+    if (state.typebot) {
+      return { typebot: state.typebot }
+    }
+
+    return { typebot: null }
+  })

--- a/apps/builder/src/features/results/api/router.ts
+++ b/apps/builder/src/features/results/api/router.ts
@@ -3,10 +3,12 @@ import { deleteResults } from './deleteResults'
 import { getResultLogs } from './getResultLogs'
 import { getResults } from './getResults'
 import { getResult } from './getResult'
+import { getSessionTypebot } from './getSessionTypebot'
 
 export const resultsRouter = router({
   getResults,
   getResult,
   deleteResults,
   getResultLogs,
+  getSessionTypebot,
 })

--- a/apps/builder/src/features/results/components/FlowReplayModal.tsx
+++ b/apps/builder/src/features/results/components/FlowReplayModal.tsx
@@ -1,0 +1,317 @@
+import {
+  Badge,
+  Flex,
+  HStack,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Spinner,
+  Text,
+  useColorModeValue,
+} from '@chakra-ui/react'
+import React, { useMemo } from 'react'
+import { isDefined } from '@typebot.io/lib'
+import { useTypebot } from '@/features/editor/providers/TypebotProvider'
+import { useResults } from '../ResultsProvider'
+import { Graph } from '@/features/graph/components/Graph'
+import { GraphProvider } from '@/features/graph/providers/GraphProvider'
+import { EventsCoordinatesProvider } from '@/features/graph/providers/EventsCoordinateProvider'
+import { Edge, VisitedBlockEntry } from '@typebot.io/schemas'
+import { trpc } from '@/lib/trpc'
+
+type Props = {
+  resultId: string | null
+  onClose: () => void
+}
+
+const statusDisplay: Record<
+  string,
+  { label: string; colorScheme: string }
+> = {
+  completed: { label: 'Completed', colorScheme: 'green' },
+  error: { label: 'Error', colorScheme: 'red' },
+  abandoned: { label: 'Abandoned', colorScheme: 'purple' },
+  in_progress: { label: 'In Progress', colorScheme: 'gray' },
+}
+
+const blockStatusColors: Record<string, { border: string; bg: string }> = {
+  ok: { border: '#22c55e', bg: 'rgba(34, 197, 94, 0.15)' },
+  error: { border: '#ef4444', bg: 'rgba(239, 68, 68, 0.15)' },
+  dead_end: { border: '#ef4444', bg: 'rgba(239, 68, 68, 0.15)' },
+  abandoned: { border: '#a855f7', bg: 'rgba(168, 85, 247, 0.15)' },
+}
+
+const edgePathColors: Record<string, string> = Object.fromEntries(
+  Object.entries(blockStatusColors).map(([key, val]) => [key, val.border])
+)
+
+const findEdgeBetweenGroups = (
+  edges: Edge[],
+  fromBlockId: string,
+  fromGroupId: string,
+  toGroupId: string,
+  visitedBlocks: VisitedBlockEntry[]
+): Edge | undefined =>
+  edges.find(
+    (e) =>
+      'blockId' in e.from &&
+      e.from.blockId === fromBlockId &&
+      e.to.groupId === toGroupId
+  ) ??
+  edges.find(
+    (e) =>
+      'blockId' in e.from &&
+      e.to.groupId === toGroupId &&
+      visitedBlocks.some(
+        (vb) => vb.groupId === fromGroupId && vb.blockId === e.from.blockId
+      )
+  )
+
+const computeHighlightedEdges = (
+  visitedBlocks: VisitedBlockEntry[],
+  edges: Edge[]
+): Map<string, string> => {
+  const highlighted = new Map<string, string>()
+  if (visitedBlocks.length === 0) return highlighted
+
+  const resolveColor = (status: string) =>
+    edgePathColors[status] ?? edgePathColors.ok
+
+  const firstBlock = visitedBlocks[0]
+  const startEdge = edges.find(
+    (e) => 'eventId' in e.from && e.to.groupId === firstBlock.groupId
+  )
+  if (startEdge) {
+    highlighted.set(startEdge.id, resolveColor(firstBlock.status))
+  }
+
+  for (let i = 0; i < visitedBlocks.length - 1; i++) {
+    const current = visitedBlocks[i]
+    const next = visitedBlocks[i + 1]
+    if (current.groupId === next.groupId) continue
+
+    const edge = findEdgeBetweenGroups(
+      edges,
+      current.blockId,
+      current.groupId,
+      next.groupId,
+      visitedBlocks
+    )
+    if (edge) {
+      highlighted.set(edge.id, resolveColor(next.status))
+    }
+  }
+  return highlighted
+}
+
+export const FlowReplayModal = ({ resultId, onClose }: Props) => {
+  const { typebot, publishedTypebot } = useTypebot()
+  const { flatResults } = useResults()
+  const bgColor = useColorModeValue('#f4f5f8', 'gray.850')
+  const bgPattern = useColorModeValue(
+    'radial-gradient(#c6d0e1 1px, transparent 0)',
+    'radial-gradient(#2f2f39 1px, transparent 0)'
+  )
+
+  const result = useMemo(
+    () =>
+      isDefined(resultId)
+        ? flatResults.find((r) => r.id === resultId)
+        : undefined,
+    [resultId, flatResults]
+  )
+
+  const { data: sessionData, isLoading: isLoadingSession } =
+    trpc.results.getSessionTypebot.useQuery(
+      {
+        typebotId: typebot?.id as string,
+        resultId: resultId as string,
+      },
+      { enabled: isDefined(resultId) && isDefined(typebot?.id) }
+    )
+
+  const replayTypebot = useMemo(() => {
+    if (sessionData?.typebot) {
+      const snap = sessionData.typebot as any
+      return {
+        ...snap,
+        typebotId: snap.typebotId ?? typebot?.id ?? '',
+        events: snap.events ?? publishedTypebot?.events ?? [],
+        groups: snap.groups ?? [],
+        edges: snap.edges ?? [],
+        variables: snap.variables ?? [],
+      }
+    }
+    return publishedTypebot ?? null
+  }, [sessionData, publishedTypebot, typebot?.id])
+
+  const visitedBlocks: VisitedBlockEntry[] = useMemo(() => {
+    if (!result) return []
+    const blocks = Array.isArray(result.visitedBlocks)
+      ? [...result.visitedBlocks]
+      : []
+    if (
+      blocks.length > 0 &&
+      result.status === 'abandoned' &&
+      blocks[blocks.length - 1].status === 'ok'
+    ) {
+      blocks[blocks.length - 1] = {
+        ...blocks[blocks.length - 1],
+        status: 'abandoned',
+      }
+    }
+    return blocks
+  }, [result])
+
+  const highlightedEdges = useMemo(() => {
+    if (!visitedBlocks.length || !replayTypebot) return new Map()
+    return computeHighlightedEdges(visitedBlocks, replayTypebot.edges)
+  }, [visitedBlocks, replayTypebot])
+
+  const dynamicStyles = useMemo(() => {
+    if (!visitedBlocks.length) return ''
+
+    const visitedGroupIds = new Set(visitedBlocks.map((b) => b.groupId))
+    const visitedGroupSelectors = Array.from(visitedGroupIds)
+      .map((gid) => `[id="group-${gid}"]`)
+      .join(', ')
+    const visitedEdgeSelectors = Array.from(highlightedEdges.keys())
+      .map((eid) => `[data-edge-id="${eid}"]`)
+      .join(', ')
+
+    const dimStyles = [
+      `[data-testid="group"] { opacity: 0.3; transition: opacity 0.2s; }`,
+      `[data-testid="edge"], [data-testid="clickable-edge"] { opacity: 0.3; transition: opacity 0.2s; }`,
+      visitedGroupSelectors
+        ? `${visitedGroupSelectors} { opacity: 1 !important; }`
+        : '',
+      visitedEdgeSelectors
+        ? `${visitedEdgeSelectors} { opacity: 1 !important; }`
+        : '',
+    ]
+      .filter(Boolean)
+      .join('\n')
+
+    const blockStyles = visitedBlocks
+      .map((block) => {
+        const colors = blockStatusColors[block.status] ?? blockStatusColors.ok
+        return `[data-testid="block ${block.blockId}"] { border: 2px solid ${colors.border} !important; background-color: ${colors.bg} !important; border-radius: 6px; }`
+      })
+      .join('\n')
+
+    const edgeStyles = Array.from(highlightedEdges.entries())
+      .map(
+        ([edgeId, color]) =>
+          `[data-edge-id="${edgeId}"] { stroke: ${color} !important; stroke-width: 3px !important; }`
+      )
+      .join('\n')
+
+    return `${dimStyles}\n${blockStyles}\n${edgeStyles}`
+  }, [visitedBlocks, highlightedEdges])
+
+  const status = result?.status ?? 'in_progress'
+  const helpdeskId = result?.helpdeskId
+  const statusCfg = statusDisplay[status] ?? statusDisplay.in_progress
+
+  const duration = useMemo(() => {
+    if (!result?.createdAt || !visitedBlocks.length) return null
+    const start = new Date(result.createdAt).getTime()
+    const lastTimestamp = visitedBlocks[visitedBlocks.length - 1]?.timestamp
+    if (!lastTimestamp) return null
+    const end = new Date(lastTimestamp).getTime()
+    const diffMs = end - start
+    if (diffMs < 0) return null
+    const mins = Math.floor(diffMs / 60000)
+    const secs = Math.floor((diffMs % 60000) / 1000)
+    return `${mins}m ${secs}s`
+  }, [result, visitedBlocks])
+
+  const isLoading = isLoadingSession || !replayTypebot
+
+  if (!publishedTypebot) return null
+
+  return (
+    <Modal
+      isOpen={isDefined(result)}
+      onClose={onClose}
+      size="full"
+      scrollBehavior="inside"
+    >
+      <ModalOverlay />
+      <ModalContent m="4" maxH="calc(100vh - 32px)" borderRadius="xl">
+        <ModalCloseButton zIndex={10} />
+        <ModalHeader pb="2">
+          <HStack spacing="4" flexWrap="wrap">
+            {helpdeskId && (
+              <Text fontSize="sm" color="gray.500">
+                Helpdesk: <strong>{helpdeskId}</strong>
+              </Text>
+            )}
+            {result?.createdAt && (
+              <Text fontSize="sm" color="gray.500">
+                {new Date(result.createdAt).toLocaleString()}
+              </Text>
+            )}
+            <Badge colorScheme={statusCfg.colorScheme}>
+              {statusCfg.label}
+            </Badge>
+            {duration && (
+              <Text fontSize="sm" color="gray.500">
+                Duração: {duration}
+              </Text>
+            )}
+            <Text fontSize="sm" color="gray.500">
+              {visitedBlocks.length} bloco
+              {visitedBlocks.length !== 1 ? 's' : ''} visitados
+            </Text>
+            {sessionData?.typebot && (
+              <Badge colorScheme="blue" variant="subtle" fontSize="2xs">
+                Snapshot da sessão
+              </Badge>
+            )}
+          </HStack>
+        </ModalHeader>
+        <ModalBody p="0" overflow="hidden" flex="1">
+          <style>{dynamicStyles}</style>
+          <Flex
+            w="full"
+            h="full"
+            minH="calc(100vh - 140px)"
+            pos="relative"
+            bgColor={bgColor}
+            backgroundImage={bgPattern}
+            backgroundSize="40px 40px"
+            backgroundPosition="-19px -19px"
+            justifyContent="center"
+          >
+            {isLoading ? (
+              <Flex
+                justify="center"
+                align="center"
+                boxSize="full"
+                bgColor="rgba(255, 255, 255, 0.5)"
+              >
+                <Spinner color="gray" />
+              </Flex>
+            ) : (
+              <GraphProvider isReadOnly isAnalytics={false}>
+                <EventsCoordinatesProvider
+                  events={replayTypebot.events}
+                >
+                  <Graph
+                    flex="1"
+                    typebot={replayTypebot}
+                    highlightedEdges={highlightedEdges}
+                  />
+                </EventsCoordinatesProvider>
+              </GraphProvider>
+            )}
+          </Flex>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/apps/builder/src/features/results/components/ResultsPage.tsx
+++ b/apps/builder/src/features/results/components/ResultsPage.tsx
@@ -35,11 +35,15 @@ export const ResultsPage = () => {
     [router.pathname]
   )
   const bgColor = useColorModeValue(
-    router.pathname.endsWith('analytics') ? '#f4f5f8' : 'white',
-    router.pathname.endsWith('analytics') ? 'gray.850' : 'gray.900'
+    isAnalytics ? '#f4f5f8' : 'white',
+    isAnalytics ? 'gray.850' : 'gray.900'
   )
+  const navBorderColor = useColorModeValue('gray.200', 'gray.700')
+  const navBg = useColorModeValue('white', 'gray.900')
+
   const [timeFilter, setTimeFilter] =
     useState<(typeof timeFilterValues)[number]>(defaultTimeFilter)
+  const [helpdeskIdFilter, setHelpdeskIdFilter] = useState('')
 
   const { showToast } = useToast()
 
@@ -60,12 +64,17 @@ export const ResultsPage = () => {
     refetch()
   }
 
+  const activeColor = 'blue.600'
+  const activeBg = 'blue.50'
+  const inactiveColor = 'gray.500'
+  const inactiveHoverBg = 'gray.100'
+
   if (is404) return <TypebotNotFoundPage />
   return (
     <Flex overflow="hidden" h="100vh" flexDir="column">
       <Seo
         title={
-          router.pathname.endsWith('analytics')
+          isAnalytics
             ? typebot?.name
               ? `${typebot.name} | Analytics`
               : 'Analytics'
@@ -75,42 +84,74 @@ export const ResultsPage = () => {
         }
       />
       <TypebotHeader />
-      <Flex h="full" w="full" bgColor={bgColor}>
+      <Flex
+        h="full"
+        w="full"
+        bgColor={bgColor}
+        direction="column"
+        overflow="hidden"
+      >
         <Flex
           pos="absolute"
           zIndex={2}
           w="full"
           justifyContent="center"
-          h="60px"
+          h="52px"
           display={['none', 'flex']}
+          borderBottomWidth="1px"
+          borderColor={navBorderColor}
+          bg={navBg}
         >
-          <HStack maxW="1600px" w="full" px="4">
+          <HStack maxW="1600px" w="full" px="4" spacing="1">
             <Button
               as={Link}
-              colorScheme={!isAnalytics ? 'blue' : 'gray'}
-              variant={!isAnalytics ? 'outline' : 'ghost'}
+              variant="ghost"
               size="sm"
               href={`/typebots/${typebot?.id}/results`}
+              rounded="lg"
+              fontWeight={!isAnalytics ? 'semibold' : 'normal'}
+              color={!isAnalytics ? activeColor : inactiveColor}
+              bg={!isAnalytics ? activeBg : 'transparent'}
+              _hover={{ bg: !isAnalytics ? activeBg : inactiveHoverBg }}
             >
               <Text>Submissions</Text>
               {(stats?.totalStarts ?? 0) > 0 && (
-                <Tag size="sm" colorScheme="blue" ml="1">
+                <Tag
+                  size="sm"
+                  bg={!isAnalytics ? 'blue.100' : 'gray.100'}
+                  color={!isAnalytics ? 'blue.700' : 'gray.600'}
+                  ml="1.5"
+                  rounded="full"
+                  fontWeight="bold"
+                  fontSize="2xs"
+                >
                   {stats?.totalStarts}
                 </Tag>
               )}
             </Button>
             <Button
               as={Link}
-              colorScheme={isAnalytics ? 'blue' : 'gray'}
-              variant={isAnalytics ? 'outline' : 'ghost'}
-              href={`/typebots/${typebot?.id}/results/analytics`}
+              variant="ghost"
               size="sm"
+              href={`/typebots/${typebot?.id}/results/analytics`}
+              rounded="lg"
+              fontWeight={isAnalytics ? 'semibold' : 'normal'}
+              color={isAnalytics ? activeColor : inactiveColor}
+              bg={isAnalytics ? activeBg : 'transparent'}
+              _hover={{ bg: isAnalytics ? activeBg : inactiveHoverBg }}
             >
               Analytics
             </Button>
           </HStack>
         </Flex>
-        <Flex pt={['10px', '60px']} w="full" justify="center">
+        <Flex
+          pt={['10px', '52px']}
+          w="full"
+          justify="center"
+          overflow="hidden"
+          flex="1"
+          minH="0"
+        >
           {workspace &&
             publishedTypebot &&
             (isAnalytics ? (
@@ -125,10 +166,13 @@ export const ResultsPage = () => {
                 typebotId={publishedTypebot.typebotId}
                 totalResults={stats?.totalStarts ?? 0}
                 onDeleteResults={handleDeletedResults}
+                helpdeskId={helpdeskIdFilter || undefined}
               >
                 <ResultsTableContainer
                   timeFilter={timeFilter}
                   onTimeFilterChange={setTimeFilter}
+                  helpdeskIdFilter={helpdeskIdFilter}
+                  onHelpdeskIdFilterChange={setHelpdeskIdFilter}
                 />
               </ResultsProvider>
             ))}

--- a/apps/builder/src/features/results/components/ResultsTableContainer.tsx
+++ b/apps/builder/src/features/results/components/ResultsTableContainer.tsx
@@ -4,6 +4,7 @@ import { LogsModal } from './LogsModal'
 import { useTypebot } from '@/features/editor/providers/TypebotProvider'
 import { useResults } from '../ResultsProvider'
 import { ResultModal } from './ResultModal'
+import { FlowReplayModal } from './FlowReplayModal'
 import { ResultsTable } from './table/ResultsTable'
 import { useRouter } from 'next/router'
 import { timeFilterValues } from '@/features/analytics/constants'
@@ -11,10 +12,14 @@ import { timeFilterValues } from '@/features/analytics/constants'
 type Props = {
   timeFilter: (typeof timeFilterValues)[number]
   onTimeFilterChange: (timeFilter: (typeof timeFilterValues)[number]) => void
+  helpdeskIdFilter: string
+  onHelpdeskIdFilterChange: (value: string) => void
 }
 export const ResultsTableContainer = ({
   timeFilter,
   onTimeFilterChange,
+  helpdeskIdFilter,
+  onHelpdeskIdFilterChange,
 }: Props) => {
   const { query } = useRouter()
   const {
@@ -29,10 +34,15 @@ export const ResultsTableContainer = ({
     string | null
   >(null)
   const [expandedResultId, setExpandedResultId] = useState<string | null>(null)
+  const [flowReplayResultId, setFlowReplayResultId] = useState<string | null>(
+    null
+  )
 
   const handleLogsModalClose = () => setInspectingLogsResultId(null)
 
   const handleResultModalClose = () => setExpandedResultId(null)
+
+  const handleFlowReplayClose = () => setFlowReplayResultId(null)
 
   const handleLogOpenIndex = (index: number) => () => {
     if (!results[index]) return
@@ -42,6 +52,11 @@ export const ResultsTableContainer = ({
   const handleResultExpandIndex = (index: number) => () => {
     if (!results[index]) return
     setExpandedResultId(results[index].id)
+  }
+
+  const handleFlowReplayIndex = (index: number) => () => {
+    if (!results[index]) return
+    setFlowReplayResultId(results[index].id)
   }
 
   useEffect(() => {
@@ -61,18 +76,26 @@ export const ResultsTableContainer = ({
         resultId={expandedResultId}
         onClose={handleResultModalClose}
       />
+      <FlowReplayModal
+        resultId={flowReplayResultId}
+        onClose={handleFlowReplayClose}
+      />
 
       {typebot && (
         <ResultsTable
           preferences={typebot.resultsTablePreferences ?? undefined}
           resultHeader={resultHeader}
           data={tableData}
+          results={results}
           onScrollToBottom={fetchNextPage}
           hasMore={hasNextPage}
           timeFilter={timeFilter}
           onLogOpenIndex={handleLogOpenIndex}
           onResultExpandIndex={handleResultExpandIndex}
+          onFlowReplayIndex={handleFlowReplayIndex}
           onTimeFilterChange={onTimeFilterChange}
+          helpdeskIdFilter={helpdeskIdFilter}
+          onHelpdeskIdFilterChange={onHelpdeskIdFilterChange}
         />
       )}
     </Stack>

--- a/apps/builder/src/features/results/components/table/Cell.tsx
+++ b/apps/builder/src/features/results/components/table/Cell.tsx
@@ -22,15 +22,20 @@ const Cell = ({
   cellIndex,
   onExpandButtonClick,
 }: Props) => {
+  const borderColor = useColorModeValue('gray.100', 'gray.700')
+  const textColor = useColorModeValue('gray.700', 'gray.200')
+
   return (
     <chakra.td
       key={cell.id}
       px="4"
-      py="2"
-      borderWidth={rowIndex === 0 ? '0 1px 1px 1px' : '1px'}
-      borderColor={useColorModeValue('gray.200', 'gray.700')}
+      py="2.5"
+      borderBottom="1px solid"
+      borderColor={borderColor}
       whiteSpace="pre-wrap"
       pos="relative"
+      fontSize="sm"
+      color={textColor}
       style={{
         minWidth: size,
         maxWidth: size,
@@ -48,11 +53,14 @@ const Cell = ({
         <Fade unmountOnExit in={isExpandButtonVisible && cellIndex === 1}>
           <Button
             leftIcon={<ExpandIcon />}
-            shadow="lg"
+            shadow="md"
             size="xs"
+            rounded="full"
+            colorScheme="blue"
+            variant="solid"
             onClick={onExpandButtonClick}
           >
-            Open
+            Abrir
           </Button>
         </Fade>
       </chakra.span>

--- a/apps/builder/src/features/results/components/table/HeaderRow.tsx
+++ b/apps/builder/src/features/results/components/table/HeaderRow.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 export const HeaderRow = ({ headerGroup, isTableScrolled }: Props) => {
   const borderColor = useColorModeValue(colors.gray[200], colors.gray[700])
-  const backgroundColor = useColorModeValue('white', colors.gray[900])
+  const backgroundColor = useColorModeValue(colors.gray[50], colors.gray[800])
 
   return (
     <tr key={headerGroup.id}>
@@ -21,17 +21,17 @@ export const HeaderRow = ({ headerGroup, isTableScrolled }: Props) => {
             key={header.id}
             px="4"
             py="3"
-            borderX="1px"
+            borderBottom="1px solid"
             borderColor={borderColor}
-            backgroundColor={isTableScrolled ? backgroundColor : undefined}
+            backgroundColor={backgroundColor}
             zIndex={10}
             pos="sticky"
             top="0"
             fontWeight="normal"
             whiteSpace="nowrap"
             wordBreak="normal"
+            textAlign="left"
             colSpan={header.colSpan}
-            shadow={`inset 0 1px 0 ${borderColor}, inset 0 -1px 0 ${borderColor}; `}
             style={{
               minWidth: header.getSize(),
               maxWidth: header.getSize(),

--- a/apps/builder/src/features/results/components/table/ResultsTable.tsx
+++ b/apps/builder/src/features/results/components/table/ResultsTable.tsx
@@ -1,17 +1,26 @@
 import {
+  Badge,
   Box,
   Button,
   chakra,
+  Flex,
   HStack,
+  IconButton,
+  Input,
+  InputGroup,
+  InputLeftElement,
   Stack,
   Text,
+  TextProps,
+  Tooltip,
   useColorModeValue,
 } from '@chakra-ui/react'
-import { AlignLeftTextIcon } from '@/components/icons'
+import { AlignLeftTextIcon, SearchIcon, CopyIcon, EyeIcon } from '@/components/icons'
 import {
   CellValueType,
   ResultHeaderCell,
   ResultsTablePreferences,
+  ResultWithAnswers,
   TableData,
 } from '@typebot.io/schemas'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
@@ -34,9 +43,47 @@ import { parseColumnsOrder } from '@typebot.io/results/parseColumnsOrder'
 import { TimeFilterDropdown } from '@/features/analytics/components/TimeFilterDropdown'
 import { timeFilterValues } from '@/features/analytics/constants'
 
+const columnHeaderProps: TextProps = {
+  fontWeight: 'semibold',
+  fontSize: 'xs',
+  textTransform: 'uppercase',
+  letterSpacing: 'wider',
+  color: 'gray.500',
+}
+
+const statusConfig: Record<
+  string,
+  { label: string; bg: string; color: string; dot: string }
+> = {
+  completed: {
+    label: 'Completo',
+    bg: 'green.50',
+    color: 'green.700',
+    dot: 'green.400',
+  },
+  error: {
+    label: 'Erro',
+    bg: 'red.50',
+    color: 'red.700',
+    dot: 'red.400',
+  },
+  abandoned: {
+    label: 'Abandonado',
+    bg: 'purple.50',
+    color: 'purple.700',
+    dot: 'purple.400',
+  },
+}
+
+const resolveDisplayStatus = (status: string): string => {
+  if (status === 'completed' || status === 'error') return status
+  return 'abandoned'
+}
+
 type ResultsTableProps = {
   resultHeader: ResultHeaderCell[]
   data: TableData[]
+  results: ResultWithAnswers[]
   hasMore?: boolean
   preferences?: ResultsTablePreferences
   timeFilter: (typeof timeFilterValues)[number]
@@ -44,11 +91,15 @@ type ResultsTableProps = {
   onScrollToBottom: () => void
   onLogOpenIndex: (index: number) => () => void
   onResultExpandIndex: (index: number) => () => void
+  onFlowReplayIndex: (index: number) => () => void
+  helpdeskIdFilter: string
+  onHelpdeskIdFilterChange: (value: string) => void
 }
 
 export const ResultsTable = ({
   resultHeader,
   data,
+  results,
   hasMore,
   preferences,
   timeFilter,
@@ -56,8 +107,14 @@ export const ResultsTable = ({
   onScrollToBottom,
   onLogOpenIndex,
   onResultExpandIndex,
+  onFlowReplayIndex,
+  helpdeskIdFilter,
+  onHelpdeskIdFilterChange,
 }: ResultsTableProps) => {
   const background = useColorModeValue('white', colors.gray[900])
+  const inputBg = useColorModeValue('white', 'gray.800')
+  const inputBorder = useColorModeValue('gray.200', 'gray.600')
+  const tableBorder = useColorModeValue('gray.200', 'gray.700')
   const { updateTypebot, currentUserMode } = useTypebot()
   const [rowSelection, setRowSelection] = useState<Record<string, boolean>>({})
   const [isTableScrolled, setIsTableScrolled] = useState(false)
@@ -143,6 +200,35 @@ export const ResultsTable = ({
           </div>
         ),
       },
+      {
+        id: '__helpdeskId',
+        enableResizing: false,
+        maxSize: 220,
+        header: () => <Text {...columnHeaderProps}>Helpdesk ID</Text>,
+        cell: ({ row }) => {
+          const result = results[row.index]
+          const helpdeskId = result?.helpdeskId
+          if (!helpdeskId) return <Text color="gray.300">—</Text>
+          return (
+            <HStack spacing="1">
+              <Text fontSize="sm" fontWeight="medium" fontFamily="mono" color="gray.700" isTruncated maxW="160px">
+                {helpdeskId}
+              </Text>
+              <Tooltip label="Copiar" hasArrow placement="top">
+                <IconButton
+                  aria-label="Copiar helpdesk ID"
+                  icon={<CopyIcon />}
+                  size="xs"
+                  variant="ghost"
+                  color="gray.400"
+                  _hover={{ color: 'blue.500' }}
+                  onClick={() => navigator.clipboard.writeText(helpdeskId)}
+                />
+              </Tooltip>
+            </HStack>
+          )
+        },
+      },
       ...resultHeader.map<ColumnDef<TableData>>((header) => ({
         id: header.id,
         accessorKey: header.id,
@@ -150,7 +236,7 @@ export const ResultsTable = ({
         header: () => (
           <HStack overflow="hidden" data-testid={`${header.label} header`}>
             <HeaderIcon header={header} />
-            <Text>{header.label}</Text>
+            <Text {...columnHeaderProps}>{header.label}</Text>
           </HStack>
         ),
         cell: (info) => {
@@ -160,23 +246,95 @@ export const ResultsTable = ({
         },
       })),
       {
+        id: '__visitedBlocksCount',
+        enableResizing: false,
+        maxSize: 120,
+        header: () => <Text {...columnHeaderProps}>Caminho</Text>,
+        cell: ({ row }) => {
+          const result = results[row.index]
+          const blocks = Array.isArray(result?.visitedBlocks)
+            ? result.visitedBlocks
+            : []
+          return (
+            <HStack spacing="1">
+              <Box w="6px" h="6px" rounded="full" bg="blue.300" />
+              <Text fontSize="sm" color="gray.600">
+                {blocks.length} bloco{blocks.length !== 1 ? 's' : ''}
+              </Text>
+            </HStack>
+          )
+        },
+      },
+      {
+        id: '__status',
+        enableResizing: false,
+        maxSize: 140,
+        header: () => <Text {...columnHeaderProps}>Status</Text>,
+        cell: ({ row }) => {
+          const result = results[row.index]
+          const rawStatus = result?.status ?? 'abandoned'
+          const displayStatus = resolveDisplayStatus(rawStatus)
+          const cfg = statusConfig[displayStatus] ?? statusConfig.abandoned
+          return (
+            <Badge
+              bg={cfg.bg}
+              color={cfg.color}
+              px="2.5"
+              py="1"
+              rounded="full"
+              fontSize="xs"
+              fontWeight="semibold"
+              display="flex"
+              alignItems="center"
+              gap="1.5"
+              w="fit-content"
+            >
+              <Box w="6px" h="6px" rounded="full" bg={cfg.dot} />
+              {cfg.label}
+            </Badge>
+          )
+        },
+      },
+      {
         id: 'logs',
         enableResizing: false,
         maxSize: 110,
-        header: () => (
-          <HStack>
-            <AlignLeftTextIcon />
-            <Text>Logs</Text>
-          </HStack>
-        ),
+        header: () => <Text {...columnHeaderProps}>Logs</Text>,
         cell: ({ row }) => (
-          <Button size="sm" onClick={onLogOpenIndex(row.index)}>
-            See logs
+          <Button
+            size="xs"
+            variant="ghost"
+            color="gray.500"
+            fontWeight="medium"
+            leftIcon={<AlignLeftTextIcon />}
+            _hover={{ bg: 'gray.100', color: 'gray.700' }}
+            onClick={onLogOpenIndex(row.index)}
+          >
+            Ver logs
+          </Button>
+        ),
+      },
+      {
+        id: '__flowReplay',
+        enableResizing: false,
+        maxSize: 130,
+        header: () => <Text {...columnHeaderProps}>Fluxo</Text>,
+        cell: ({ row }) => (
+          <Button
+            size="xs"
+            variant="outline"
+            colorScheme="blue"
+            fontWeight="medium"
+            leftIcon={<EyeIcon />}
+            rounded="full"
+            onClick={onFlowReplayIndex(row.index)}
+          >
+            Ver fluxo
           </Button>
         ),
       },
     ],
-    [onLogOpenIndex, resultHeader]
+    [onLogOpenIndex, onFlowReplayIndex, resultHeader, results]
   )
 
   const instance = useReactTable({
@@ -215,47 +373,72 @@ export const ResultsTable = ({
     return () => {
       observer.disconnect()
     }
-    // We need to rerun this effect when the bottomElement changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [handleObserver, bottomElement.current])
 
   return (
-    <Stack maxW="1600px" px="4" overflowY="hidden" spacing={6}>
-      <HStack w="full" justifyContent="flex-end">
-        {currentUserMode === 'write' && (
-          <SelectionToolbar
-            selectedResultsId={Object.keys(rowSelection)}
-            onClearSelection={() => setRowSelection({})}
+    <Stack maxW="1600px" px="4" overflowY="hidden" spacing={4}>
+      <Flex
+        w="full"
+        justify="space-between"
+        align="center"
+        py="2"
+        gap="3"
+        flexWrap="wrap"
+      >
+        <HStack spacing="3" flex="1" minW="0">
+          <InputGroup size="sm" maxW="280px">
+            <InputLeftElement pointerEvents="none">
+              <SearchIcon color="gray.400" boxSize="3.5" />
+            </InputLeftElement>
+            <Input
+              placeholder="Buscar por helpdeskId..."
+              value={helpdeskIdFilter}
+              onChange={(e) => onHelpdeskIdFilterChange(e.target.value)}
+              rounded="lg"
+              bg={inputBg}
+              borderColor={inputBorder}
+              fontSize="sm"
+              _placeholder={{ color: 'gray.400' }}
+              _focus={{ borderColor: 'blue.400', boxShadow: '0 0 0 1px var(--chakra-colors-blue-400)' }}
+            />
+          </InputGroup>
+          {currentUserMode === 'write' && (
+            <SelectionToolbar
+              selectedResultsId={Object.keys(rowSelection)}
+              onClearSelection={() => setRowSelection({})}
+            />
+          )}
+        </HStack>
+        <HStack spacing="2">
+          <TimeFilterDropdown
+            timeFilter={timeFilter}
+            onTimeFilterChange={onTimeFilterChange}
+            size="sm"
           />
-        )}
-        <TimeFilterDropdown
-          timeFilter={timeFilter}
-          onTimeFilterChange={onTimeFilterChange}
-          size="sm"
-        />
-        <TableSettingsButton
-          resultHeader={resultHeader}
-          columnVisibility={columnsVisibility}
-          setColumnVisibility={changeColumnVisibility}
-          columnOrder={columnsOrder}
-          onColumnOrderChange={changeColumnOrder}
-        />
-      </HStack>
+          <TableSettingsButton
+            resultHeader={resultHeader}
+            columnVisibility={columnsVisibility}
+            setColumnVisibility={changeColumnVisibility}
+            columnOrder={columnsOrder}
+            onColumnOrderChange={changeColumnOrder}
+          />
+        </HStack>
+      </Flex>
+
       <Box
         ref={tableWrapper}
         overflow="auto"
-        rounded="md"
+        rounded="xl"
+        border="1px solid"
+        borderColor={tableBorder}
         data-testid="results-table"
-        backgroundImage={`linear-gradient(to right, ${background}, ${background}), linear-gradient(to right, ${background}, ${background}),linear-gradient(to right, rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0)),linear-gradient(to left, rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0));`}
-        backgroundPosition="left center, right center, left center, right center"
-        backgroundRepeat="no-repeat"
-        backgroundSize="30px 100%, 30px 100%, 15px 100%, 15px 100%"
-        backgroundAttachment="local, local, scroll, scroll"
+        bg={background}
         onScroll={(e) =>
           setIsTableScrolled((e.target as HTMLElement).scrollTop > 0)
         }
       >
-        <chakra.table rounded="md">
+        <chakra.table w="full">
           <thead>
             {instance.getHeaderGroups().map((headerGroup) => (
               <HeaderRow

--- a/apps/builder/src/features/results/components/table/Row.tsx
+++ b/apps/builder/src/features/results/components/table/Row.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { Row as RowProps } from '@tanstack/react-table'
 import Cell from './Cell'
 import { TableData } from '@typebot.io/schemas'
+import { chakra, useColorModeValue } from '@chakra-ui/react'
 
 type Props = {
   row: RowProps<TableData>
@@ -17,20 +18,24 @@ export const Row = ({
   isSelected,
 }: Props) => {
   const [isExpandButtonVisible, setIsExpandButtonVisible] = useState(false)
+  const hoverBg = useColorModeValue('gray.50', 'gray.800')
 
   const showExpandButton = () => setIsExpandButtonVisible(true)
   const hideExpandButton = () => setIsExpandButtonVisible(false)
   return (
-    <tr
+    <chakra.tr
       key={row.id}
       data-rowid={row.id}
-      ref={(ref) => {
+      role="group"
+      ref={(ref: HTMLTableRowElement | null) => {
         if (bottomElement && bottomElement.current?.dataset.rowid !== row.id)
           bottomElement.current = ref
       }}
       onMouseEnter={showExpandButton}
       onClick={showExpandButton}
       onMouseLeave={hideExpandButton}
+      transition="background 0.1s"
+      _hover={{ bg: hoverBg }}
     >
       {row.getVisibleCells().map((cell, cellIndex) => (
         <Cell
@@ -44,6 +49,6 @@ export const Row = ({
           isSelected={isSelected}
         />
       ))}
-    </tr>
+    </chakra.tr>
   )
 }

--- a/packages/bot-engine/apiHandlers/startChatPreview.ts
+++ b/packages/bot-engine/apiHandlers/startChatPreview.ts
@@ -38,6 +38,7 @@ export const startChatPreview = async ({
     clientSideActions,
     newSessionState,
     visitedEdges,
+    visitedBlocks,
     setVariableHistory,
   } = await startSession({
     version: 2,
@@ -68,6 +69,7 @@ export const startChatPreview = async ({
         logs,
         clientSideActions,
         visitedEdges,
+        visitedBlocks,
         setVariableHistory,
         hasCustomEmbedBubble: messages.some(
           (message) => message.type === 'custom-embed'

--- a/packages/bot-engine/continueBotFlow.ts
+++ b/packages/bot-engine/continueBotFlow.ts
@@ -6,6 +6,7 @@ import {
   InputBlock,
   SessionState,
   SetVariableHistoryItem,
+  VisitedBlockEntry,
 } from '@typebot.io/schemas'
 import { byId } from '@typebot.io/lib'
 import { isInputBlock } from '@typebot.io/schemas/helpers'
@@ -80,19 +81,19 @@ export const continueBotFlow = async (
   ContinueChatResponse & {
     newSessionState: SessionState
     visitedEdges: VisitedEdge[]
+    visitedBlocks: VisitedBlockEntry[]
     setVariableHistory: SetVariableHistoryItem[]
   }
 > => {
-  logger.info('continueBotFlow executing', {
+  logger.debug('continueBotFlow executing', {
     sessionId,
     currentBlockId: state.currentBlockId,
-    reply: typeof reply === 'string' ? reply.slice(0, 50) : 'object',
-    version,
   })
 
   let firstBubbleWasStreamed = false
   let newSessionState = { ...state }
   const visitedEdges: VisitedEdge[] = []
+  const visitedBlocks: VisitedBlockEntry[] = []
   const setVariableHistory: SetVariableHistoryItem[] = []
 
   if (!newSessionState.currentBlockId)
@@ -231,6 +232,7 @@ export const continueBotFlow = async (
         )),
         newSessionState,
         visitedEdges: [],
+        visitedBlocks: [],
         setVariableHistory: [],
       }
 
@@ -239,6 +241,13 @@ export const continueBotFlow = async (
     newSessionState = await processAndSaveAnswer(state, block)(formattedReply)
   }
 
+  visitedBlocks.push({
+    blockId: block.id,
+    groupId: group.id,
+    timestamp: new Date().toISOString(),
+    status: 'ok',
+  })
+
   const groupHasMoreBlocks = blockIndex < group.blocks.length - 1
 
   // Special handling for Declare Variables block - re-execute it to check for more inputs
@@ -246,12 +255,13 @@ export const continueBotFlow = async (
     const chatReply = await executeGroup(
       {
         ...group,
-        blocks: group.blocks.slice(blockIndex), // Start from current block (re-execute)
+        blocks: group.blocks.slice(blockIndex),
       } as Group,
       {
         version,
         state: newSessionState,
         visitedEdges,
+        visitedBlocks,
         setVariableHistory,
         firstBubbleWasStreamed,
         startTime,
@@ -280,6 +290,7 @@ export const continueBotFlow = async (
         version,
         state: newSessionState,
         visitedEdges,
+        visitedBlocks,
         setVariableHistory,
         firstBubbleWasStreamed,
         startTime,
@@ -294,15 +305,24 @@ export const continueBotFlow = async (
     }
   }
 
-  if (!nextEdgeId && state.typebotsQueue.length === 1)
+  if (!nextEdgeId && state.typebotsQueue.length === 1) {
+    const isClaudiaBlock = block.type === 'claudia'
+    visitedBlocks.push({
+      blockId: block.id,
+      groupId: group.id,
+      timestamp: new Date().toISOString(),
+      status: isClaudiaBlock ? 'ok' : 'dead_end',
+    })
     return {
       messages: [],
       newSessionState,
       lastMessageNewFormat:
         formattedReply !== reply ? formattedReply : undefined,
       visitedEdges,
+      visitedBlocks,
       setVariableHistory,
     }
+  }
 
   const nextGroup = await getNextGroup({
     state: newSessionState,
@@ -314,28 +334,38 @@ export const continueBotFlow = async (
 
   newSessionState = nextGroup.newSessionState
 
-  if (!nextGroup.group)
+  if (!nextGroup.group) {
+    const isClaudiaBlock = block.type === 'claudia'
+    visitedBlocks.push({
+      blockId: block.id,
+      groupId: group.id,
+      timestamp: new Date().toISOString(),
+      status: isClaudiaBlock ? 'ok' : 'dead_end',
+    })
     return {
       messages: [],
       newSessionState,
       lastMessageNewFormat:
         formattedReply !== reply ? formattedReply : undefined,
       visitedEdges,
+      visitedBlocks,
       setVariableHistory,
     }
+  }
 
   const chatReply = await executeGroup(nextGroup.group, {
     version,
     state: newSessionState,
     firstBubbleWasStreamed,
     visitedEdges,
+    visitedBlocks,
     setVariableHistory,
     startTime,
     textBubbleContentFormat,
     sessionId,
   })
 
-  logger.info('continueBotFlow finishing', {
+  logger.debug('continueBotFlow finishing', {
     nextBlockId: newSessionState.currentBlockId,
     messagesCount: chatReply.messages.length,
   })

--- a/packages/bot-engine/executeGroup.ts
+++ b/packages/bot-engine/executeGroup.ts
@@ -6,6 +6,7 @@ import {
   SessionState,
   SetVariableHistoryItem,
   Variable,
+  VisitedBlockEntry,
 } from '@typebot.io/schemas'
 import { isNotEmpty } from '@typebot.io/lib'
 import {
@@ -48,6 +49,7 @@ type ContextProps = {
   currentLastBubbleId?: string
   firstBubbleWasStreamed?: boolean
   visitedEdges: VisitedEdge[]
+  visitedBlocks: VisitedBlockEntry[]
   setVariableHistory: SetVariableHistoryItem[]
   startTime?: number
   textBubbleContentFormat: 'richText' | 'markdown'
@@ -60,6 +62,7 @@ export const executeGroup = async (
     version,
     state,
     visitedEdges,
+    visitedBlocks,
     setVariableHistory,
     currentReply,
     currentLastBubbleId,
@@ -73,6 +76,7 @@ export const executeGroup = async (
     newSessionState: SessionState
     setVariableHistory: SetVariableHistoryItem[]
     visitedEdges: VisitedEdge[]
+    visitedBlocks: VisitedBlockEntry[]
   }
 > => {
   let newStartTime = startTime
@@ -109,6 +113,12 @@ export const executeGroup = async (
 
     if (isBubbleBlock(block)) {
       if (!block.content || (firstBubbleWasStreamed && index === 0)) {
+        visitedBlocks.push({
+          blockId: block.id,
+          groupId: group.id,
+          timestamp: new Date().toISOString(),
+          status: 'ok',
+        })
         continue
       }
       messages.push(
@@ -120,6 +130,13 @@ export const executeGroup = async (
         })
       )
       lastBubbleBlockId = block.id
+
+      visitedBlocks.push({
+        blockId: block.id,
+        groupId: group.id,
+        timestamp: new Date().toISOString(),
+        status: 'ok',
+      })
 
       const bubbleTypebot = newSessionState.typebotsQueue[0].typebot
       const bubbleWorkspaceName = bubbleTypebot.workspaceName ?? 'unknown'
@@ -168,8 +185,21 @@ export const executeGroup = async (
             newSessionState = updatedState
           }
         }
+        visitedBlocks.push({
+          blockId: block.id,
+          groupId: group.id,
+          timestamp: new Date().toISOString(),
+          status: 'ok',
+        })
         continue
       }
+
+      visitedBlocks.push({
+        blockId: block.id,
+        groupId: group.id,
+        timestamp: new Date().toISOString(),
+        status: 'ok',
+      })
 
       const inputResult = {
         messages,
@@ -181,6 +211,7 @@ export const executeGroup = async (
         clientSideActions,
         logs,
         visitedEdges,
+        visitedBlocks,
         setVariableHistory,
       }
       return inputResult
@@ -195,8 +226,23 @@ export const executeGroup = async (
     ) as ExecuteLogicResponse | ExecuteIntegrationResponse | null
 
     if (!executionResponse) {
+      visitedBlocks.push({
+        blockId: block.id,
+        groupId: group.id,
+        timestamp: new Date().toISOString(),
+        status: 'ok',
+      })
       continue
     }
+
+    visitedBlocks.push({
+      blockId: block.id,
+      groupId: group.id,
+      timestamp: new Date().toISOString(),
+      status: executionResponse.logs?.some((l) => l.status === 'error')
+        ? 'error'
+        : 'ok',
+    })
 
     const typebot = newSessionState.typebotsQueue[0].typebot
     const workspaceName = typebot.workspaceName ?? 'unknown'
@@ -267,6 +313,7 @@ export const executeGroup = async (
         clientSideActions,
         logs,
         visitedEdges,
+        visitedBlocks,
         setVariableHistory,
       }
     }
@@ -307,6 +354,7 @@ export const executeGroup = async (
           clientSideActions,
           logs,
           visitedEdges,
+          visitedBlocks,
           setVariableHistory,
         }
       }
@@ -320,15 +368,36 @@ export const executeGroup = async (
     }
   }
 
-  if (!nextEdgeId && newSessionState.typebotsQueue.length === 1)
+  if (!nextEdgeId && newSessionState.typebotsQueue.length === 1) {
+    const lastBlock = group.blocks[group.blocks.length - 1]
+    if (lastBlock) {
+      const isClaudiaBlock = lastBlock.type === 'claudia'
+      visitedBlocks.push({
+        blockId: lastBlock.id,
+        groupId: group.id,
+        timestamp: new Date().toISOString(),
+        status: isClaudiaBlock ? 'ok' : 'dead_end',
+      })
+      if (!isClaudiaBlock) {
+        logs = [
+          ...(logs ?? []),
+          {
+            status: 'error' as const,
+            description: `Dead end: block "${lastBlock.id}" in group "${group.title ?? group.id}" has no outgoing connection`,
+          },
+        ]
+      }
+    }
     return {
       messages,
       newSessionState,
       clientSideActions,
       logs,
       visitedEdges,
+      visitedBlocks,
       setVariableHistory,
     }
+  }
 
   const nextGroup = await getNextGroup({
     state: newSessionState,
@@ -341,12 +410,32 @@ export const executeGroup = async (
   if (nextGroup.visitedEdge) visitedEdges.push(nextGroup.visitedEdge)
 
   if (!nextGroup.group) {
+    const lastBlock = group.blocks[group.blocks.length - 1]
+    if (lastBlock) {
+      const isClaudiaBlock = lastBlock.type === 'claudia'
+      visitedBlocks.push({
+        blockId: lastBlock.id,
+        groupId: group.id,
+        timestamp: new Date().toISOString(),
+        status: isClaudiaBlock ? 'ok' : 'dead_end',
+      })
+      if (!isClaudiaBlock) {
+        logs = [
+          ...(logs ?? []),
+          {
+            status: 'error' as const,
+            description: `Dead end: edge from block "${lastBlock.id}" points to a non-existent group`,
+          },
+        ]
+      }
+    }
     return {
       messages,
       newSessionState,
       clientSideActions,
       logs,
       visitedEdges,
+      visitedBlocks,
       setVariableHistory,
     }
   }
@@ -355,6 +444,7 @@ export const executeGroup = async (
     version,
     state: newSessionState,
     visitedEdges,
+    visitedBlocks,
     setVariableHistory,
     currentReply: {
       messages,

--- a/packages/bot-engine/saveStateToDatabase.ts
+++ b/packages/bot-engine/saveStateToDatabase.ts
@@ -2,6 +2,7 @@ import {
   ContinueChatResponse,
   ChatSession,
   SetVariableHistoryItem,
+  VisitedBlockEntry,
 } from '@typebot.io/schemas'
 import { upsertResult } from './queries/upsertResult'
 import { updateSession } from './queries/updateSession'
@@ -17,6 +18,7 @@ type Props = {
   logs: ContinueChatResponse['logs']
   clientSideActions: ContinueChatResponse['clientSideActions']
   visitedEdges: VisitedEdge[]
+  visitedBlocks?: VisitedBlockEntry[]
   setVariableHistory: SetVariableHistoryItem[]
   hasCustomEmbedBubble?: boolean
   initialSessionId?: string
@@ -28,23 +30,11 @@ export const saveStateToDatabase = async ({
   logs,
   clientSideActions,
   visitedEdges,
+  visitedBlocks,
   setVariableHistory,
   hasCustomEmbedBubble,
   initialSessionId,
 }: Props) => {
-  logger.info('saveStateToDatabase called', {
-    sessionId: id,
-    hasExistingSessionId: !!id,
-    existingSessionId: id,
-    initialSessionId,
-    resultId: state.typebotsQueue[0]?.resultId,
-    typebotId: state.typebotsQueue[0]?.typebot?.id,
-    hasInput: !!input,
-    inputId: input?.id,
-    hasCustomEmbedBubble,
-    answersCount: state.typebotsQueue[0]?.answers?.length || 0,
-  })
-
   const containsSetVariableClientSideAction = clientSideActions?.some(
     (action) => action.expectsDedicatedReply
   )
@@ -57,28 +47,6 @@ export const saveStateToDatabase = async ({
 
   const resultId = state.typebotsQueue[0].resultId
 
-  logger.info('saveStateToDatabase session handling', {
-    sessionId: id,
-    hasExistingSessionId: !!id,
-    existingSessionId: id,
-    initialSessionId,
-    resultId,
-    isCompleted,
-    isCompletedConditions: {
-      hasNoInput: !input,
-      hasNoSetVariableClientSideAction: !containsSetVariableClientSideAction,
-      hasNoCustomEmbedBubble: !hasCustomEmbedBubble,
-    },
-    willDeleteSession: !!(id && isCompleted && resultId),
-    willDeleteSessionConditions: {
-      hasSessionId: !!id,
-      isCompleted,
-      hasResultId: !!resultId,
-    },
-    willUpdateSession: !!(id && !(isCompleted && resultId)),
-    willCreateSession: !id,
-  })
-
   if (id) {
     if (isCompleted && resultId) queries.push(deleteSession(id))
     else queries.push(updateSession({ id, state, isReplying: false }))
@@ -88,14 +56,6 @@ export const saveStateToDatabase = async ({
     ? { state, id }
     : await createSession({ id: initialSessionId, state, isReplying: false })
 
-  logger.info('saveStateToDatabase session result', {
-    sessionId: session.id,
-    resultId,
-    isCompleted,
-    hasQueries: queries.length > 0,
-    sessionIdMatches: initialSessionId ? session.id === initialSessionId : 'N/A',
-  })
-
   if (!resultId) {
     if (queries.length > 0) await prisma.$transaction(queries)
     return session
@@ -103,32 +63,52 @@ export const saveStateToDatabase = async ({
 
   const answers = state.typebotsQueue[0].answers
 
+  const resultIsCompleted = Boolean(
+    !input && !containsSetVariableClientSideAction && answers.length > 0
+  )
+
+  const hasDeadEnd = visitedBlocks?.some((b) => b.status === 'dead_end')
+  const hasErrorBlock = visitedBlocks?.some((b) => b.status === 'error')
+  const derivedStatus = hasDeadEnd
+    ? 'error'
+    : resultIsCompleted
+    ? 'completed'
+    : hasErrorBlock
+    ? 'error'
+    : 'abandoned'
+
   queries.push(
     upsertResult({
       resultId,
       typebot: state.typebotsQueue[0].typebot,
-      isCompleted: Boolean(
-        !input && !containsSetVariableClientSideAction && answers.length > 0
-      ),
+      isCompleted: resultIsCompleted,
       hasStarted: answers.length > 0,
       lastChatSessionId: session.id,
       logs,
       visitedEdges,
       setVariableHistory,
+      status: derivedStatus,
     })
   )
 
+  // Atomic append to avoid read-then-write race condition on concurrent requests
+  if (visitedBlocks && visitedBlocks.length > 0) {
+    const blocksJson = JSON.stringify(visitedBlocks)
+    queries.push(
+      prisma.$queryRaw`
+        UPDATE "Result"
+        SET "visitedBlocks" = COALESCE("visitedBlocks", '[]'::jsonb) || ${blocksJson}::jsonb
+        WHERE id = ${resultId}
+      `
+    )
+  }
+
   await prisma.$transaction(queries)
 
-  logger.info('saveStateToDatabase completed successfully', {
+  logger.debug('saveStateToDatabase completed', {
     sessionId: session.id,
     resultId,
-    typebotId: state.typebotsQueue[0]?.typebot?.id,
-    isCompleted: Boolean(
-      !input && !containsSetVariableClientSideAction && answers.length > 0
-    ),
-    hasStarted: answers.length > 0,
-    queriesExecuted: queries.length,
+    isCompleted: resultIsCompleted,
   })
 
   return session

--- a/packages/bot-engine/startBotFlow.ts
+++ b/packages/bot-engine/startBotFlow.ts
@@ -4,6 +4,7 @@ import {
   SessionState,
   SetVariableHistoryItem,
   StartFrom,
+  VisitedBlockEntry,
 } from '@typebot.io/schemas'
 import { executeGroup } from './executeGroup'
 import { getNextGroup } from './getNextGroup'
@@ -30,11 +31,13 @@ export const startBotFlow = async ({
   ContinueChatResponse & {
     newSessionState: SessionState
     visitedEdges: VisitedEdge[]
+    visitedBlocks: VisitedBlockEntry[]
     setVariableHistory: SetVariableHistoryItem[]
   }
 > => {
   let newSessionState = state
   const visitedEdges: VisitedEdge[] = []
+  const visitedBlocks: VisitedBlockEntry[] = []
   const setVariableHistory: SetVariableHistoryItem[] = []
   if (startFrom?.type === 'group') {
     const group = state.typebotsQueue[0].typebot.groups.find(
@@ -49,6 +52,7 @@ export const startBotFlow = async ({
       version,
       state: newSessionState,
       visitedEdges,
+      visitedBlocks,
       setVariableHistory,
       startTime,
       textBubbleContentFormat,
@@ -65,6 +69,7 @@ export const startBotFlow = async ({
       newSessionState,
       setVariableHistory: [],
       visitedEdges: [],
+      visitedBlocks: [],
     }
   const nextGroup = await getNextGroup({
     state: newSessionState,
@@ -73,11 +78,12 @@ export const startBotFlow = async ({
   })
   newSessionState = nextGroup.newSessionState
   if (!nextGroup.group)
-    return { messages: [], newSessionState, visitedEdges, setVariableHistory }
+    return { messages: [], newSessionState, visitedEdges, visitedBlocks, setVariableHistory }
   return executeGroup(nextGroup.group, {
     version,
     state: newSessionState,
     visitedEdges,
+    visitedBlocks,
     setVariableHistory,
     startTime,
     textBubbleContentFormat,

--- a/packages/bot-engine/startSession.ts
+++ b/packages/bot-engine/startSession.ts
@@ -12,6 +12,7 @@ import {
   TypebotInSession,
   Block,
   SetVariableHistoryItem,
+  VisitedBlockEntry,
 } from '@typebot.io/schemas'
 import {
   StartChatInput,
@@ -76,6 +77,7 @@ export const startSession = async ({
   Omit<StartChatResponse, 'resultId' | 'isStreamEnabled' | 'sessionId'> & {
     newSessionState: SessionState
     visitedEdges: VisitedEdge[]
+    visitedBlocks: VisitedBlockEntry[]
     setVariableHistory: SetVariableHistoryItem[]
     resultId?: string
   }
@@ -184,6 +186,7 @@ export const startSession = async ({
       dynamicTheme: parseDynamicTheme(initialState),
       messages: [],
       visitedEdges: [],
+      visitedBlocks: [],
       setVariableHistory: [],
     }
   }
@@ -242,6 +245,7 @@ export const startSession = async ({
     newSessionState,
     logs,
     visitedEdges,
+    visitedBlocks,
     setVariableHistory,
   } = chatReply
 
@@ -297,6 +301,7 @@ export const startSession = async ({
       dynamicTheme: parseDynamicTheme(newSessionState),
       logs: startLogs.length > 0 ? startLogs : undefined,
       visitedEdges,
+      visitedBlocks,
       setVariableHistory,
     }
 
@@ -320,6 +325,7 @@ export const startSession = async ({
     dynamicTheme: parseDynamicTheme(newSessionState),
     logs: startLogs.length > 0 ? startLogs : undefined,
     visitedEdges,
+    visitedBlocks,
     setVariableHistory,
   }
 }

--- a/packages/prisma/mysql/schema.prisma
+++ b/packages/prisma/mysql/schema.prisma
@@ -1,6 +1,5 @@
 generator client {
-  provider        = "prisma-client-js"
-  previewFeatures = ["metrics"]
+  provider = "prisma-client-js"
 }
 
 datasource db {
@@ -263,6 +262,9 @@ model Result {
   hasStarted         Boolean?
   isArchived         Boolean?                 @default(false)
   lastChatSessionId  String?
+  helpdeskId         String?
+  status             String                   @default("abandoned")
+  visitedBlocks      Json?
   typebot            Typebot                  @relation(fields: [typebotId], references: [id], onDelete: Cascade)
   answers            Answer[]
   logs               Log[]
@@ -272,6 +274,9 @@ model Result {
 
   @@index([typebotId, isArchived, hasStarted, createdAt(sort: Desc)])
   @@index([typebotId, isArchived, isCompleted])
+  @@index([helpdeskId])
+  @@index([createdAt])
+  @@index([status])
 }
 
 model SetVariableHistoryItem {

--- a/packages/prisma/postgresql/schema.prisma
+++ b/packages/prisma/postgresql/schema.prisma
@@ -1,6 +1,5 @@
 generator client {
-  provider        = "prisma-client-js"
-  previewFeatures = ["metrics"]
+  provider = "prisma-client-js"
 }
 
 datasource db {
@@ -289,19 +288,19 @@ model CollaboratorsOnTypebots {
 }
 
 model PublicTypebot {
-  id        String   @id @default(cuid())
-  version   String?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
-  typebotId String   @unique
-  groups    Json
-  events    Json?
-  variables Json
-  edges     Json
-  theme     Json
-  settings  Json
-  isSecondaryFlow  Boolean  @default(false)
-  typebot   Typebot  @relation(fields: [typebotId], references: [id], onDelete: Cascade)
+  id              String   @id @default(cuid())
+  version         String?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @default(now()) @updatedAt
+  typebotId       String   @unique
+  groups          Json
+  events          Json?
+  variables       Json
+  edges           Json
+  theme           Json
+  settings        Json
+  isSecondaryFlow Boolean  @default(false)
+  typebot         Typebot  @relation(fields: [typebotId], references: [id], onDelete: Cascade)
 }
 
 model Result {
@@ -313,6 +312,9 @@ model Result {
   hasStarted         Boolean?
   isArchived         Boolean?                 @default(false)
   lastChatSessionId  String?
+  helpdeskId         String?
+  status             String                   @default("abandoned")
+  visitedBlocks      Json?
   typebot            Typebot                  @relation(fields: [typebotId], references: [id], onDelete: Cascade)
   answers            Answer[]
   answersV2          AnswerV2[]
@@ -322,6 +324,9 @@ model Result {
 
   @@index([typebotId, hasStarted, createdAt(sort: Desc)])
   @@index([typebotId, isCompleted])
+  @@index([helpdeskId])
+  @@index([createdAt])
+  @@index([status])
 }
 
 model SetVariableHistoryItem {

--- a/packages/results/parseColumnsOrder.ts
+++ b/packages/results/parseColumnsOrder.ts
@@ -1,15 +1,27 @@
 import { ResultHeaderCell } from '@typebot.io/schemas'
 
+const fixedPrefix = ['select', '__helpdeskId']
+const fixedSuffix = ['__visitedBlocksCount', '__status', 'logs', '__flowReplay']
+
 export const parseColumnsOrder = (
   existingOrder: string[] | undefined,
   resultHeader: ResultHeaderCell[]
-) =>
-  existingOrder
+) => {
+  const dynamicIds = existingOrder
     ? [
-        ...existingOrder.slice(0, -1),
+        ...existingOrder.filter(
+          (id) => !fixedPrefix.includes(id) && !fixedSuffix.includes(id)
+        ),
         ...resultHeader
-          .filter((header) => !existingOrder.includes(header.id))
+          .filter(
+            (header) =>
+              !existingOrder.includes(header.id) &&
+              !fixedPrefix.includes(header.id) &&
+              !fixedSuffix.includes(header.id)
+          )
           .map((h) => h.id),
-        'logs',
       ]
-    : ['select', ...resultHeader.map((h) => h.id), 'logs']
+    : resultHeader.map((h) => h.id)
+
+  return [...fixedPrefix, ...dynamicIds, ...fixedSuffix]
+}

--- a/packages/schemas/features/result.ts
+++ b/packages/schemas/features/result.ts
@@ -6,6 +6,7 @@ import {
   Log as LogPrisma,
   SetVariableHistoryItem as SetVariableHistoryItemPrisma,
   VisitedEdge,
+  Prisma,
 } from '@typebot.io/prisma'
 import { InputBlockType } from './blocks/inputs/constants'
 
@@ -18,6 +19,9 @@ export const resultSchema = z.object({
   hasStarted: z.boolean().nullable(),
   isArchived: z.boolean().nullable(),
   lastChatSessionId: z.string().nullable(),
+  helpdeskId: z.string().nullable(),
+  status: z.string(),
+  visitedBlocks: z.custom<Prisma.JsonValue>(),
 }) satisfies z.ZodType<ResultPrisma>
 
 export const resultWithAnswersSchema = resultSchema.merge(


### PR DESCRIPTION
## Contexto

Adiciona um botão "Ver fluxo" em cada linha da tabela de resultados, abrindo um modal que exibe o replay visual da sessão do usuário — mostrando o caminho percorrido no fluxo.

Isso facilita a análise de sessões individuais sem precisar sair da tela de resultados.

## Alterações principais

- Novo endpoint `getSessionTypebot` para buscar dados da sessão
- Componente `FlowReplayModal` com visualização do fluxo percorrido
- Coluna "Ver fluxo" adicionada na tabela de resultados
- Ajustes em `parseColumnsOrder` para suportar a nova coluna


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new persisted session-tracking fields on `Result` plus new analytics queries that batch-scan results; incorrect status/visited-block recording or migrations could impact analytics accuracy and result writes.
> 
> **Overview**
> Adds flow-level CX analytics backed by new `Result` fields (`status`, `visitedBlocks`, optional `helpdeskId`) and indexes in both Prisma schemas, and updates the shared result schema to expose them.
> 
> The bot engine now records `visitedBlocks` entries during `startSession`/`executeGroup`/`continueBotFlow`, derives a consistent `Result.status` (completed/abandoned/error, including dead-ends), and appends `visitedBlocks` atomically in `saveStateToDatabase`.
> 
> Builder analytics gains new TRPC procedures (`getCxStats`, `getBlockVisitStats`) and a UI refresh: a collapsible `CxMetricsPanel` (volume/completion/error/Claudia action metrics + volume-by-day) and new graph overlays showing per-group visit percentages and per-block abandon/error badges; graph edges also support optional highlighting and zoom button positioning tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f4fc4e4aaca750433c5ec38f49fd2daceab16ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adiciona um painel de métricas CX colapsável (`CxMetricsPanel`) com volume, taxa de conclusão, ações da Claudia e duração média; sobrepõe badges de visita por grupo e badges de abandono/erro por bloco no grafo de analytics; e introduz um modal `FlowReplayModal` na tela de resultados que exibe o replay visual da sessão com blocos e arestas destacadas por status.

O motor de bot passa a registrar `visitedBlocks` em cada passo e a derivar um `Result.status` (`completed`/`abandoned`/`error`) persistido via `saveStateToDatabase`.

- **P1 (`getAnalyticsStats.ts`):** `totalSessions` é contado de todos os registros do período, mas o loop de batch só processa registros com `visitedBlocks IS NOT NULL`. Todos os `visitPercentage` e percentuais de issues são divididos por um denominador inflado — resultando em 0% para todo fluxo enquanto houver sessões históricas sem `visitedBlocks`.
- **P1 (`saveStateToDatabase.ts`):** SQL bruto usa sintaxe JSONB específica do PostgreSQL (`'[]'::jsonb || ...`), quebrando implantações MySQL (thread anterior).
- **P1 (`continueBotFlow.ts`):** Blocos em dead-end são inseridos duas vezes em `visitedBlocks` (thread anterior).

<h3>Confidence Score: 4/5</h3>

PR não deve ser mergeado sem corrigir a inconsistência do denominador em `getBlockVisitStats`, que tornará todas as percentagens analíticas incorretas.

Dois P1s de threads anteriores (SQL incompatível com MySQL e double-push de blocos) permanecem sem resolução. Este review adiciona um terceiro P1: o denominador inflado em `getBlockVisitStats` que faz todas as percentagens de visita reportarem valores incorretos desde o primeiro deploy. Os itens P2 são menores e não bloqueiam merge.

`apps/builder/src/features/analytics/api/getAnalyticsStats.ts` (denominador incorreto), `packages/bot-engine/saveStateToDatabase.ts` (raw SQL PostgreSQL-only), `packages/bot-engine/continueBotFlow.ts` (double-push em dead-end)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/builder/src/features/analytics/api/getAnalyticsStats.ts | New TRPC procedures `getCxStats` and `getBlockVisitStats`; `totalSessions` denominator in `getBlockVisitStats` is unfiltered while batch only processes records with non-null `visitedBlocks`, producing incorrect percentages |
| packages/bot-engine/saveStateToDatabase.ts | Derives and persists `status` and appends `visitedBlocks` via raw PostgreSQL JSONB syntax (incompatible with MySQL); active sessions incorrectly labelled `abandoned` mid-session (both previously flagged) |
| packages/bot-engine/continueBotFlow.ts | Records `visitedBlocks` on each step; dead-end branches push the same block twice — once as `ok` and once as `dead_end` (previously flagged) |
| apps/builder/src/features/results/components/FlowReplayModal.tsx | New modal showing flow replay with highlighted edges and block status overlays; status badge labels are in English while the rest of the component uses PT-BR |
| apps/builder/src/features/analytics/components/CxMetricsPanel.tsx | Collapsible panel showing CX metrics (volume, completion, errors, Claudia actions, avg duration) and a volume-by-day bar chart; fully in PT-BR and straightforward UI |
| apps/builder/src/features/results/api/getSessionTypebot.ts | Fetches typebot snapshot from completed session state; output schema uses `z.any()` bypassing Zod validation; auth check is correct |
| packages/schemas/features/result.ts | Adds `helpdeskId`, `status`, and `visitedBlocks` fields to `resultSchema`; `status` typed as `z.string()` (unconstrained) rather than an enum |
| packages/results/parseColumnsOrder.ts | Adds `__flowReplay` to fixed suffix columns and `__helpdeskId` to fixed prefix; clean and consistent with existing pattern |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant BotEngine
    participant DB as Database (Result)
    participant Builder
    participant AnalyticsAPI

    User->>BotEngine: Send message / start session
    BotEngine->>BotEngine: executeGroup / continueBotFlow accumulate visitedBlocks[]
    BotEngine->>DB: saveStateToDatabase() upsertResult(status=derived) RAW SQL append visitedBlocks

    Builder->>AnalyticsAPI: getCxStats(typebotId, timeFilter)
    AnalyticsAPI->>DB: COUNT all results (totalSessions)
    AnalyticsAPI->>DB: Batch fetch results with visitedBlocks not null
    AnalyticsAPI-->>Builder: totalSessions, completed, abandoned

    Builder->>AnalyticsAPI: getBlockVisitStats(typebotId, timeFilter)
    AnalyticsAPI->>DB: COUNT all results totalSessions inflated
    AnalyticsAPI->>DB: Batch fetch only visitedBlocks not null
    AnalyticsAPI-->>Builder: groupStats percent of inflated total, blockIssues

    Builder->>Builder: FlowReplayModal open
    Builder->>AnalyticsAPI: getSessionTypebot(typebotId, resultId)
    AnalyticsAPI->>DB: Result.lastChatSessionId to ChatSession.state
    AnalyticsAPI-->>Builder: typebot snapshot or null
    Builder->>Builder: Render Graph with highlightedEdges and CSS overlays
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/schemas/features/result.ts`, line 1-10 ([link](https://github.com/cloudhumans/typebot.io/blob/5f4fc4e4aaca750433c5ec38f49fd2daceab16ff/packages/schemas/features/result.ts#L1-L10)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=7" align="top"></a> **`VisitedBlockEntry` type is missing from the schemas package**

   All six `bot-engine` files (`continueBotFlow.ts`, `executeGroup.ts`, `saveStateToDatabase.ts`, `startBotFlow.ts`, `startSession.ts`, and `startChatPreview.ts`) import `VisitedBlockEntry` from `@typebot.io/schemas`, but this type is **never defined or exported** from the schemas package. A search across the entire `packages/schemas` directory confirms zero occurrences of `VisitedBlockEntry`.

   This will cause TypeScript compilation errors at build time. The type needs to be defined and exported, for example in `packages/schemas/features/result.ts` or a dedicated file:

   ```ts
   export type VisitedBlockEntry = {
     blockId: string
     groupId: string
     timestamp: string
     status: 'ok' | 'dead_end' | 'error' | 'abandoned'
   }
   ```

   Without this export the PR cannot compile.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/schemas/features/result.ts
   Line: 1-10

   Comment:
   **`VisitedBlockEntry` type is missing from the schemas package**

   All six `bot-engine` files (`continueBotFlow.ts`, `executeGroup.ts`, `saveStateToDatabase.ts`, `startBotFlow.ts`, `startSession.ts`, and `startChatPreview.ts`) import `VisitedBlockEntry` from `@typebot.io/schemas`, but this type is **never defined or exported** from the schemas package. A search across the entire `packages/schemas` directory confirms zero occurrences of `VisitedBlockEntry`.

   This will cause TypeScript compilation errors at build time. The type needs to be defined and exported, for example in `packages/schemas/features/result.ts` or a dedicated file:

   ```ts
   export type VisitedBlockEntry = {
     blockId: string
     groupId: string
     timestamp: string
     status: 'ok' | 'dead_end' | 'error' | 'abandoned'
   }
   ```

   Without this export the PR cannot compile.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fschemas%2Ffeatures%2Fresult.ts%0ALine%3A%201-10%0A%0AComment%3A%0A**%60VisitedBlockEntry%60%20type%20is%20missing%20from%20the%20schemas%20package**%0A%0AAll%20six%20%60bot-engine%60%20files%20%28%60continueBotFlow.ts%60%2C%20%60executeGroup.ts%60%2C%20%60saveStateToDatabase.ts%60%2C%20%60startBotFlow.ts%60%2C%20%60startSession.ts%60%2C%20and%20%60startChatPreview.ts%60%29%20import%20%60VisitedBlockEntry%60%20from%20%60%40typebot.io%2Fschemas%60%2C%20but%20this%20type%20is%20**never%20defined%20or%20exported**%20from%20the%20schemas%20package.%20A%20search%20across%20the%20entire%20%60packages%2Fschemas%60%20directory%20confirms%20zero%20occurrences%20of%20%60VisitedBlockEntry%60.%0A%0AThis%20will%20cause%20TypeScript%20compilation%20errors%20at%20build%20time.%20The%20type%20needs%20to%20be%20defined%20and%20exported%2C%20for%20example%20in%20%60packages%2Fschemas%2Ffeatures%2Fresult.ts%60%20or%20a%20dedicated%20file%3A%0A%0A%60%60%60ts%0Aexport%20type%20VisitedBlockEntry%20%3D%20%7B%0A%20%20blockId%3A%20string%0A%20%20groupId%3A%20string%0A%20%20timestamp%3A%20string%0A%20%20status%3A%20'ok'%20%7C%20'dead_end'%20%7C%20'error'%20%7C%20'abandoned'%0A%7D%0A%60%60%60%0A%0AWithout%20this%20export%20the%20PR%20cannot%20compile.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudhumans%2Ftypebot.io"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fschemas%2Ffeatures%2Fresult.ts%0ALine%3A%201-10%0A%0AComment%3A%0A**%60VisitedBlockEntry%60%20type%20is%20missing%20from%20the%20schemas%20package**%0A%0AAll%20six%20%60bot-engine%60%20files%20%28%60continueBotFlow.ts%60%2C%20%60executeGroup.ts%60%2C%20%60saveStateToDatabase.ts%60%2C%20%60startBotFlow.ts%60%2C%20%60startSession.ts%60%2C%20and%20%60startChatPreview.ts%60%29%20import%20%60VisitedBlockEntry%60%20from%20%60%40typebot.io%2Fschemas%60%2C%20but%20this%20type%20is%20**never%20defined%20or%20exported**%20from%20the%20schemas%20package.%20A%20search%20across%20the%20entire%20%60packages%2Fschemas%60%20directory%20confirms%20zero%20occurrences%20of%20%60VisitedBlockEntry%60.%0A%0AThis%20will%20cause%20TypeScript%20compilation%20errors%20at%20build%20time.%20The%20type%20needs%20to%20be%20defined%20and%20exported%2C%20for%20example%20in%20%60packages%2Fschemas%2Ffeatures%2Fresult.ts%60%20or%20a%20dedicated%20file%3A%0A%0A%60%60%60ts%0Aexport%20type%20VisitedBlockEntry%20%3D%20%7B%0A%20%20blockId%3A%20string%0A%20%20groupId%3A%20string%0A%20%20timestamp%3A%20string%0A%20%20status%3A%20'ok'%20%7C%20'dead_end'%20%7C%20'error'%20%7C%20'abandoned'%0A%7D%0A%60%60%60%0A%0AWithout%20this%20export%20the%20PR%20cannot%20compile.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fanalytics%2Fapi%2FgetAnalyticsStats.ts%3A101-206%0A**%60totalSessions%60%20denominator%20inflates%20percentages%20for%20new%20installations**%0A%0A%60totalSessions%60%20is%20counted%20from%20ALL%20results%20matching%20%60baseWhere%60%20%28line%20101%29%2C%20but%20the%20batch%20loop%20%28lines%20128%E2%80%93137%29%20filters%20to%20only%20records%20where%20%60visitedBlocks%20IS%20NOT%20NULL%60.%20Every%20%60visitPercentage%60%20and%20issue%20%60percentage%60%20is%20then%20divided%20by%20this%20larger%20unfiltered%20count.%0A%0AFor%20any%20deployment%20where%20%60visitedBlocks%60%20was%20added%20mid-flight%20%28i.e.%2C%20all%20historical%20results%20have%20%60visitedBlocks%20%3D%20null%60%29%2C%20the%20batch%20returns%200%20visits%20while%20%60totalSessions%60%20is%20non-zero%2C%20so%20the%20endpoint%20returns%20%60groupStats%3A%20%5B%5D%60%20alongside%20a%20non-zero%20%60totalSessions%60%20%E2%80%94%20implying%20analytics%20ran%20but%20found%20nothing%2C%20and%20all%20percentages%20appear%20as%200%25%20even%20though%20every%20active%20session%20passes%20through%20every%20group.%0A%0AFix%3A%20count%20%60totalSessions%60%20using%20the%20same%20filter%20applied%20to%20the%20batch%2C%20or%20add%20a%20separate%20%60analyzedSessions%60%20field%20so%20callers%20can%20correctly%20contextualise%20the%20percentages.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fresults%2Fcomponents%2FFlowReplayModal.tsx%3A30-38%0A**Status%20labels%20devem%20estar%20em%20Portugu%C3%AAs%20%28PT-BR%29**%0A%0AOs%20r%C3%B3tulos%20de%20status%20s%C3%A3o%20exibidos%20em%20ingl%C3%AAs%2C%20enquanto%20o%20restante%20da%20interface%20do%20componente%20%28%60Dura%C3%A7%C3%A3o%3A%60%2C%20%60bloco%28s%29%20visitados%60%2C%20%60Snapshot%20da%20sess%C3%A3o%60%29%20j%C3%A1%20usa%20Portugu%C3%AAs%20Brasileiro.%20As%20labels%20devem%20ser%20traduzidas%20para%20manter%20consist%C3%AAncia.%0A%0A%60%60%60suggestion%0Aconst%20statusDisplay%3A%20Record%3C%0A%20%20string%2C%0A%20%20%7B%20label%3A%20string%3B%20colorScheme%3A%20string%20%7D%0A%3E%20%3D%20%7B%0A%20%20completed%3A%20%7B%20label%3A%20'Conclu%C3%ADda'%2C%20colorScheme%3A%20'green'%20%7D%2C%0A%20%20error%3A%20%7B%20label%3A%20'Erro'%2C%20colorScheme%3A%20'red'%20%7D%2C%0A%20%20abandoned%3A%20%7B%20label%3A%20'Abandonada'%2C%20colorScheme%3A%20'purple'%20%7D%2C%0A%20%20in_progress%3A%20%7B%20label%3A%20'Em%20andamento'%2C%20colorScheme%3A%20'gray'%20%7D%2C%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fresults%2Fapi%2FgetSessionTypebot.ts%3A14-18%0A**%60z.any%28%29%60%20no%20output%20schema%20desabilita%20valida%C3%A7%C3%A3o%20do%20TRPC**%0A%0AUsar%20%60z.any%28%29.nullable%28%29%60%20como%20tipo%20de%20sa%C3%ADda%20para%20%60typebot%60%20descarta%20toda%20valida%C3%A7%C3%A3o%20de%20resposta%20do%20Zod.%20Se%20a%20forma%20do%20objeto%20de%20sess%C3%A3o%20mudar%2C%20o%20cliente%20receber%C3%A1%20dados%20malformados%20silenciosamente%20sem%20erro%20de%20contrato.%20Considere%20ao%20menos%20tipar%20os%20campos%20que%20o%20%60FlowReplayModal%60%20consome%20%28%60groups%60%2C%20%60edges%60%2C%20%60events%60%2C%20%60variables%60%29%20com%20um%20schema%20parcial.%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=185&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fanalytics%2Fapi%2FgetAnalyticsStats.ts%3A101-206%0A**%60totalSessions%60%20denominator%20inflates%20percentages%20for%20new%20installations**%0A%0A%60totalSessions%60%20is%20counted%20from%20ALL%20results%20matching%20%60baseWhere%60%20%28line%20101%29%2C%20but%20the%20batch%20loop%20%28lines%20128%E2%80%93137%29%20filters%20to%20only%20records%20where%20%60visitedBlocks%20IS%20NOT%20NULL%60.%20Every%20%60visitPercentage%60%20and%20issue%20%60percentage%60%20is%20then%20divided%20by%20this%20larger%20unfiltered%20count.%0A%0AFor%20any%20deployment%20where%20%60visitedBlocks%60%20was%20added%20mid-flight%20%28i.e.%2C%20all%20historical%20results%20have%20%60visitedBlocks%20%3D%20null%60%29%2C%20the%20batch%20returns%200%20visits%20while%20%60totalSessions%60%20is%20non-zero%2C%20so%20the%20endpoint%20returns%20%60groupStats%3A%20%5B%5D%60%20alongside%20a%20non-zero%20%60totalSessions%60%20%E2%80%94%20implying%20analytics%20ran%20but%20found%20nothing%2C%20and%20all%20percentages%20appear%20as%200%25%20even%20though%20every%20active%20session%20passes%20through%20every%20group.%0A%0AFix%3A%20count%20%60totalSessions%60%20using%20the%20same%20filter%20applied%20to%20the%20batch%2C%20or%20add%20a%20separate%20%60analyzedSessions%60%20field%20so%20callers%20can%20correctly%20contextualise%20the%20percentages.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fresults%2Fcomponents%2FFlowReplayModal.tsx%3A30-38%0A**Status%20labels%20devem%20estar%20em%20Portugu%C3%AAs%20%28PT-BR%29**%0A%0AOs%20r%C3%B3tulos%20de%20status%20s%C3%A3o%20exibidos%20em%20ingl%C3%AAs%2C%20enquanto%20o%20restante%20da%20interface%20do%20componente%20%28%60Dura%C3%A7%C3%A3o%3A%60%2C%20%60bloco%28s%29%20visitados%60%2C%20%60Snapshot%20da%20sess%C3%A3o%60%29%20j%C3%A1%20usa%20Portugu%C3%AAs%20Brasileiro.%20As%20labels%20devem%20ser%20traduzidas%20para%20manter%20consist%C3%AAncia.%0A%0A%60%60%60suggestion%0Aconst%20statusDisplay%3A%20Record%3C%0A%20%20string%2C%0A%20%20%7B%20label%3A%20string%3B%20colorScheme%3A%20string%20%7D%0A%3E%20%3D%20%7B%0A%20%20completed%3A%20%7B%20label%3A%20'Conclu%C3%ADda'%2C%20colorScheme%3A%20'green'%20%7D%2C%0A%20%20error%3A%20%7B%20label%3A%20'Erro'%2C%20colorScheme%3A%20'red'%20%7D%2C%0A%20%20abandoned%3A%20%7B%20label%3A%20'Abandonada'%2C%20colorScheme%3A%20'purple'%20%7D%2C%0A%20%20in_progress%3A%20%7B%20label%3A%20'Em%20andamento'%2C%20colorScheme%3A%20'gray'%20%7D%2C%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fresults%2Fapi%2FgetSessionTypebot.ts%3A14-18%0A**%60z.any%28%29%60%20no%20output%20schema%20desabilita%20valida%C3%A7%C3%A3o%20do%20TRPC**%0A%0AUsar%20%60z.any%28%29.nullable%28%29%60%20como%20tipo%20de%20sa%C3%ADda%20para%20%60typebot%60%20descarta%20toda%20valida%C3%A7%C3%A3o%20de%20resposta%20do%20Zod.%20Se%20a%20forma%20do%20objeto%20de%20sess%C3%A3o%20mudar%2C%20o%20cliente%20receber%C3%A1%20dados%20malformados%20silenciosamente%20sem%20erro%20de%20contrato.%20Considere%20ao%20menos%20tipar%20os%20campos%20que%20o%20%60FlowReplayModal%60%20consome%20%28%60groups%60%2C%20%60edges%60%2C%20%60events%60%2C%20%60variables%60%29%20com%20um%20schema%20parcial.%0A%0A&pr=185&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/builder/src/features/analytics/api/getAnalyticsStats.ts
Line: 101-206

Comment:
**`totalSessions` denominator inflates percentages for new installations**

`totalSessions` is counted from ALL results matching `baseWhere` (line 101), but the batch loop (lines 128–137) filters to only records where `visitedBlocks IS NOT NULL`. Every `visitPercentage` and issue `percentage` is then divided by this larger unfiltered count.

For any deployment where `visitedBlocks` was added mid-flight (i.e., all historical results have `visitedBlocks = null`), the batch returns 0 visits while `totalSessions` is non-zero, so the endpoint returns `groupStats: []` alongside a non-zero `totalSessions` — implying analytics ran but found nothing, and all percentages appear as 0% even though every active session passes through every group.

Fix: count `totalSessions` using the same filter applied to the batch, or add a separate `analyzedSessions` field so callers can correctly contextualise the percentages.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/builder/src/features/results/components/FlowReplayModal.tsx
Line: 30-38

Comment:
**Status labels devem estar em Português (PT-BR)**

Os rótulos de status são exibidos em inglês, enquanto o restante da interface do componente (`Duração:`, `bloco(s) visitados`, `Snapshot da sessão`) já usa Português Brasileiro. As labels devem ser traduzidas para manter consistência.

```suggestion
const statusDisplay: Record<
  string,
  { label: string; colorScheme: string }
> = {
  completed: { label: 'Concluída', colorScheme: 'green' },
  error: { label: 'Erro', colorScheme: 'red' },
  abandoned: { label: 'Abandonada', colorScheme: 'purple' },
  in_progress: { label: 'Em andamento', colorScheme: 'gray' },
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/builder/src/features/results/api/getSessionTypebot.ts
Line: 14-18

Comment:
**`z.any()` no output schema desabilita validação do TRPC**

Usar `z.any().nullable()` como tipo de saída para `typebot` descarta toda validação de resposta do Zod. Se a forma do objeto de sessão mudar, o cliente receberá dados malformados silenciosamente sem erro de contrato. Considere ao menos tipar os campos que o `FlowReplayModal` consome (`groups`, `edges`, `events`, `variables`) com um schema parcial.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge pull request #186 from cloudhumans..."](https://github.com/cloudhumans/typebot.io/commit/854eea776e6a0b7d30783c106ef6e6743b109762) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28232183)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->