### PR TITLE
✨feature: add flow replay button and modal in results table

### DIFF
--- a/apps/builder/src/features/results/api/getSessionTypebot.ts
+++ b/apps/builder/src/features/results/api/getSessionTypebot.ts
@@ -1,0 +1,63 @@
+import prisma from '@typebot.io/lib/prisma'
+import { authenticatedProcedure } from '@/helpers/server/trpc'
+import { TRPCError } from '@trpc/server'
+import { z } from 'zod'
+import { isReadTypebotForbidden } from '@/features/typebot/helpers/isReadTypebotForbidden'
+
+export const getSessionTypebot = authenticatedProcedure
+  .input(
+    z.object({
+      typebotId: z.string(),
+      resultId: z.string(),
+    })
+  )
+  .output(
+    z.object({
+      typebot: z.any().nullable(),
+    })
+  )
+  .query(async ({ input, ctx: { user } }) => {
+    const typebot = await prisma.typebot.findUnique({
+      where: { id: input.typebotId },
+      select: {
+        id: true,
+        groups: true,
+        workspace: {
+          select: {
+            id: true,
+            isSuspended: true,
+            isPastDue: true,
+            members: { select: { userId: true } },
+          },
+        },
+        collaborators: { select: { userId: true, type: true } },
+      },
+    })
+    if (!typebot || (await isReadTypebotForbidden(typebot, user)))
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Typebot not found' })
+
+    const result = await prisma.result.findFirst({
+      where: { id: input.resultId, typebotId: input.typebotId },
+      select: { lastChatSessionId: true },
+    })
+    if (!result?.lastChatSessionId) return { typebot: null }
+
+    const session = await prisma.chatSession.findUnique({
+      where: { id: result.lastChatSessionId },
+      select: { state: true },
+    })
+    if (!session?.state) return { typebot: null }
+
+    const state = session.state as any
+
+    // v3 and v2 store the typebot in typebotsQueue[0].typebot
+    if (state.typebotsQueue?.[0]?.typebot) {
+      return { typebot: state.typebotsQueue[0].typebot }
+    }
+    // v1 stores it in state.typebot
+    if (state.typebot) {
+      return { typebot: state.typebot }
+    }
+
+    return { typebot: null }
+  })

--- a/apps/builder/src/features/results/api/router.ts
+++ b/apps/builder/src/features/results/api/router.ts
@@ -3,10 +3,12 @@ import { deleteResults } from './deleteResults'
 import { getResultLogs } from './getResultLogs'
 import { getResults } from './getResults'
 import { getResult } from './getResult'
+import { getSessionTypebot } from './getSessionTypebot'
 
 export const resultsRouter = router({
   getResults,
   getResult,
   deleteResults,
   getResultLogs,
+  getSessionTypebot,
 })

--- a/apps/builder/src/features/results/components/FlowReplayModal.tsx
+++ b/apps/builder/src/features/results/components/FlowReplayModal.tsx
@@ -1,0 +1,317 @@
+import {
+  Badge,
+  Flex,
+  HStack,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Spinner,
+  Text,
+  useColorModeValue,
+} from '@chakra-ui/react'
+import React, { useMemo } from 'react'
+import { isDefined } from '@typebot.io/lib'
+import { useTypebot } from '@/features/editor/providers/TypebotProvider'
+import { useResults } from '../ResultsProvider'
+import { Graph } from '@/features/graph/components/Graph'
+import { GraphProvider } from '@/features/graph/providers/GraphProvider'
+import { EventsCoordinatesProvider } from '@/features/graph/providers/EventsCoordinateProvider'
+import { Edge, VisitedBlockEntry } from '@typebot.io/schemas'
+import { trpc } from '@/lib/trpc'
+
+type Props = {
+  resultId: string | null
+  onClose: () => void
+}
+
+const statusDisplay: Record<
+  string,
+  { label: string; colorScheme: string }
+> = {
+  completed: { label: 'Completed', colorScheme: 'green' },
+  error: { label: 'Error', colorScheme: 'red' },
+  abandoned: { label: 'Abandoned', colorScheme: 'purple' },
+  in_progress: { label: 'In Progress', colorScheme: 'gray' },
+}
+
+const blockStatusColors: Record<string, { border: string; bg: string }> = {
+  ok: { border: '#22c55e', bg: 'rgba(34, 197, 94, 0.15)' },
+  error: { border: '#ef4444', bg: 'rgba(239, 68, 68, 0.15)' },
+  dead_end: { border: '#ef4444', bg: 'rgba(239, 68, 68, 0.15)' },
+  abandoned: { border: '#a855f7', bg: 'rgba(168, 85, 247, 0.15)' },
+}
+
+const edgePathColors: Record<string, string> = Object.fromEntries(
+  Object.entries(blockStatusColors).map(([key, val]) => [key, val.border])
+)
+
+const findEdgeBetweenGroups = (
+  edges: Edge[],
+  fromBlockId: string,
+  fromGroupId: string,
+  toGroupId: string,
+  visitedBlocks: VisitedBlockEntry[]
+): Edge | undefined =>
+  edges.find(
+    (e) =>
+      'blockId' in e.from &&
+      e.from.blockId === fromBlockId &&
+      e.to.groupId === toGroupId
+  ) ??
+  edges.find(
+    (e) =>
+      'blockId' in e.from &&
+      e.to.groupId === toGroupId &&
+      visitedBlocks.some(
+        (vb) => vb.groupId === fromGroupId && vb.blockId === e.from.blockId
+      )
+  )
+
+const computeHighlightedEdges = (
+  visitedBlocks: VisitedBlockEntry[],
+  edges: Edge[]
+): Map<string, string> => {
+  const highlighted = new Map<string, string>()
+  if (visitedBlocks.length === 0) return highlighted
+
+  const resolveColor = (status: string) =>
+    edgePathColors[status] ?? edgePathColors.ok
+
+  const firstBlock = visitedBlocks[0]
+  const startEdge = edges.find(
+    (e) => 'eventId' in e.from && e.to.groupId === firstBlock.groupId
+  )
+  if (startEdge) {
+    highlighted.set(startEdge.id, resolveColor(firstBlock.status))
+  }
+
+  for (let i = 0; i < visitedBlocks.length - 1; i++) {
+    const current = visitedBlocks[i]
+    const next = visitedBlocks[i + 1]
+    if (current.groupId === next.groupId) continue
+
+    const edge = findEdgeBetweenGroups(
+      edges,
+      current.blockId,
+      current.groupId,
+      next.groupId,
+      visitedBlocks
+    )
+    if (edge) {
+      highlighted.set(edge.id, resolveColor(next.status))
+    }
+  }
+  return highlighted
+}
+
+export const FlowReplayModal = ({ resultId, onClose }: Props) => {
+  const { typebot, publishedTypebot } = useTypebot()
+  const { flatResults } = useResults()
+  const bgColor = useColorModeValue('#f4f5f8', 'gray.850')
+  const bgPattern = useColorModeValue(
+    'radial-gradient(#c6d0e1 1px, transparent 0)',
+    'radial-gradient(#2f2f39 1px, transparent 0)'
+  )
+
+  const result = useMemo(
+    () =>
+      isDefined(resultId)
+        ? flatResults.find((r) => r.id === resultId)
+        : undefined,
+    [resultId, flatResults]
+  )
+
+  const { data: sessionData, isLoading: isLoadingSession } =
+    trpc.results.getSessionTypebot.useQuery(
+      {
+        typebotId: typebot?.id as string,
+        resultId: resultId as string,
+      },
+      { enabled: isDefined(resultId) && isDefined(typebot?.id) }
+    )
+
+  const replayTypebot = useMemo(() => {
+    if (sessionData?.typebot) {
+      const snap = sessionData.typebot as any
+      return {
+        ...snap,
+        typebotId: snap.typebotId ?? typebot?.id ?? '',
+        events: snap.events ?? publishedTypebot?.events ?? [],
+        groups: snap.groups ?? [],
+        edges: snap.edges ?? [],
+        variables: snap.variables ?? [],
+      }
+    }
+    return publishedTypebot ?? null
+  }, [sessionData, publishedTypebot, typebot?.id])
+
+  const visitedBlocks: VisitedBlockEntry[] = useMemo(() => {
+    if (!result) return []
+    const blocks = Array.isArray(result.visitedBlocks)
+      ? [...result.visitedBlocks]
+      : []
+    if (
+      blocks.length > 0 &&
+      result.status === 'abandoned' &&
+      blocks[blocks.length - 1].status === 'ok'
+    ) {
+      blocks[blocks.length - 1] = {
+        ...blocks[blocks.length - 1],
+        status: 'abandoned',
+      }
+    }
+    return blocks
+  }, [result])
+
+  const highlightedEdges = useMemo(() => {
+    if (!visitedBlocks.length || !replayTypebot) return new Map()
+    return computeHighlightedEdges(visitedBlocks, replayTypebot.edges)
+  }, [visitedBlocks, replayTypebot])
+
+  const dynamicStyles = useMemo(() => {
+    if (!visitedBlocks.length) return ''
+
+    const visitedGroupIds = new Set(visitedBlocks.map((b) => b.groupId))
+    const visitedGroupSelectors = Array.from(visitedGroupIds)
+      .map((gid) => `[id="group-${gid}"]`)
+      .join(', ')
+    const visitedEdgeSelectors = Array.from(highlightedEdges.keys())
+      .map((eid) => `[data-edge-id="${eid}"]`)
+      .join(', ')
+
+    const dimStyles = [
+      `[data-testid="group"] { opacity: 0.3; transition: opacity 0.2s; }`,
+      `[data-testid="edge"], [data-testid="clickable-edge"] { opacity: 0.3; transition: opacity 0.2s; }`,
+      visitedGroupSelectors
+        ? `${visitedGroupSelectors} { opacity: 1 !important; }`
+        : '',
+      visitedEdgeSelectors
+        ? `${visitedEdgeSelectors} { opacity: 1 !important; }`
+        : '',
+    ]
+      .filter(Boolean)
+      .join('\n')
+
+    const blockStyles = visitedBlocks
+      .map((block) => {
+        const colors = blockStatusColors[block.status] ?? blockStatusColors.ok
+        return `[data-testid="block ${block.blockId}"] { border: 2px solid ${colors.border} !important; background-color: ${colors.bg} !important; border-radius: 6px; }`
+      })
+      .join('\n')
+
+    const edgeStyles = Array.from(highlightedEdges.entries())
+      .map(
+        ([edgeId, color]) =>
+          `[data-edge-id="${edgeId}"] { stroke: ${color} !important; stroke-width: 3px !important; }`
+      )
+      .join('\n')
+
+    return `${dimStyles}\n${blockStyles}\n${edgeStyles}`
+  }, [visitedBlocks, highlightedEdges])
+
+  const status = result?.status ?? 'in_progress'
+  const helpdeskId = result?.helpdeskId
+  const statusCfg = statusDisplay[status] ?? statusDisplay.in_progress
+
+  const duration = useMemo(() => {
+    if (!result?.createdAt || !visitedBlocks.length) return null
+    const start = new Date(result.createdAt).getTime()
+    const lastTimestamp = visitedBlocks[visitedBlocks.length - 1]?.timestamp
+    if (!lastTimestamp) return null
+    const end = new Date(lastTimestamp).getTime()
+    const diffMs = end - start
+    if (diffMs < 0) return null
+    const mins = Math.floor(diffMs / 60000)
+    const secs = Math.floor((diffMs % 60000) / 1000)
+    return `${mins}m ${secs}s`
+  }, [result, visitedBlocks])
+
+  const isLoading = isLoadingSession || !replayTypebot
+
+  if (!publishedTypebot) return null
+
+  return (
+    <Modal
+      isOpen={isDefined(result)}
+      onClose={onClose}
+      size="full"
+      scrollBehavior="inside"
+    >
+      <ModalOverlay />
+      <ModalContent m="4" maxH="calc(100vh - 32px)" borderRadius="xl">
+        <ModalCloseButton zIndex={10} />
+        <ModalHeader pb="2">
+          <HStack spacing="4" flexWrap="wrap">
+            {helpdeskId && (
+              <Text fontSize="sm" color="gray.500">
+                Helpdesk: <strong>{helpdeskId}</strong>
+              </Text>
+            )}
+            {result?.createdAt && (
+              <Text fontSize="sm" color="gray.500">
+                {new Date(result.createdAt).toLocaleString()}
+              </Text>
+            )}
+            <Badge colorScheme={statusCfg.colorScheme}>
+              {statusCfg.label}
+            </Badge>
+            {duration && (
+              <Text fontSize="sm" color="gray.500">
+                Duração: {duration}
+              </Text>
+            )}
+            <Text fontSize="sm" color="gray.500">
+              {visitedBlocks.length} bloco
+              {visitedBlocks.length !== 1 ? 's' : ''} visitados
+            </Text>
+            {sessionData?.typebot && (
+              <Badge colorScheme="blue" variant="subtle" fontSize="2xs">
+                Snapshot da sessão
+              </Badge>
+            )}
+          </HStack>
+        </ModalHeader>
+        <ModalBody p="0" overflow="hidden" flex="1">
+          <style>{dynamicStyles}</style>
+          <Flex
+            w="full"
+            h="full"
+            minH="calc(100vh - 140px)"
+            pos="relative"
+            bgColor={bgColor}
+            backgroundImage={bgPattern}
+            backgroundSize="40px 40px"
+            backgroundPosition="-19px -19px"
+            justifyContent="center"
+          >
+            {isLoading ? (
+              <Flex
+                justify="center"
+                align="center"
+                boxSize="full"
+                bgColor="rgba(255, 255, 255, 0.5)"
+              >
+                <Spinner color="gray" />
+              </Flex>
+            ) : (
+              <GraphProvider isReadOnly isAnalytics={false}>
+                <EventsCoordinatesProvider
+                  events={replayTypebot.events}
+                >
+                  <Graph
+                    flex="1"
+                    typebot={replayTypebot}
+                    highlightedEdges={highlightedEdges}
+                  />
+                </EventsCoordinatesProvider>
+              </GraphProvider>
+            )}
+          </Flex>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/apps/builder/src/features/results/components/ResultsTableContainer.tsx
+++ b/apps/builder/src/features/results/components/ResultsTableContainer.tsx
@@ -4,6 +4,7 @@ import { LogsModal } from './LogsModal'
 import { useTypebot } from '@/features/editor/providers/TypebotProvider'
 import { useResults } from '../ResultsProvider'
 import { ResultModal } from './ResultModal'
+import { FlowReplayModal } from './FlowReplayModal'
 import { ResultsTable } from './table/ResultsTable'
 import { useRouter } from 'next/router'
 import { timeFilterValues } from '@/features/analytics/constants'
@@ -11,10 +12,14 @@ import { timeFilterValues } from '@/features/analytics/constants'
 type Props = {
   timeFilter: (typeof timeFilterValues)[number]
   onTimeFilterChange: (timeFilter: (typeof timeFilterValues)[number]) => void
+  helpdeskIdFilter: string
+  onHelpdeskIdFilterChange: (value: string) => void
 }
 export const ResultsTableContainer = ({
   timeFilter,
   onTimeFilterChange,
+  helpdeskIdFilter,
+  onHelpdeskIdFilterChange,
 }: Props) => {
   const { query } = useRouter()
   const {
@@ -29,10 +34,15 @@ export const ResultsTableContainer = ({
     string | null
   >(null)
   const [expandedResultId, setExpandedResultId] = useState<string | null>(null)
+  const [flowReplayResultId, setFlowReplayResultId] = useState<string | null>(
+    null
+  )
 
   const handleLogsModalClose = () => setInspectingLogsResultId(null)
 
   const handleResultModalClose = () => setExpandedResultId(null)
+
+  const handleFlowReplayClose = () => setFlowReplayResultId(null)
 
   const handleLogOpenIndex = (index: number) => () => {
     if (!results[index]) return
@@ -42,6 +52,11 @@ export const ResultsTableContainer = ({
   const handleResultExpandIndex = (index: number) => () => {
     if (!results[index]) return
     setExpandedResultId(results[index].id)
+  }
+
+  const handleFlowReplayIndex = (index: number) => () => {
+    if (!results[index]) return
+    setFlowReplayResultId(results[index].id)
   }
 
   useEffect(() => {
@@ -61,18 +76,26 @@ export const ResultsTableContainer = ({
         resultId={expandedResultId}
         onClose={handleResultModalClose}
       />
+      <FlowReplayModal
+        resultId={flowReplayResultId}
+        onClose={handleFlowReplayClose}
+      />
 
       {typebot && (
         <ResultsTable
           preferences={typebot.resultsTablePreferences ?? undefined}
           resultHeader={resultHeader}
           data={tableData}
+          results={results}
           onScrollToBottom={fetchNextPage}
           hasMore={hasNextPage}
           timeFilter={timeFilter}
           onLogOpenIndex={handleLogOpenIndex}
           onResultExpandIndex={handleResultExpandIndex}
+          onFlowReplayIndex={handleFlowReplayIndex}
           onTimeFilterChange={onTimeFilterChange}
+          helpdeskIdFilter={helpdeskIdFilter}
+          onHelpdeskIdFilterChange={onHelpdeskIdFilterChange}
         />
       )}
     </Stack>

--- a/apps/builder/src/features/results/components/table/Cell.tsx
+++ b/apps/builder/src/features/results/components/table/Cell.tsx
@@ -22,15 +22,20 @@ const Cell = ({
   cellIndex,
   onExpandButtonClick,
 }: Props) => {
+  const borderColor = useColorModeValue('gray.100', 'gray.700')
+  const textColor = useColorModeValue('gray.700', 'gray.200')
+
   return (
     <chakra.td
       key={cell.id}
       px="4"
-      py="2"
-      borderWidth={rowIndex === 0 ? '0 1px 1px 1px' : '1px'}
-      borderColor={useColorModeValue('gray.200', 'gray.700')}
+      py="2.5"
+      borderBottom="1px solid"
+      borderColor={borderColor}
       whiteSpace="pre-wrap"
       pos="relative"
+      fontSize="sm"
+      color={textColor}
       style={{
         minWidth: size,
         maxWidth: size,
@@ -48,11 +53,14 @@ const Cell = ({
         <Fade unmountOnExit in={isExpandButtonVisible && cellIndex === 1}>
           <Button
             leftIcon={<ExpandIcon />}
-            shadow="lg"
+            shadow="md"
             size="xs"
+            rounded="full"
+            colorScheme="blue"
+            variant="solid"
             onClick={onExpandButtonClick}
           >
-            Open
+            Abrir
           </Button>
         </Fade>
       </chakra.span>

--- a/apps/builder/src/features/results/components/table/HeaderRow.tsx
+++ b/apps/builder/src/features/results/components/table/HeaderRow.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 export const HeaderRow = ({ headerGroup, isTableScrolled }: Props) => {
   const borderColor = useColorModeValue(colors.gray[200], colors.gray[700])
-  const backgroundColor = useColorModeValue('white', colors.gray[900])
+  const backgroundColor = useColorModeValue(colors.gray[50], colors.gray[800])
 
   return (
     <tr key={headerGroup.id}>
@@ -21,17 +21,17 @@ export const HeaderRow = ({ headerGroup, isTableScrolled }: Props) => {
             key={header.id}
             px="4"
             py="3"
-            borderX="1px"
+            borderBottom="1px solid"
             borderColor={borderColor}
-            backgroundColor={isTableScrolled ? backgroundColor : undefined}
+            backgroundColor={backgroundColor}
             zIndex={10}
             pos="sticky"
             top="0"
             fontWeight="normal"
             whiteSpace="nowrap"
             wordBreak="normal"
+            textAlign="left"
             colSpan={header.colSpan}
-            shadow={`inset 0 1px 0 ${borderColor}, inset 0 -1px 0 ${borderColor}; `}
             style={{
               minWidth: header.getSize(),
               maxWidth: header.getSize(),

--- a/apps/builder/src/features/results/components/table/ResultsTable.tsx
+++ b/apps/builder/src/features/results/components/table/ResultsTable.tsx
@@ -1,17 +1,26 @@
 import {
+  Badge,
   Box,
   Button,
   chakra,
+  Flex,
   HStack,
+  IconButton,
+  Input,
+  InputGroup,
+  InputLeftElement,
   Stack,
   Text,
+  TextProps,
+  Tooltip,
   useColorModeValue,
 } from '@chakra-ui/react'
-import { AlignLeftTextIcon } from '@/components/icons'
+import { AlignLeftTextIcon, SearchIcon, CopyIcon, EyeIcon } from '@/components/icons'
 import {
   CellValueType,
   ResultHeaderCell,
   ResultsTablePreferences,
+  ResultWithAnswers,
   TableData,
 } from '@typebot.io/schemas'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
@@ -34,9 +43,47 @@ import { parseColumnsOrder } from '@typebot.io/results/parseColumnsOrder'
 import { TimeFilterDropdown } from '@/features/analytics/components/TimeFilterDropdown'
 import { timeFilterValues } from '@/features/analytics/constants'
 
+const columnHeaderProps: TextProps = {
+  fontWeight: 'semibold',
+  fontSize: 'xs',
+  textTransform: 'uppercase',
+  letterSpacing: 'wider',
+  color: 'gray.500',
+}
+
+const statusConfig: Record<
+  string,
+  { label: string; bg: string; color: string; dot: string }
+> = {
+  completed: {
+    label: 'Completo',
+    bg: 'green.50',
+    color: 'green.700',
+    dot: 'green.400',
+  },
+  error: {
+    label: 'Erro',
+    bg: 'red.50',
+    color: 'red.700',
+    dot: 'red.400',
+  },
+  abandoned: {
+    label: 'Abandonado',
+    bg: 'purple.50',
+    color: 'purple.700',
+    dot: 'purple.400',
+  },
+}
+
+const resolveDisplayStatus = (status: string): string => {
+  if (status === 'completed' || status === 'error') return status
+  return 'abandoned'
+}
+
 type ResultsTableProps = {
   resultHeader: ResultHeaderCell[]
   data: TableData[]
+  results: ResultWithAnswers[]
   hasMore?: boolean
   preferences?: ResultsTablePreferences
   timeFilter: (typeof timeFilterValues)[number]
@@ -44,11 +91,15 @@ type ResultsTableProps = {
   onScrollToBottom: () => void
   onLogOpenIndex: (index: number) => () => void
   onResultExpandIndex: (index: number) => () => void
+  onFlowReplayIndex: (index: number) => () => void
+  helpdeskIdFilter: string
+  onHelpdeskIdFilterChange: (value: string) => void
 }
 
 export const ResultsTable = ({
   resultHeader,
   data,
+  results,
   hasMore,
   preferences,
   timeFilter,
@@ -56,8 +107,14 @@ export const ResultsTable = ({
   onScrollToBottom,
   onLogOpenIndex,
   onResultExpandIndex,
+  onFlowReplayIndex,
+  helpdeskIdFilter,
+  onHelpdeskIdFilterChange,
 }: ResultsTableProps) => {
   const background = useColorModeValue('white', colors.gray[900])
+  const inputBg = useColorModeValue('white', 'gray.800')
+  const inputBorder = useColorModeValue('gray.200', 'gray.600')
+  const tableBorder = useColorModeValue('gray.200', 'gray.700')
   const { updateTypebot, currentUserMode } = useTypebot()
   const [rowSelection, setRowSelection] = useState<Record<string, boolean>>({})
   const [isTableScrolled, setIsTableScrolled] = useState(false)
@@ -143,6 +200,35 @@ export const ResultsTable = ({
           </div>
         ),
       },
+      {
+        id: '__helpdeskId',
+        enableResizing: false,
+        maxSize: 220,
+        header: () => <Text {...columnHeaderProps}>Helpdesk ID</Text>,
+        cell: ({ row }) => {
+          const result = results[row.index]
+          const helpdeskId = result?.helpdeskId
+          if (!helpdeskId) return <Text color="gray.300">—</Text>
+          return (
+            <HStack spacing="1">
+              <Text fontSize="sm" fontWeight="medium" fontFamily="mono" color="gray.700" isTruncated maxW="160px">
+                {helpdeskId}
+              </Text>
+              <Tooltip label="Copiar" hasArrow placement="top">
+                <IconButton
+                  aria-label="Copiar helpdesk ID"
+                  icon={<CopyIcon />}
+                  size="xs"
+                  variant="ghost"
+                  color="gray.400"
+                  _hover={{ color: 'blue.500' }}
+                  onClick={() => navigator.clipboard.writeText(helpdeskId)}
+                />
+              </Tooltip>
+            </HStack>
+          )
+        },
+      },
       ...resultHeader.map<ColumnDef<TableData>>((header) => ({
         id: header.id,
         accessorKey: header.id,
@@ -150,7 +236,7 @@ export const ResultsTable = ({
         header: () => (
           <HStack overflow="hidden" data-testid={`${header.label} header`}>
             <HeaderIcon header={header} />
-            <Text>{header.label}</Text>
+            <Text {...columnHeaderProps}>{header.label}</Text>
           </HStack>
         ),
         cell: (info) => {
@@ -160,23 +246,95 @@ export const ResultsTable = ({
         },
       })),
       {
+        id: '__visitedBlocksCount',
+        enableResizing: false,
+        maxSize: 120,
+        header: () => <Text {...columnHeaderProps}>Caminho</Text>,
+        cell: ({ row }) => {
+          const result = results[row.index]
+          const blocks = Array.isArray(result?.visitedBlocks)
+            ? result.visitedBlocks
+            : []
+          return (
+            <HStack spacing="1">
+              <Box w="6px" h="6px" rounded="full" bg="blue.300" />
+              <Text fontSize="sm" color="gray.600">
+                {blocks.length} bloco{blocks.length !== 1 ? 's' : ''}
+              </Text>
+            </HStack>
+          )
+        },
+      },
+      {
+        id: '__status',
+        enableResizing: false,
+        maxSize: 140,
+        header: () => <Text {...columnHeaderProps}>Status</Text>,
+        cell: ({ row }) => {
+          const result = results[row.index]
+          const rawStatus = result?.status ?? 'abandoned'
+          const displayStatus = resolveDisplayStatus(rawStatus)
+          const cfg = statusConfig[displayStatus] ?? statusConfig.abandoned
+          return (
+            <Badge
+              bg={cfg.bg}
+              color={cfg.color}
+              px="2.5"
+              py="1"
+              rounded="full"
+              fontSize="xs"
+              fontWeight="semibold"
+              display="flex"
+              alignItems="center"
+              gap="1.5"
+              w="fit-content"
+            >
+              <Box w="6px" h="6px" rounded="full" bg={cfg.dot} />
+              {cfg.label}
+            </Badge>
+          )
+        },
+      },
+      {
         id: 'logs',
         enableResizing: false,
         maxSize: 110,
-        header: () => (
-          <HStack>
-            <AlignLeftTextIcon />
-            <Text>Logs</Text>
-          </HStack>
-        ),
+        header: () => <Text {...columnHeaderProps}>Logs</Text>,
         cell: ({ row }) => (
-          <Button size="sm" onClick={onLogOpenIndex(row.index)}>
-            See logs
+          <Button
+            size="xs"
+            variant="ghost"
+            color="gray.500"
+            fontWeight="medium"
+            leftIcon={<AlignLeftTextIcon />}
+            _hover={{ bg: 'gray.100', color: 'gray.700' }}
+            onClick={onLogOpenIndex(row.index)}
+          >
+            Ver logs
+          </Button>
+        ),
+      },
+      {
+        id: '__flowReplay',
+        enableResizing: false,
+        maxSize: 130,
+        header: () => <Text {...columnHeaderProps}>Fluxo</Text>,
+        cell: ({ row }) => (
+          <Button
+            size="xs"
+            variant="outline"
+            colorScheme="blue"
+            fontWeight="medium"
+            leftIcon={<EyeIcon />}
+            rounded="full"
+            onClick={onFlowReplayIndex(row.index)}
+          >
+            Ver fluxo
           </Button>
         ),
       },
     ],
-    [onLogOpenIndex, resultHeader]
+    [onLogOpenIndex, onFlowReplayIndex, resultHeader, results]
   )
 
   const instance = useReactTable({
@@ -215,47 +373,72 @@ export const ResultsTable = ({
     return () => {
       observer.disconnect()
     }
-    // We need to rerun this effect when the bottomElement changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [handleObserver, bottomElement.current])
 
   return (
-    <Stack maxW="1600px" px="4" overflowY="hidden" spacing={6}>
-      <HStack w="full" justifyContent="flex-end">
-        {currentUserMode === 'write' && (
-          <SelectionToolbar
-            selectedResultsId={Object.keys(rowSelection)}
-            onClearSelection={() => setRowSelection({})}
+    <Stack maxW="1600px" px="4" overflowY="hidden" spacing={4}>
+      <Flex
+        w="full"
+        justify="space-between"
+        align="center"
+        py="2"
+        gap="3"
+        flexWrap="wrap"
+      >
+        <HStack spacing="3" flex="1" minW="0">
+          <InputGroup size="sm" maxW="280px">
+            <InputLeftElement pointerEvents="none">
+              <SearchIcon color="gray.400" boxSize="3.5" />
+            </InputLeftElement>
+            <Input
+              placeholder="Buscar por helpdeskId..."
+              value={helpdeskIdFilter}
+              onChange={(e) => onHelpdeskIdFilterChange(e.target.value)}
+              rounded="lg"
+              bg={inputBg}
+              borderColor={inputBorder}
+              fontSize="sm"
+              _placeholder={{ color: 'gray.400' }}
+              _focus={{ borderColor: 'blue.400', boxShadow: '0 0 0 1px var(--chakra-colors-blue-400)' }}
+            />
+          </InputGroup>
+          {currentUserMode === 'write' && (
+            <SelectionToolbar
+              selectedResultsId={Object.keys(rowSelection)}
+              onClearSelection={() => setRowSelection({})}
+            />
+          )}
+        </HStack>
+        <HStack spacing="2">
+          <TimeFilterDropdown
+            timeFilter={timeFilter}
+            onTimeFilterChange={onTimeFilterChange}
+            size="sm"
           />
-        )}
-        <TimeFilterDropdown
-          timeFilter={timeFilter}
-          onTimeFilterChange={onTimeFilterChange}
-          size="sm"
-        />
-        <TableSettingsButton
-          resultHeader={resultHeader}
-          columnVisibility={columnsVisibility}
-          setColumnVisibility={changeColumnVisibility}
-          columnOrder={columnsOrder}
-          onColumnOrderChange={changeColumnOrder}
-        />
-      </HStack>
+          <TableSettingsButton
+            resultHeader={resultHeader}
+            columnVisibility={columnsVisibility}
+            setColumnVisibility={changeColumnVisibility}
+            columnOrder={columnsOrder}
+            onColumnOrderChange={changeColumnOrder}
+          />
+        </HStack>
+      </Flex>
+
       <Box
         ref={tableWrapper}
         overflow="auto"
-        rounded="md"
+        rounded="xl"
+        border="1px solid"
+        borderColor={tableBorder}
         data-testid="results-table"
-        backgroundImage={`linear-gradient(to right, ${background}, ${background}), linear-gradient(to right, ${background}, ${background}),linear-gradient(to right, rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0)),linear-gradient(to left, rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0));`}
-        backgroundPosition="left center, right center, left center, right center"
-        backgroundRepeat="no-repeat"
-        backgroundSize="30px 100%, 30px 100%, 15px 100%, 15px 100%"
-        backgroundAttachment="local, local, scroll, scroll"
+        bg={background}
         onScroll={(e) =>
           setIsTableScrolled((e.target as HTMLElement).scrollTop > 0)
         }
       >
-        <chakra.table rounded="md">
+        <chakra.table w="full">
           <thead>
             {instance.getHeaderGroups().map((headerGroup) => (
               <HeaderRow

--- a/apps/builder/src/features/results/components/table/Row.tsx
+++ b/apps/builder/src/features/results/components/table/Row.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { Row as RowProps } from '@tanstack/react-table'
 import Cell from './Cell'
 import { TableData } from '@typebot.io/schemas'
+import { chakra, useColorModeValue } from '@chakra-ui/react'
 
 type Props = {
   row: RowProps<TableData>
@@ -17,20 +18,24 @@ export const Row = ({
   isSelected,
 }: Props) => {
   const [isExpandButtonVisible, setIsExpandButtonVisible] = useState(false)
+  const hoverBg = useColorModeValue('gray.50', 'gray.800')
 
   const showExpandButton = () => setIsExpandButtonVisible(true)
   const hideExpandButton = () => setIsExpandButtonVisible(false)
   return (
-    <tr
+    <chakra.tr
       key={row.id}
       data-rowid={row.id}
-      ref={(ref) => {
+      role="group"
+      ref={(ref: HTMLTableRowElement | null) => {
         if (bottomElement && bottomElement.current?.dataset.rowid !== row.id)
           bottomElement.current = ref
       }}
       onMouseEnter={showExpandButton}
       onClick={showExpandButton}
       onMouseLeave={hideExpandButton}
+      transition="background 0.1s"
+      _hover={{ bg: hoverBg }}
     >
       {row.getVisibleCells().map((cell, cellIndex) => (
         <Cell
@@ -44,6 +49,6 @@ export const Row = ({
           isSelected={isSelected}
         />
       ))}
-    </tr>
+    </chakra.tr>
   )
 }

--- a/packages/results/parseColumnsOrder.ts
+++ b/packages/results/parseColumnsOrder.ts
@@ -1,15 +1,27 @@
 import { ResultHeaderCell } from '@typebot.io/schemas'
 
+const fixedPrefix = ['select', '__helpdeskId']
+const fixedSuffix = ['__visitedBlocksCount', '__status', 'logs', '__flowReplay']
+
 export const parseColumnsOrder = (
   existingOrder: string[] | undefined,
   resultHeader: ResultHeaderCell[]
-) =>
-  existingOrder
+) => {
+  const dynamicIds = existingOrder
     ? [
-        ...existingOrder.slice(0, -1),
+        ...existingOrder.filter(
+          (id) => !fixedPrefix.includes(id) && !fixedSuffix.includes(id)
+        ),
         ...resultHeader
-          .filter((header) => !existingOrder.includes(header.id))
+          .filter(
+            (header) =>
+              !existingOrder.includes(header.id) &&
+              !fixedPrefix.includes(header.id) &&
+              !fixedSuffix.includes(header.id)
+          )
           .map((h) => h.id),
-        'logs',
       ]
-    : ['select', ...resultHeader.map((h) => h.id), 'logs']
+    : resultHeader.map((h) => h.id)
+
+  return [...fixedPrefix, ...dynamicIds, ...fixedSuffix]
+}


### PR DESCRIPTION
## Contexto

Adiciona um botão "Ver fluxo" em cada linha da tabela de resultados, abrindo um modal que exibe o replay visual da sessão do usuário — mostrando o caminho percorrido no fluxo.

Isso facilita a análise de sessões individuais sem precisar sair da tela de resultados.

## Alterações principais

- Novo endpoint `getSessionTypebot` para buscar dados da sessão
- Componente `FlowReplayModal` com visualização do fluxo percorrido
- Coluna "Ver fluxo" adicionada na tabela de resultados
- Ajustes em `parseColumnsOrder` para suportar a nova coluna


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated endpoint that reads stored chat session state and uses it to render a session-specific flow snapshot in the UI; mistakes could expose data across workspaces or break results rendering. Mostly additive UI/table changes, but touches data access and column ordering logic.
> 
> **Overview**
> Adds a new `results.getSessionTypebot` tRPC procedure that validates read access to a `typebot`, resolves the `result`’s `lastChatSessionId`, and returns the stored typebot snapshot from the chat session state (supporting multiple legacy state shapes).
> 
> Introduces `FlowReplayModal`, wired from the results table via a new **“Ver fluxo”** action, to render a read-only graph replay with visited blocks/edges highlighted and session metadata (status, duration, helpdesk ID).
> 
> Updates the results table UX by adding fixed columns for **Helpdesk ID** (with copy action), **path length**, and **status**, plus a helpdesk ID search input; adjusts table styling and updates `parseColumnsOrder` to keep new fixed columns pinned at the start/end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15282dfe7d77e8cc12767e3ac6230264e77f1cd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a "Ver fluxo" (flow replay) button to each row of the results table, opening a full-screen modal that renders the typebot graph with visited nodes and edges highlighted to show the path a user took through a session. It also introduces new UI columns (`helpdeskId`, `status`, `caminho`) and a `helpdeskId` search input, along with a new tRPC endpoint (`getSessionTypebot`) that reads session state snapshots from the database.

The feature concept is solid and the graph-rendering approach is clever, but there are two blocking issues before it can ship:

- **TypeScript build error**: `ResultsTableContainer` now declares `helpdeskIdFilter` and `onHelpdeskIdFilterChange` as required props, but `ResultsPage.tsx` (its only caller) was not updated to provide them. The project will not compile.
- **Non-functional filter**: The `helpdeskId` search input is rendered and wired to state, but the filter value is never applied to the `data` / `results` arrays anywhere in the call chain \u2014 typing in the box has no effect on the displayed rows.

Additional P2 items:
- Status labels in `FlowReplayModal.tsx` are in English (`Completed`, `Error`, \u2026) while the equivalent labels in `ResultsTable.tsx` are in ptBR (`Completo`, `Erro`, \u2026), creating a language inconsistency in the same product surface.
- Block/edge IDs are interpolated directly into a `<style>` string without sanitization; while safe today with UUID-shaped IDs, the pattern is fragile.
- The modal's `isOpen` is driven by `isDefined(result)` (looked up from `flatResults`) rather than `isDefined(resultId)`, meaning a deep-linked result that hasn't loaded into the flat list yet will silently keep the modal closed.

<h3>Confidence Score: 2/5</h3>

Not safe to merge — the PR will not compile and ships a visually present but fully non-functional search filter.

Two concrete blocking issues: a TypeScript build error from missing required props in ResultsPage.tsx, and a helpdeskId filter that renders but does nothing. Both must be fixed before the feature can be used in production.

ResultsTableContainer.tsx and ResultsTable.tsx are the most critical; ResultsPage.tsx needs the new props wired up.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/builder/src/features/results/api/getSessionTypebot.ts | New tRPC endpoint that fetches a session's typebot snapshot from chatSession state; authorization is properly gated via isReadTypebotForbidden, handles v1/v2/v3 state shapes. |
| apps/builder/src/features/results/api/router.ts | Trivial addition of getSessionTypebot to the results router; no issues. |
| apps/builder/src/features/results/components/FlowReplayModal.tsx | New modal displaying the flow replay graph; has inconsistent English status labels vs rest of the UI (ptBR), an isOpen logic gap when result isn't yet in flatResults, and unescaped IDs in injected CSS. |
| apps/builder/src/features/results/components/ResultsTableContainer.tsx | Adds FlowReplayModal integration and two new required props (helpdeskIdFilter, onHelpdeskIdFilterChange) that are NOT passed by the parent ResultsPage.tsx — will cause a TypeScript build error. |
| apps/builder/src/features/results/components/table/ResultsTable.tsx | Adds helpdeskId, status, visited-blocks-count, and flow-replay columns; renders a helpdeskId search input that is purely cosmetic — the filter value is never applied to the underlying data. |
| apps/builder/src/features/results/components/table/Cell.tsx | Cosmetic styling improvements (border simplification, font size, hover button style); hooks moved out of JSX correctly; Open → Abrir localization. |
| apps/builder/src/features/results/components/table/HeaderRow.tsx | Styling cleanup — background always shown, border simplified, text-align added; no functional changes. |
| apps/builder/src/features/results/components/table/Row.tsx | Upgrades plain tr to chakra.tr for hover styling; straightforward change with no logic impact. |
| packages/results/parseColumnsOrder.ts | Refactored to separate fixed-prefix and fixed-suffix columns from user-reorderable dynamic columns; logic is correct, though existing user column orders that include the now-fixed IDs will have those columns relocated on next render. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/builder/src/features/results/components/ResultsPage.tsx`, line 129-132 ([link](https://github.com/cloudhumans/typebot.io/blob/15282dfe7d77e8cc12767e3ac6230264e77f1cd0/apps/builder/src/features/results/components/ResultsPage.tsx#L129-L132)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=7" align="top"></a> **Missing required props causes TypeScript compilation failure**

   `ResultsTableContainer` was updated to require two new props — `helpdeskIdFilter: string` and `onHelpdeskIdFilterChange: (value: string) => void` — but `ResultsPage.tsx` still calls it without providing them. TypeScript will reject this build.

   You need to lift the `helpdeskIdFilter` state up into `ResultsPage` and pass it down:

   

   And add the corresponding state at the top of `ResultsPage`:

   ```tsx
   const [helpdeskIdFilter, setHelpdeskIdFilter] = useState('')
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/builder/src/features/results/components/ResultsPage.tsx
   Line: 129-132

   Comment:
   **Missing required props causes TypeScript compilation failure**

   `ResultsTableContainer` was updated to require two new props — `helpdeskIdFilter: string` and `onHelpdeskIdFilterChange: (value: string) => void` — but `ResultsPage.tsx` still calls it without providing them. TypeScript will reject this build.

   You need to lift the `helpdeskIdFilter` state up into `ResultsPage` and pass it down:

   

   And add the corresponding state at the top of `ResultsPage`:

   ```tsx
   const [helpdeskIdFilter, setHelpdeskIdFilter] = useState('')
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fbuilder%2Fsrc%2Ffeatures%2Fresults%2Fcomponents%2FResultsPage.tsx%0ALine%3A%20129-132%0A%0AComment%3A%0A**Missing%20required%20props%20causes%20TypeScript%20compilation%20failure**%0A%0A%60ResultsTableContainer%60%20was%20updated%20to%20require%20two%20new%20props%20%E2%80%94%20%60helpdeskIdFilter%3A%20string%60%20and%20%60onHelpdeskIdFilterChange%3A%20%28value%3A%20string%29%20%3D%3E%20void%60%20%E2%80%94%20but%20%60ResultsPage.tsx%60%20still%20calls%20it%20without%20providing%20them.%20TypeScript%20will%20reject%20this%20build.%0A%0AYou%20need%20to%20lift%20the%20%60helpdeskIdFilter%60%20state%20up%20into%20%60ResultsPage%60%20and%20pass%20it%20down%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CResultsTableContainer%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20timeFilter%3D%7BtimeFilter%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onTimeFilterChange%3D%7BsetTimeFilter%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20helpdeskIdFilter%3D%7BhelpdeskIdFilter%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onHelpdeskIdFilterChange%3D%7BsetHelpdeskIdFilter%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%3E%0A%60%60%60%0A%0AAnd%20add%20the%20corresponding%20state%20at%20the%20top%20of%20%60ResultsPage%60%3A%0A%0A%60%60%60tsx%0Aconst%20%5BhelpdeskIdFilter%2C%20setHelpdeskIdFilter%5D%20%3D%20useState%28''%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudhumans%2Ftypebot.io"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fbuilder%2Fsrc%2Ffeatures%2Fresults%2Fcomponents%2FResultsPage.tsx%0ALine%3A%20129-132%0A%0AComment%3A%0A**Missing%20required%20props%20causes%20TypeScript%20compilation%20failure**%0A%0A%60ResultsTableContainer%60%20was%20updated%20to%20require%20two%20new%20props%20%E2%80%94%20%60helpdeskIdFilter%3A%20string%60%20and%20%60onHelpdeskIdFilterChange%3A%20%28value%3A%20string%29%20%3D%3E%20void%60%20%E2%80%94%20but%20%60ResultsPage.tsx%60%20still%20calls%20it%20without%20providing%20them.%20TypeScript%20will%20reject%20this%20build.%0A%0AYou%20need%20to%20lift%20the%20%60helpdeskIdFilter%60%20state%20up%20into%20%60ResultsPage%60%20and%20pass%20it%20down%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CResultsTableContainer%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20timeFilter%3D%7BtimeFilter%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onTimeFilterChange%3D%7BsetTimeFilter%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20helpdeskIdFilter%3D%7BhelpdeskIdFilter%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onHelpdeskIdFilterChange%3D%7BsetHelpdeskIdFilter%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%3E%0A%60%60%60%0A%0AAnd%20add%20the%20corresponding%20state%20at%20the%20top%20of%20%60ResultsPage%60%3A%0A%0A%60%60%60tsx%0Aconst%20%5BhelpdeskIdFilter%2C%20setHelpdeskIdFilter%5D%20%3D%20useState%28''%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fresults%2Fcomponents%2FResultsPage.tsx%3A129-132%0A**Missing%20required%20props%20causes%20TypeScript%20compilation%20failure**%0A%0A%60ResultsTableContainer%60%20was%20updated%20to%20require%20two%20new%20props%20%E2%80%94%20%60helpdeskIdFilter%3A%20string%60%20and%20%60onHelpdeskIdFilterChange%3A%20%28value%3A%20string%29%20%3D%3E%20void%60%20%E2%80%94%20but%20%60ResultsPage.tsx%60%20still%20calls%20it%20without%20providing%20them.%20TypeScript%20will%20reject%20this%20build.%0A%0AYou%20need%20to%20lift%20the%20%60helpdeskIdFilter%60%20state%20up%20into%20%60ResultsPage%60%20and%20pass%20it%20down%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CResultsTableContainer%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20timeFilter%3D%7BtimeFilter%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onTimeFilterChange%3D%7BsetTimeFilter%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20helpdeskIdFilter%3D%7BhelpdeskIdFilter%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onHelpdeskIdFilterChange%3D%7BsetHelpdeskIdFilter%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%3E%0A%60%60%60%0A%0AAnd%20add%20the%20corresponding%20state%20at%20the%20top%20of%20%60ResultsPage%60%3A%0A%0A%60%60%60tsx%0Aconst%20%5BhelpdeskIdFilter%2C%20setHelpdeskIdFilter%5D%20%3D%20useState%28''%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%205%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fresults%2Fcomponents%2Ftable%2FResultsTable.tsx%3A394-397%0A**Filter%20input%20is%20purely%20cosmetic%20%E2%80%94%20no%20actual%20filtering%20occurs**%0A%0AThe%20%60helpdeskIdFilter%60%20value%20is%20only%20bound%20to%20the%20%60%3CInput%3E%60%20for%20display%3B%20it%20is%20never%20used%20to%20filter%20%60data%60%20or%20%60results%60.%20Typing%20in%20the%20search%20box%20has%20no%20effect%20on%20the%20rows%20shown.%0A%0AFiltering%20needs%20to%20happen%20somewhere%20in%20the%20pipeline.%20The%20two%20realistic%20options%20are%3A%0A%0A-%20**Client-side**%3A%20filter%20the%20%60results%60%20array%20in%20%60ResultsTable%60%20%28or%20the%20parent%29%20before%20passing%20it%20to%20%60useReactTable%60.%0A-%20**Server-side**%3A%20pass%20%60helpdeskIdFilter%60%20into%20%60ResultsProvider%60%20%2F%20the%20tRPC%20%60getResults%60%20query%20as%20a%20query%20parameter%20and%20let%20the%20API%20filter.%0A%0AWithout%20one%20of%20these%2C%20the%20feature%20ships%20as%20a%20broken%20UI%20element.%0A%0A%23%23%23%20Issue%203%20of%205%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fresults%2Fcomponents%2FFlowReplayModal.tsx%3A238%0A**Modal%20never%20opens%20when%20result%20is%20not%20yet%20in%20%60flatResults%60**%0A%0A%60isOpen%3D%7BisDefined%28result%29%7D%60%20is%20evaluated%20against%20%60flatResults%60.%20This%20is%20correct%20when%20the%20user%20clicks%20a%20row%20already%20loaded%20in%20memory.%20However%2C%20when%20%60resultId%60%20is%20set%20but%20%60flatResults%60%20has%20not%20yet%20been%20populated%20%28e.g.%2C%20on%20a%20fresh%20page%20load%20with%20a%20deep-linked%20%60%3Fid%3D...%60%29%2C%20%60result%60%20will%20be%20%60undefined%60%20and%20the%20modal%20stays%20closed%20even%20though%20the%20API%20query%20has%20been%20fired.%0A%0AConsider%20aligning%20%60FlowReplayModal%60%20to%20use%20%60isDefined%28resultId%29%60%20for%20%60isOpen%60%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20isOpen%3D%7BisDefined%28resultId%29%7D%0A%60%60%60%0A%0AThen%20guard%20the%20body%20rendering%20on%20%60result%60%20being%20defined%20to%20avoid%20rendering%20with%20no%20data.%0A%0A%23%23%23%20Issue%204%20of%205%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fresults%2Fcomponents%2FFlowReplayModal.tsx%3A30-38%0A**Inconsistent%20status%20labels%20%E2%80%94%20English%20here%2C%20Portuguese%20in%20%60ResultsTable%60**%0A%0A%60statusDisplay%60%20in%20this%20file%20uses%20English%20labels%20%28%60'Completed'%60%2C%20%60'Error'%60%2C%20%60'Abandoned'%60%2C%20%60'In%20Progress'%60%29%2C%20while%20the%20equivalent%20%60statusConfig%60%20in%20%60ResultsTable.tsx%60%20uses%20Portuguese%20%28%60'Completo'%60%2C%20%60'Erro'%60%2C%20%60'Abandonado'%60%29.%20This%20means%20the%20same%20status%20renders%20in%20two%20different%20languages%20depending%20on%20which%20component%20the%20user%20is%20looking%20at.%0A%0AGiven%20the%20team%20convention%20of%20ptBR%20for%20UI%20text%2C%20align%20these%20labels%3A%0A%0A%60%60%60suggestion%0Aconst%20statusDisplay%3A%20Record%3C%0A%20%20string%2C%0A%20%20%7B%20label%3A%20string%3B%20colorScheme%3A%20string%20%7D%0A%3E%20%3D%20%7B%0A%20%20completed%3A%20%7B%20label%3A%20'Completo'%2C%20colorScheme%3A%20'green'%20%7D%2C%0A%20%20error%3A%20%7B%20label%3A%20'Erro'%2C%20colorScheme%3A%20'red'%20%7D%2C%0A%20%20abandoned%3A%20%7B%20label%3A%20'Abandonado'%2C%20colorScheme%3A%20'purple'%20%7D%2C%0A%20%20in_progress%3A%20%7B%20label%3A%20'Em%20andamento'%2C%20colorScheme%3A%20'gray'%20%7D%2C%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%205%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fresults%2Fcomponents%2FFlowReplayModal.tsx%3A174-213%0A**Unescaped%20IDs%20interpolated%20directly%20into%20injected%20CSS**%0A%0A%60groupId%60%2C%20%60blockId%60%2C%20and%20%60edgeId%60%20values%20are%20interpolated%20directly%20into%20the%20CSS%20string%20that%20is%20then%20injected%20via%20%60%3Cstyle%3E%7BdynamicStyles%7D%3C%2Fstyle%3E%60.%20Typebot%20IDs%20are%20currently%20UUIDs%20%28safe%29%2C%20but%20the%20code%20makes%20no%20assertion%20of%20that%20%E2%80%94%20if%20an%20ID%20ever%20contains%20characters%20like%20%60%22%60%2C%20%60%7B%60%2C%20%60%7D%60%2C%20or%20%60%3B%60%2C%20the%20generated%20CSS%20could%20be%20malformed%20or%20leak%20unexpected%20style%20rules.%0A%0AConsider%20sanitizing%20each%20ID%20before%20interpolation%3A%0A%0A%60%60%60ts%0Aconst%20safeId%20%3D%20%28id%3A%20string%29%20%3D%3E%20id.replace%28%2F%5B%5E%5Cw-%5D%2Fg%2C%20''%29%0A%2F%2F%20then%3A%20%60%5Bid%3D%22group-%24%7BsafeId%28gid%29%7D%22%5D%60%0A%60%60%60%0A%0AThis%20is%20low-risk%20today%20but%20would%20become%20a%20real%20issue%20if%20ID%20generation%20changes.%0A%0A&repo=cloudhumans%2Ftypebot.io"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fresults%2Fcomponents%2FResultsPage.tsx%3A129-132%0A**Missing%20required%20props%20causes%20TypeScript%20compilation%20failure**%0A%0A%60ResultsTableContainer%60%20was%20updated%20to%20require%20two%20new%20props%20%E2%80%94%20%60helpdeskIdFilter%3A%20string%60%20and%20%60onHelpdeskIdFilterChange%3A%20%28value%3A%20string%29%20%3D%3E%20void%60%20%E2%80%94%20but%20%60ResultsPage.tsx%60%20still%20calls%20it%20without%20providing%20them.%20TypeScript%20will%20reject%20this%20build.%0A%0AYou%20need%20to%20lift%20the%20%60helpdeskIdFilter%60%20state%20up%20into%20%60ResultsPage%60%20and%20pass%20it%20down%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3CResultsTableContainer%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20timeFilter%3D%7BtimeFilter%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onTimeFilterChange%3D%7BsetTimeFilter%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20helpdeskIdFilter%3D%7BhelpdeskIdFilter%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20onHelpdeskIdFilterChange%3D%7BsetHelpdeskIdFilter%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%3E%0A%60%60%60%0A%0AAnd%20add%20the%20corresponding%20state%20at%20the%20top%20of%20%60ResultsPage%60%3A%0A%0A%60%60%60tsx%0Aconst%20%5BhelpdeskIdFilter%2C%20setHelpdeskIdFilter%5D%20%3D%20useState%28''%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%205%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fresults%2Fcomponents%2Ftable%2FResultsTable.tsx%3A394-397%0A**Filter%20input%20is%20purely%20cosmetic%20%E2%80%94%20no%20actual%20filtering%20occurs**%0A%0AThe%20%60helpdeskIdFilter%60%20value%20is%20only%20bound%20to%20the%20%60%3CInput%3E%60%20for%20display%3B%20it%20is%20never%20used%20to%20filter%20%60data%60%20or%20%60results%60.%20Typing%20in%20the%20search%20box%20has%20no%20effect%20on%20the%20rows%20shown.%0A%0AFiltering%20needs%20to%20happen%20somewhere%20in%20the%20pipeline.%20The%20two%20realistic%20options%20are%3A%0A%0A-%20**Client-side**%3A%20filter%20the%20%60results%60%20array%20in%20%60ResultsTable%60%20%28or%20the%20parent%29%20before%20passing%20it%20to%20%60useReactTable%60.%0A-%20**Server-side**%3A%20pass%20%60helpdeskIdFilter%60%20into%20%60ResultsProvider%60%20%2F%20the%20tRPC%20%60getResults%60%20query%20as%20a%20query%20parameter%20and%20let%20the%20API%20filter.%0A%0AWithout%20one%20of%20these%2C%20the%20feature%20ships%20as%20a%20broken%20UI%20element.%0A%0A%23%23%23%20Issue%203%20of%205%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fresults%2Fcomponents%2FFlowReplayModal.tsx%3A238%0A**Modal%20never%20opens%20when%20result%20is%20not%20yet%20in%20%60flatResults%60**%0A%0A%60isOpen%3D%7BisDefined%28result%29%7D%60%20is%20evaluated%20against%20%60flatResults%60.%20This%20is%20correct%20when%20the%20user%20clicks%20a%20row%20already%20loaded%20in%20memory.%20However%2C%20when%20%60resultId%60%20is%20set%20but%20%60flatResults%60%20has%20not%20yet%20been%20populated%20%28e.g.%2C%20on%20a%20fresh%20page%20load%20with%20a%20deep-linked%20%60%3Fid%3D...%60%29%2C%20%60result%60%20will%20be%20%60undefined%60%20and%20the%20modal%20stays%20closed%20even%20though%20the%20API%20query%20has%20been%20fired.%0A%0AConsider%20aligning%20%60FlowReplayModal%60%20to%20use%20%60isDefined%28resultId%29%60%20for%20%60isOpen%60%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20isOpen%3D%7BisDefined%28resultId%29%7D%0A%60%60%60%0A%0AThen%20guard%20the%20body%20rendering%20on%20%60result%60%20being%20defined%20to%20avoid%20rendering%20with%20no%20data.%0A%0A%23%23%23%20Issue%204%20of%205%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fresults%2Fcomponents%2FFlowReplayModal.tsx%3A30-38%0A**Inconsistent%20status%20labels%20%E2%80%94%20English%20here%2C%20Portuguese%20in%20%60ResultsTable%60**%0A%0A%60statusDisplay%60%20in%20this%20file%20uses%20English%20labels%20%28%60'Completed'%60%2C%20%60'Error'%60%2C%20%60'Abandoned'%60%2C%20%60'In%20Progress'%60%29%2C%20while%20the%20equivalent%20%60statusConfig%60%20in%20%60ResultsTable.tsx%60%20uses%20Portuguese%20%28%60'Completo'%60%2C%20%60'Erro'%60%2C%20%60'Abandonado'%60%29.%20This%20means%20the%20same%20status%20renders%20in%20two%20different%20languages%20depending%20on%20which%20component%20the%20user%20is%20looking%20at.%0A%0AGiven%20the%20team%20convention%20of%20ptBR%20for%20UI%20text%2C%20align%20these%20labels%3A%0A%0A%60%60%60suggestion%0Aconst%20statusDisplay%3A%20Record%3C%0A%20%20string%2C%0A%20%20%7B%20label%3A%20string%3B%20colorScheme%3A%20string%20%7D%0A%3E%20%3D%20%7B%0A%20%20completed%3A%20%7B%20label%3A%20'Completo'%2C%20colorScheme%3A%20'green'%20%7D%2C%0A%20%20error%3A%20%7B%20label%3A%20'Erro'%2C%20colorScheme%3A%20'red'%20%7D%2C%0A%20%20abandoned%3A%20%7B%20label%3A%20'Abandonado'%2C%20colorScheme%3A%20'purple'%20%7D%2C%0A%20%20in_progress%3A%20%7B%20label%3A%20'Em%20andamento'%2C%20colorScheme%3A%20'gray'%20%7D%2C%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%205%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fresults%2Fcomponents%2FFlowReplayModal.tsx%3A174-213%0A**Unescaped%20IDs%20interpolated%20directly%20into%20injected%20CSS**%0A%0A%60groupId%60%2C%20%60blockId%60%2C%20and%20%60edgeId%60%20values%20are%20interpolated%20directly%20into%20the%20CSS%20string%20that%20is%20then%20injected%20via%20%60%3Cstyle%3E%7BdynamicStyles%7D%3C%2Fstyle%3E%60.%20Typebot%20IDs%20are%20currently%20UUIDs%20%28safe%29%2C%20but%20the%20code%20makes%20no%20assertion%20of%20that%20%E2%80%94%20if%20an%20ID%20ever%20contains%20characters%20like%20%60%22%60%2C%20%60%7B%60%2C%20%60%7D%60%2C%20or%20%60%3B%60%2C%20the%20generated%20CSS%20could%20be%20malformed%20or%20leak%20unexpected%20style%20rules.%0A%0AConsider%20sanitizing%20each%20ID%20before%20interpolation%3A%0A%0A%60%60%60ts%0Aconst%20safeId%20%3D%20%28id%3A%20string%29%20%3D%3E%20id.replace%28%2F%5B%5E%5Cw-%5D%2Fg%2C%20''%29%0A%2F%2F%20then%3A%20%60%5Bid%3D%22group-%24%7BsafeId%28gid%29%7D%22%5D%60%0A%60%60%60%0A%0AThis%20is%20low-risk%20today%20but%20would%20become%20a%20real%20issue%20if%20ID%20generation%20changes.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/builder/src/features/results/components/ResultsPage.tsx
Line: 129-132

Comment:
**Missing required props causes TypeScript compilation failure**

`ResultsTableContainer` was updated to require two new props — `helpdeskIdFilter: string` and `onHelpdeskIdFilterChange: (value: string) => void` — but `ResultsPage.tsx` still calls it without providing them. TypeScript will reject this build.

You need to lift the `helpdeskIdFilter` state up into `ResultsPage` and pass it down:

```suggestion
              <ResultsTableContainer
                timeFilter={timeFilter}
                onTimeFilterChange={setTimeFilter}
                helpdeskIdFilter={helpdeskIdFilter}
                onHelpdeskIdFilterChange={setHelpdeskIdFilter}
              />
```

And add the corresponding state at the top of `ResultsPage`:

```tsx
const [helpdeskIdFilter, setHelpdeskIdFilter] = useState('')
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/builder/src/features/results/components/table/ResultsTable.tsx
Line: 394-397

Comment:
**Filter input is purely cosmetic — no actual filtering occurs**

The `helpdeskIdFilter` value is only bound to the `<Input>` for display; it is never used to filter `data` or `results`. Typing in the search box has no effect on the rows shown.

Filtering needs to happen somewhere in the pipeline. The two realistic options are:

- **Client-side**: filter the `results` array in `ResultsTable` (or the parent) before passing it to `useReactTable`.
- **Server-side**: pass `helpdeskIdFilter` into `ResultsProvider` / the tRPC `getResults` query as a query parameter and let the API filter.

Without one of these, the feature ships as a broken UI element.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/builder/src/features/results/components/FlowReplayModal.tsx
Line: 238

Comment:
**Modal never opens when result is not yet in `flatResults`**

`isOpen={isDefined(result)}` is evaluated against `flatResults`. This is correct when the user clicks a row already loaded in memory. However, when `resultId` is set but `flatResults` has not yet been populated (e.g., on a fresh page load with a deep-linked `?id=...`), `result` will be `undefined` and the modal stays closed even though the API query has been fired.

Consider aligning `FlowReplayModal` to use `isDefined(resultId)` for `isOpen`:

```suggestion
      isOpen={isDefined(resultId)}
```

Then guard the body rendering on `result` being defined to avoid rendering with no data.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/builder/src/features/results/components/FlowReplayModal.tsx
Line: 30-38

Comment:
**Inconsistent status labels — English here, Portuguese in `ResultsTable`**

`statusDisplay` in this file uses English labels (`'Completed'`, `'Error'`, `'Abandoned'`, `'In Progress'`), while the equivalent `statusConfig` in `ResultsTable.tsx` uses Portuguese (`'Completo'`, `'Erro'`, `'Abandonado'`). This means the same status renders in two different languages depending on which component the user is looking at.

Given the team convention of ptBR for UI text, align these labels:

```suggestion
const statusDisplay: Record<
  string,
  { label: string; colorScheme: string }
> = {
  completed: { label: 'Completo', colorScheme: 'green' },
  error: { label: 'Erro', colorScheme: 'red' },
  abandoned: { label: 'Abandonado', colorScheme: 'purple' },
  in_progress: { label: 'Em andamento', colorScheme: 'gray' },
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/builder/src/features/results/components/FlowReplayModal.tsx
Line: 174-213

Comment:
**Unescaped IDs interpolated directly into injected CSS**

`groupId`, `blockId`, and `edgeId` values are interpolated directly into the CSS string that is then injected via `<style>{dynamicStyles}</style>`. Typebot IDs are currently UUIDs (safe), but the code makes no assertion of that — if an ID ever contains characters like `"`, `{`, `}`, or `;`, the generated CSS could be malformed or leak unexpected style rules.

Consider sanitizing each ID before interpolation:

```ts
const safeId = (id: string) => id.replace(/[^\w-]/g, '')
// then: `[id="group-${safeId(gid)}"]`
```

This is low-risk today but would become a real issue if ID generation changes.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["✨feature: add flow replay button and mod..."](https://github.com/cloudhumans/typebot.io/commit/15282dfe7d77e8cc12767e3ac6230264e77f1cd0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28232377)</sub>

> Greptile also left **4 inline comments** on this PR.

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->