### PR TITLE
fix: surface Google Sheets tabs with invalid header rows

### DIFF
--- a/apps/builder/src/features/blocks/integrations/googleSheets/components/SheetsDropdown.tsx
+++ b/apps/builder/src/features/blocks/integrations/googleSheets/components/SheetsDropdown.tsx
@@ -1,6 +1,16 @@
 import { MoreInfoTooltip } from '@/components/MoreInfoTooltip'
 import { Select } from '@/components/inputs/Select'
-import { HStack, Input } from '@chakra-ui/react'
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  AlertTitle,
+  Box,
+  HStack,
+  Input,
+  Stack,
+  Text,
+} from '@chakra-ui/react'
 import { Sheet } from '../types'
 
 type Props = {
@@ -17,7 +27,10 @@ export const SheetsDropdown = ({
   onSelectSheetId,
 }: Props) => {
   if (isLoading) return <Input value="Loading..." isDisabled />
-  if (!sheets || sheets.length === 0)
+  const validSheets = (sheets ?? []).filter((s) => !s.error)
+  const invalidSheets = (sheets ?? []).filter((s) => s.error)
+
+  if (validSheets.length === 0 && invalidSheets.length === 0)
     return (
       <HStack>
         <Input value="No sheets found" isDisabled />
@@ -28,11 +41,51 @@ export const SheetsDropdown = ({
       </HStack>
     )
   return (
-    <Select
-      selectedItem={sheetId}
-      items={(sheets ?? []).map((s) => ({ label: s.name, value: s.id }))}
-      onSelect={onSelectSheetId}
-      placeholder={'Select the sheet'}
-    />
+    <Stack spacing={2}>
+      {validSheets.length > 0 ? (
+        <Select
+          selectedItem={sheetId}
+          items={validSheets.map((s) => ({ label: s.name, value: s.id }))}
+          onSelect={onSelectSheetId}
+          placeholder={'Select the sheet'}
+        />
+      ) : (
+        <HStack>
+          <Input value="No usable sheets found" isDisabled />
+          <MoreInfoTooltip>
+            Every sheet in this spreadsheet has a header row issue. See the
+            details below.
+          </MoreInfoTooltip>
+        </HStack>
+      )}
+      {invalidSheets.length > 0 && (
+        <Alert status="warning" borderRadius="md" alignItems="flex-start">
+          <AlertIcon />
+          <Box>
+            <AlertTitle fontSize="sm">
+              {invalidSheets.length === 1
+                ? '1 sheet cannot be used'
+                : `${invalidSheets.length} sheets cannot be used`}
+            </AlertTitle>
+            <AlertDescription fontSize="sm">
+              <Text mb={1}>
+                Fix the header row (row 1) of these sheets so it has unique,
+                non-empty values:
+              </Text>
+              <Stack spacing={1} pl={4}>
+                {invalidSheets.map((s) => (
+                  <Text key={s.id}>
+                    <Text as="span" fontWeight="semibold">
+                      {s.name}
+                    </Text>
+                    {s.error ? `: ${s.error}` : null}
+                  </Text>
+                ))}
+              </Stack>
+            </AlertDescription>
+          </Box>
+        </Alert>
+      )}
+    </Stack>
   )
 }

--- a/apps/builder/src/features/blocks/integrations/googleSheets/types.ts
+++ b/apps/builder/src/features/blocks/integrations/googleSheets/types.ts
@@ -1,3 +1,8 @@
-export type Sheet = { id: string; name: string; columns: string[] }
+export type Sheet = {
+  id: string
+  name: string
+  columns: string[]
+  error?: string
+}
 
 export type Spreadsheet = { id: string; name: string }

--- a/apps/builder/src/pages/api/integrations/google-sheets/spreadsheets/[id]/sheets.ts
+++ b/apps/builder/src/pages/api/integrations/google-sheets/spreadsheets/[id]/sheets.ts
@@ -1,7 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { GoogleSpreadsheet } from 'google-spreadsheet'
 import { getAuthenticatedGoogleClient } from '@/lib/googleSheets'
-import { isDefined } from '@typebot.io/lib'
 import {
   badRequest,
   methodNotAllowed,
@@ -28,25 +27,31 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const doc = new GoogleSpreadsheet(spreadsheetId, auth.client)
     await doc.loadInfo()
     return res.send({
-      sheets: (
-        await Promise.all(
-          Array.from(Array(doc.sheetCount)).map(async (_, idx) => {
-            const sheet = doc.sheetsByIndex[idx]
-            try {
-              await sheet.loadHeaderRow()
-            } catch (err) {
-              if (err && typeof err === 'object' && 'message' in err)
-                logger.error(err.message)
-              return
-            }
+      sheets: await Promise.all(
+        Array.from(Array(doc.sheetCount)).map(async (_, idx) => {
+          const sheet = doc.sheetsByIndex[idx]
+          try {
+            await sheet.loadHeaderRow()
             return {
               id: sheet.sheetId.toString(),
               name: sheet.title,
               columns: sheet.headerValues,
             }
-          })
-        )
-      ).filter(isDefined),
+          } catch (err) {
+            const message =
+              err && typeof err === 'object' && 'message' in err
+                ? String(err.message)
+                : 'Failed to load header row'
+            logger.error(message)
+            return {
+              id: sheet.sheetId.toString(),
+              name: sheet.title,
+              columns: [],
+              error: message,
+            }
+          }
+        })
+      ),
     })
   }
   return methodNotAllowed(res)


### PR DESCRIPTION
Previously, sheets that failed `loadHeaderRow()` (duplicate or empty headers) were silently filtered out of the sheets endpoint response, leaving users unable to tell why a tab was missing from the dropdown. Now the endpoint returns all tabs — invalid ones include an `error` field — and the UI shows a warning listing the affected tabs with the reason so users can fix the spreadsheet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds error reporting and UI messaging around Google Sheets header-row parsing; low risk aside from potential downstream assumptions about sheets always having non-empty `columns`.
> 
> **Overview**
> Google Sheets sheet discovery now returns *all* tabs, including those whose `loadHeaderRow()` fails; failed tabs include an `error` message and empty `columns` instead of being silently filtered out.
> 
> The builder UI updates `SheetsDropdown` to only list usable sheets in the selector, and shows a warning alert enumerating unusable tabs and their specific header-row issues (including a new empty-state when all tabs are invalid).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e245177e56926d6588636e9f8e4ca6586a6be829. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the UX of the Google Sheets block by surfacing previously-hidden tab errors. Sheets that fail `loadHeaderRow()` (e.g. duplicate or empty headers) were previously silently filtered out of the API response; now they are returned with an `error` field. The `SheetsDropdown` component separates valid and invalid sheets and renders a Chakra UI warning alert listing the affected tabs with actionable guidance.

Key changes:
- **`sheets.ts`**: The `catch` block now returns a structured error object `{ id, name, columns: [], error: message }` instead of filtering the sheet out.
- **`types.ts`**: `Sheet` type gains an optional `error?: string` field.
- **`SheetsDropdown.tsx`**: Sheets are split into `validSheets` / `invalidSheets`; a warning `Alert` is rendered below the dropdown listing unworkable tabs.

One notable concern: the catch block in `sheets.ts` is broad — it catches *all* errors from `loadHeaderRow()`, not just header-validation errors. Network timeouts, quota errors, and per-sheet permission denials will be caught, their raw Google API message surfaced to users, and the sheet will appear in the \"Fix your header row\" warning. This misclassifies infrastructure failures as data problems, which will mislead users.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the happy path (header validation errors); one targeted fix recommended to avoid misleading users when API/network errors occur.

The core feature — surfacing header-row problems in the UI instead of silently dropping tabs — is implemented correctly and the UI changes are clean. The P1 concern (broad catch misclassifying API errors as header problems) is real but affects edge cases (quota exhaustion, per-sheet permission, network hiccup) that are less common than the primary header-validation scenario this PR targets. The two P2 style issues are non-blocking. No data loss or security risk introduced.

apps/builder/src/pages/api/integrations/google-sheets/spreadsheets/[id]/sheets.ts — the catch block should distinguish header-validation errors from API/network errors before returning them to the client.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/builder/src/pages/api/integrations/google-sheets/spreadsheets/[id]/sheets.ts | Catch block returns all `loadHeaderRow()` errors (including network/quota/auth failures) as if they are header-row validation problems, misleading users. |
| apps/builder/src/features/blocks/integrations/googleSheets/components/SheetsDropdown.tsx | New warning Alert correctly surfaces invalid-sheet details; minor redundant truthy check on line 81 inside `invalidSheets.map()`. |
| apps/builder/src/features/blocks/integrations/googleSheets/types.ts | Minimal, correct addition of `error?: string` to the `Sheet` type. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as SheetsDropdown
    participant Hook as useSheets (SWR)
    participant API as /api/.../sheets.ts
    participant GS as Google Sheets API

    UI->>Hook: fetch sheets (spreadsheetId, credentialsId)
    Hook->>API: GET /sheets?credentialsId=...
    API->>GS: doc.loadInfo()
    GS-->>API: spreadsheet metadata (sheetCount, titles)
    loop for each sheet (Promise.all)
        API->>GS: sheet.loadHeaderRow()
        alt header row OK
            GS-->>API: { headerValues }
            API-->>API: return { id, name, columns }
        else header validation error OR API/network error
            GS-->>API: throws Error
            API-->>API: return { id, name, columns:[], error: message }
        end
    end
    API-->>Hook: { sheets: [...valid, ...invalid] }
    Hook-->>UI: sheets[]
    UI->>UI: split into validSheets / invalidSheets
    UI-->>UI: render Select (validSheets only)
    UI-->>UI: render Alert warning (invalidSheets, if any)
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fbuilder%2Fsrc%2Fpages%2Fapi%2Fintegrations%2Fgoogle-sheets%2Fspreadsheets%2F%5Bid%5D%2Fsheets.ts%3A40-51%0A**Broad%20catch%20misclassifies%20API%2Fnetwork%20errors%20as%20header-row%20problems**%0A%0AThe%20%60catch%60%20block%20wraps%20*every*%20exception%20from%20%60loadHeaderRow%28%29%60%20%E2%80%94%20not%20just%20the%20header-validation%20errors%20the%20PR%20is%20designed%20to%20surface.%20%60loadHeaderRow%28%29%60%20makes%20a%20separate%20HTTP%20request%20to%20Google's%20API%2C%20so%20it%20can%20throw%20for%20reasons%20completely%20unrelated%20to%20header%20content%3A%0A%0A-%20Per-sheet%20read-permission%20denied%20%28%60403%20Forbidden%60%29%0A-%20Quota%20%2F%20rate-limit%20exhausted%20%28%60429%20Too%20Many%20Requests%60%29%0A-%20Network%20timeout%20%28%60ETIMEDOUT%60%2C%20%60ECONNRESET%60%2C%20etc.%29%0A%0AIn%20all%20of%20these%20cases%20the%20sheet%20is%20returned%20to%20the%20client%20with%20%60columns%3A%20%5B%5D%60%20and%20an%20%60error%60%20message%2C%20and%20the%20UI%20tells%20the%20user%20to%20%22Fix%20the%20header%20row%20%28row%201%29%22.%20That%20guidance%20is%20wrong%20and%20will%20send%20the%20user%20on%20a%20fruitless%20search%20through%20their%20spreadsheet.%0A%0AConsider%20differentiating%20the%20error%20type%20before%20deciding%20how%20to%20label%20it%3A%0A%0A%60%60%60typescript%0A%7D%20catch%20%28err%29%20%7B%0A%20%20const%20message%20%3D%0A%20%20%20%20err%20%26%26%20typeof%20err%20%3D%3D%3D%20'object'%20%26%26%20'message'%20in%20err%0A%20%20%20%20%20%20%3F%20String%28err.message%29%0A%20%20%20%20%20%20%3A%20'Failed%20to%20load%20header%20row'%0A%20%20const%20isHeaderError%20%3D%0A%20%20%20%20message.includes%28'No%20values%20in%20the%20header%20row'%29%20%7C%7C%0A%20%20%20%20message.includes%28'Duplicate%20header%20value'%29%0A%20%20logger.error%28message%29%0A%20%20return%20%7B%0A%20%20%20%20id%3A%20sheet.sheetId.toString%28%29%2C%0A%20%20%20%20name%3A%20sheet.title%2C%0A%20%20%20%20columns%3A%20%5B%5D%2C%0A%20%20%20%20error%3A%20isHeaderError%20%3F%20message%20%3A%20'Could%20not%20load%20this%20sheet%20%28API%20error%29'%2C%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0AEven%20a%20simpler%20approach%20%E2%80%94%20a%20distinct%20%60errorKind%3A%20'header'%20%7C%20'api'%60%20field%20%E2%80%94%20would%20let%20the%20UI%20give%20accurate%20guidance.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fblocks%2Fintegrations%2FgoogleSheets%2Fcomponents%2FSheetsDropdown.tsx%3A81%0A**Redundant%20truthy%20check%20%E2%80%94%20dead%20%60null%60%20branch**%0A%0A%60invalidSheets%60%20is%20already%20filtered%20to%20only%20sheets%20where%20%60s.error%60%20is%20truthy%20%28line%2031%3A%20%60.filter%28%28s%29%20%3D%3E%20s.error%29%60%29%2C%20so%20the%20ternary%20condition%20is%20always%20%60true%60%20inside%20this%20%60map%60.%20The%20%60null%60%20fallback%20can%20never%20be%20reached.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7B%60%3A%20%24%7Bs.error%7D%60%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fblocks%2Fintegrations%2FgoogleSheets%2Fcomponents%2FSheetsDropdown.tsx%3A33-42%0A**%22No%20sheets%20found%22%20tooltip%20is%20now%20misleading**%0A%0AThe%20tooltip%20inside%20the%20%60validSheets.length%20%3D%3D%3D%200%20%26%26%20invalidSheets.length%20%3D%3D%3D%200%60%20branch%20still%20says%3A%0A%0A%3E%20%22Make%20sure%20your%20spreadsheet%20contains%20at%20least%20a%20sheet%20with%20a%20header%20row.%20Also%20make%20sure%20your%20header%20row%20does%20not%20contain%20duplicates.%22%0A%0AThis%20path%20is%20now%20only%20reached%20when%20the%20spreadsheet%20genuinely%20has%20zero%20sheets%20%28or%20%60sheets%60%20is%20empty%20for%20another%20reason%29.%20A%20user%20reaching%20this%20state%20almost%20certainly%20does%20not%20have%20a%20header%20row%20problem%20%E2%80%94%20they%20have%20an%20empty%20spreadsheet.%20The%20tooltip%20text%20is%20a%20holdover%20from%20the%20previous%20behaviour%20and%20should%20be%20updated%20to%20reflect%20the%20new%20semantics.%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=188&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fbuilder%2Fsrc%2Fpages%2Fapi%2Fintegrations%2Fgoogle-sheets%2Fspreadsheets%2F%5Bid%5D%2Fsheets.ts%3A40-51%0A**Broad%20catch%20misclassifies%20API%2Fnetwork%20errors%20as%20header-row%20problems**%0A%0AThe%20%60catch%60%20block%20wraps%20*every*%20exception%20from%20%60loadHeaderRow%28%29%60%20%E2%80%94%20not%20just%20the%20header-validation%20errors%20the%20PR%20is%20designed%20to%20surface.%20%60loadHeaderRow%28%29%60%20makes%20a%20separate%20HTTP%20request%20to%20Google's%20API%2C%20so%20it%20can%20throw%20for%20reasons%20completely%20unrelated%20to%20header%20content%3A%0A%0A-%20Per-sheet%20read-permission%20denied%20%28%60403%20Forbidden%60%29%0A-%20Quota%20%2F%20rate-limit%20exhausted%20%28%60429%20Too%20Many%20Requests%60%29%0A-%20Network%20timeout%20%28%60ETIMEDOUT%60%2C%20%60ECONNRESET%60%2C%20etc.%29%0A%0AIn%20all%20of%20these%20cases%20the%20sheet%20is%20returned%20to%20the%20client%20with%20%60columns%3A%20%5B%5D%60%20and%20an%20%60error%60%20message%2C%20and%20the%20UI%20tells%20the%20user%20to%20%22Fix%20the%20header%20row%20%28row%201%29%22.%20That%20guidance%20is%20wrong%20and%20will%20send%20the%20user%20on%20a%20fruitless%20search%20through%20their%20spreadsheet.%0A%0AConsider%20differentiating%20the%20error%20type%20before%20deciding%20how%20to%20label%20it%3A%0A%0A%60%60%60typescript%0A%7D%20catch%20%28err%29%20%7B%0A%20%20const%20message%20%3D%0A%20%20%20%20err%20%26%26%20typeof%20err%20%3D%3D%3D%20'object'%20%26%26%20'message'%20in%20err%0A%20%20%20%20%20%20%3F%20String%28err.message%29%0A%20%20%20%20%20%20%3A%20'Failed%20to%20load%20header%20row'%0A%20%20const%20isHeaderError%20%3D%0A%20%20%20%20message.includes%28'No%20values%20in%20the%20header%20row'%29%20%7C%7C%0A%20%20%20%20message.includes%28'Duplicate%20header%20value'%29%0A%20%20logger.error%28message%29%0A%20%20return%20%7B%0A%20%20%20%20id%3A%20sheet.sheetId.toString%28%29%2C%0A%20%20%20%20name%3A%20sheet.title%2C%0A%20%20%20%20columns%3A%20%5B%5D%2C%0A%20%20%20%20error%3A%20isHeaderError%20%3F%20message%20%3A%20'Could%20not%20load%20this%20sheet%20%28API%20error%29'%2C%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0AEven%20a%20simpler%20approach%20%E2%80%94%20a%20distinct%20%60errorKind%3A%20'header'%20%7C%20'api'%60%20field%20%E2%80%94%20would%20let%20the%20UI%20give%20accurate%20guidance.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fblocks%2Fintegrations%2FgoogleSheets%2Fcomponents%2FSheetsDropdown.tsx%3A81%0A**Redundant%20truthy%20check%20%E2%80%94%20dead%20%60null%60%20branch**%0A%0A%60invalidSheets%60%20is%20already%20filtered%20to%20only%20sheets%20where%20%60s.error%60%20is%20truthy%20%28line%2031%3A%20%60.filter%28%28s%29%20%3D%3E%20s.error%29%60%29%2C%20so%20the%20ternary%20condition%20is%20always%20%60true%60%20inside%20this%20%60map%60.%20The%20%60null%60%20fallback%20can%20never%20be%20reached.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7B%60%3A%20%24%7Bs.error%7D%60%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fblocks%2Fintegrations%2FgoogleSheets%2Fcomponents%2FSheetsDropdown.tsx%3A33-42%0A**%22No%20sheets%20found%22%20tooltip%20is%20now%20misleading**%0A%0AThe%20tooltip%20inside%20the%20%60validSheets.length%20%3D%3D%3D%200%20%26%26%20invalidSheets.length%20%3D%3D%3D%200%60%20branch%20still%20says%3A%0A%0A%3E%20%22Make%20sure%20your%20spreadsheet%20contains%20at%20least%20a%20sheet%20with%20a%20header%20row.%20Also%20make%20sure%20your%20header%20row%20does%20not%20contain%20duplicates.%22%0A%0AThis%20path%20is%20now%20only%20reached%20when%20the%20spreadsheet%20genuinely%20has%20zero%20sheets%20%28or%20%60sheets%60%20is%20empty%20for%20another%20reason%29.%20A%20user%20reaching%20this%20state%20almost%20certainly%20does%20not%20have%20a%20header%20row%20problem%20%E2%80%94%20they%20have%20an%20empty%20spreadsheet.%20The%20tooltip%20text%20is%20a%20holdover%20from%20the%20previous%20behaviour%20and%20should%20be%20updated%20to%20reflect%20the%20new%20semantics.%0A%0A&pr=188&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/builder/src/pages/api/integrations/google-sheets/spreadsheets/[id]/sheets.ts
Line: 40-51

Comment:
**Broad catch misclassifies API/network errors as header-row problems**

The `catch` block wraps *every* exception from `loadHeaderRow()` — not just the header-validation errors the PR is designed to surface. `loadHeaderRow()` makes a separate HTTP request to Google's API, so it can throw for reasons completely unrelated to header content:

- Per-sheet read-permission denied (`403 Forbidden`)
- Quota / rate-limit exhausted (`429 Too Many Requests`)
- Network timeout (`ETIMEDOUT`, `ECONNRESET`, etc.)

In all of these cases the sheet is returned to the client with `columns: []` and an `error` message, and the UI tells the user to "Fix the header row (row 1)". That guidance is wrong and will send the user on a fruitless search through their spreadsheet.

Consider differentiating the error type before deciding how to label it:

```typescript
} catch (err) {
  const message =
    err && typeof err === 'object' && 'message' in err
      ? String(err.message)
      : 'Failed to load header row'
  const isHeaderError =
    message.includes('No values in the header row') ||
    message.includes('Duplicate header value')
  logger.error(message)
  return {
    id: sheet.sheetId.toString(),
    name: sheet.title,
    columns: [],
    error: isHeaderError ? message : 'Could not load this sheet (API error)',
  }
}
```

Even a simpler approach — a distinct `errorKind: 'header' | 'api'` field — would let the UI give accurate guidance.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/builder/src/features/blocks/integrations/googleSheets/components/SheetsDropdown.tsx
Line: 81

Comment:
**Redundant truthy check — dead `null` branch**

`invalidSheets` is already filtered to only sheets where `s.error` is truthy (line 31: `.filter((s) => s.error)`), so the ternary condition is always `true` inside this `map`. The `null` fallback can never be reached.

```suggestion
                    {`: ${s.error}`}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/builder/src/features/blocks/integrations/googleSheets/components/SheetsDropdown.tsx
Line: 33-42

Comment:
**"No sheets found" tooltip is now misleading**

The tooltip inside the `validSheets.length === 0 && invalidSheets.length === 0` branch still says:

> "Make sure your spreadsheet contains at least a sheet with a header row. Also make sure your header row does not contain duplicates."

This path is now only reached when the spreadsheet genuinely has zero sheets (or `sheets` is empty for another reason). A user reaching this state almost certainly does not have a header row problem — they have an empty spreadsheet. The tooltip text is a holdover from the previous behaviour and should be updated to reflect the new semantics.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: surface Google Sheets tabs with inv..."](https://github.com/cloudhumans/typebot.io/commit/e245177e56926d6588636e9f8e4ca6586a6be829) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28797596)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->