### PR TITLE
:sparkles: Log warning when MCP tools/list returns empty

### DIFF
--- a/apps/builder/src/pages/api/mcp.ts
+++ b/apps/builder/src/pages/api/mcp.ts
@@ -113,6 +113,14 @@ export default async function handler(
           requestId: id,
         })
 
+        if (mcpTools.length === 0) {
+          logger.warn(`MCP tools/list returned empty for tenant=${tenant}`, {
+            tenant,
+            includeDrafts,
+            requestId: id,
+          })
+        }
+
         return res.status(200).json({
           jsonrpc: '2.0',
           result: { tools: mcpTools },


### PR DESCRIPTION
## Summary
- Emit `warn` log at `apps/builder/src/pages/api/mcp.ts` when `tools/list` returns zero tools
- Message includes tenant inline (`MCP tools/list returned empty for tenant=...`) plus structured fields (`tenant`, `includeDrafts`, `requestId`)

## Test plan
- [ ] Hit `/api/mcp` `tools/list` for a tenant with no published tools → warn log appears with tenant
- [ ] Hit `/api/mcp` `tools/list` for a tenant with tools → only info logs, no empty warn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change in an API route; no behavior or data flow changes beyond emitting an extra warning when the tool list is empty.
> 
> **Overview**
> Adds a new `warn` log in the MCP `tools/list` handler (`apps/builder/src/pages/api/mcp.ts`) when the computed tool list is empty, including `tenant`, `includeDrafts`, and `requestId` for easier diagnosis.
> 
> Response payload and behavior are otherwise unchanged; this is purely additional observability around unexpected empty tool sets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 444df52be186627212d1bc86922dfddbf1c17ee8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `warn`-level log in `apps/builder/src/pages/api/mcp.ts` when a `tools/list` MCP request resolves to zero tools for a given tenant. The intent is to make empty-tool-list situations visible in Datadog without changing any functional behaviour.

The change is minimal and safe — no dependency changes, no logic alterations, no new config entries. One issue to address:

- **Structured logging inconsistency (P1):** The new `logger.warn` message uses a template literal (`` `MCP tools/list returned empty for tenant=${tenant}` ``) to embed `tenant` inline, while also passing `tenant` as a structured field. Every other `logger` call in the same file uses a plain string message and keeps all data exclusively in the structured object. The fix is one line: replace the template literal with the plain string `'MCP tools/list returned empty'`.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the string interpolation in the warn log message to match the structured logging convention used throughout the file.

Single-file, non-functional change that only adds a log statement. No dependency changes, no business logic altered, no security implications. One targeted P1 fix (drop the template literal from the message) is all that stands between this and a clean merge.

apps/builder/src/pages/api/mcp.ts — specifically line 117 where the warn message uses string interpolation instead of a plain string.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/builder/src/pages/api/mcp.ts | Adds a warn log when tools/list returns 0 tools; message uses string interpolation inconsistent with every other logger call in the file (structured logging rule violated) |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant Handler as /api/mcp
    participant DB as getWorkflowTools
    participant Log as logger

    Client->>Handler: POST tools/list (x-tenant: T)
    Handler->>Log: info("MCP tools/list", {tenant, includeDrafts, requestId})
    Handler->>DB: getWorkflowTools({tenant, includeDrafts})
    DB-->>Handler: { tools: [] }
    Handler->>Log: info("MCP tools/list completed", {tenant, toolCount: 0, ...})
    alt mcpTools.length === 0 (NEW)
        Handler->>Log: warn("MCP tools/list returned empty", {tenant, includeDrafts, requestId})
    end
    Handler-->>Client: 200 { result: { tools: [] } }
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fbuilder%2Fsrc%2Fpages%2Fapi%2Fmcp.ts%3A117-121%0A**String%20interpolation%20in%20log%20message%20violates%20structured%20logging%20convention**%0A%0AThe%20message%20string%20bakes%20%60tenant%60%20into%20the%20text%20via%20template%20literal%2C%20while%20%60tenant%60%20is%20simultaneously%20passed%20as%20a%20structured%20field.%20Every%20other%20%60logger%60%20call%20in%20this%20file%20uses%20a%20plain%20string%20message%20and%20puts%20data%20only%20in%20the%20structured%20object%20%E2%80%94%20this%20is%20the%20pattern%20that%20keeps%20Datadog%20logs%20searchable%20and%20cheap%20to%20parse.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20logger.warn%28'MCP%20tools%2Flist%20returned%20empty'%2C%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20tenant%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20includeDrafts%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20requestId%3A%20id%2C%0A%20%20%20%20%20%20%20%20%20%20%7D%29%0A%60%60%60%0A%0A**Rule%20Used%3A**%20What%3A%20Use%20structured%20key-value%20logging%2C%20not%20string...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D35b4945c-838d-4cfb-857d-a02c03320138%29%29%0A%0A&repo=cloudhumans%2Ftypebot.io"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fbuilder%2Fsrc%2Fpages%2Fapi%2Fmcp.ts%3A117-121%0A**String%20interpolation%20in%20log%20message%20violates%20structured%20logging%20convention**%0A%0AThe%20message%20string%20bakes%20%60tenant%60%20into%20the%20text%20via%20template%20literal%2C%20while%20%60tenant%60%20is%20simultaneously%20passed%20as%20a%20structured%20field.%20Every%20other%20%60logger%60%20call%20in%20this%20file%20uses%20a%20plain%20string%20message%20and%20puts%20data%20only%20in%20the%20structured%20object%20%E2%80%94%20this%20is%20the%20pattern%20that%20keeps%20Datadog%20logs%20searchable%20and%20cheap%20to%20parse.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20logger.warn%28'MCP%20tools%2Flist%20returned%20empty'%2C%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20tenant%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20includeDrafts%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20requestId%3A%20id%2C%0A%20%20%20%20%20%20%20%20%20%20%7D%29%0A%60%60%60%0A%0A**Rule%20Used%3A**%20What%3A%20Use%20structured%20key-value%20logging%2C%20not%20string...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D35b4945c-838d-4cfb-857d-a02c03320138%29%29%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/builder/src/pages/api/mcp.ts
Line: 117-121

Comment:
**String interpolation in log message violates structured logging convention**

The message string bakes `tenant` into the text via template literal, while `tenant` is simultaneously passed as a structured field. Every other `logger` call in this file uses a plain string message and puts data only in the structured object — this is the pattern that keeps Datadog logs searchable and cheap to parse.

```suggestion
          logger.warn('MCP tools/list returned empty', {
            tenant,
            includeDrafts,
            requestId: id,
          })
```

**Rule Used:** What: Use structured key-value logging, not string... ([source](https://app.greptile.com/review/custom-context?memory=35b4945c-838d-4cfb-857d-a02c03320138))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: log warning when MCP tools/list re..."](https://github.com/cloudhumans/typebot.io/commit/444df52be186627212d1bc86922dfddbf1c17ee8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28674336)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - What: Use structured key-value logging, not string... ([source](https://app.greptile.com/review/custom-context?memory=35b4945c-838d-4cfb-857d-a02c03320138))

<!-- /greptile_comment -->