### PR TITLE
feat(mcp): expose Typebot createdAt/updatedAt via tool _meta

### DIFF
--- a/apps/builder/src/features/mcp/helpers/transformToMCPTool.ts
+++ b/apps/builder/src/features/mcp/helpers/transformToMCPTool.ts
@@ -36,6 +36,8 @@ export function transformToMCPTool(tool: WorkflowTool) {
     _meta: {
       workflowId: tool.id,
       isPublished: tool.isPublished,
+      createdAt: tool.createdAt.toISOString(),
+      updatedAt: tool.updatedAt.toISOString(),
     },
   }
 }

--- a/apps/builder/src/features/mcp/services/getWorkflowTools.ts
+++ b/apps/builder/src/features/mcp/services/getWorkflowTools.ts
@@ -53,6 +53,8 @@ export async function getWorkflowTools({
       variables: true,
       publicId: true,
       groups: true,
+      createdAt: true,
+      updatedAt: true,
       publishedTypebot: {
         select: {
           id: true,
@@ -122,6 +124,8 @@ export async function getWorkflowTools({
         isPublished: Boolean(typebot.publishedTypebot),
         variables,
         publicName: typebot.publicId ?? `${slug}-${typebot.id.slice(-7)}`,
+        createdAt: typebot.createdAt,
+        updatedAt: typebot.updatedAt,
       }
     })
 

--- a/apps/builder/src/features/mcp/types.ts
+++ b/apps/builder/src/features/mcp/types.ts
@@ -12,6 +12,10 @@ export interface WorkflowTool {
     description?: string
   }>
   publicName: string
+  /** Creation timestamp from the underlying Typebot row. */
+  createdAt: Date
+  /** Last-update timestamp from the underlying Typebot row. */
+  updatedAt: Date
 }
 
 /**

--- a/apps/builder/src/features/mcp/types.ts
+++ b/apps/builder/src/features/mcp/types.ts
@@ -12,9 +12,7 @@ export interface WorkflowTool {
     description?: string
   }>
   publicName: string
-  /** Creation timestamp from the underlying Typebot row. */
   createdAt: Date
-  /** Last-update timestamp from the underlying Typebot row. */
   updatedAt: Date
 }
 


### PR DESCRIPTION
## Summary
- Expose `createdAt` and `updatedAt` (ISO strings) on each MCP tool's `_meta` in `apps/builder/src/features/mcp/helpers/transformToMCPTool.ts`
- Select `createdAt` / `updatedAt` in `getWorkflowTools` and pass them through the `WorkflowTool` shape so the values come straight from the underlying Typebot row

## Test plan
- [ ] Hit `/api/mcp` `tools/list` → each tool's `_meta` contains `createdAt` and `updatedAt` as ISO-8601 strings
- [ ] Values match the `createdAt` / `updatedAt` of the source Typebot row in Postgres
- [ ] Existing `_meta` fields (`workflowId`, `isPublished`) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive metadata-only change that threads two timestamp fields through the MCP tool listing with minimal behavioral impact.
> 
> **Overview**
> MCP `tools/list` responses now include Typebot timestamps by adding `createdAt`/`updatedAt` to each tool’s `_meta` (as ISO strings) in `transformToMCPTool`.
> 
> To support this, `getWorkflowTools` now selects and returns `createdAt`/`updatedAt` from Prisma, and the `WorkflowTool` type is extended to require these fields end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45a7f28183cb7893673edfb11551632d1aa51c1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes `createdAt` and `updatedAt` timestamps on each MCP tool's `_meta` object, surfacing when a Typebot workflow was first created and last modified to MCP consumers such as the claudia Tools page.

The implementation is clean and consistent with the existing `_meta` pattern (`workflowId`, `isPublished`): the Prisma query in `getWorkflowTools` now selects both timestamp columns, the `WorkflowTool` interface is extended with non-optional `Date` fields, and `transformToMCPTool` serialises them to ISO-8601 strings via `.toISOString()`. Since Prisma `createdAt`/`updatedAt` columns are always non-null (auto-managed by the ORM), the non-optional type declaration is correct and `.toISOString()` is always safe to call.

**Key changes**
- `types.ts`: `createdAt: Date` and `updatedAt: Date` added to `WorkflowTool` interface
- `getWorkflowTools.ts`: selects and passes through the two timestamp columns from Prisma
- `transformToMCPTool.ts`: serialises timestamps to ISO-8601 strings in `_meta`

No existing functionality is altered; the change is purely additive.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive metadata change with no impact on execution logic.

All three files receive minimal, well-scoped changes. The new fields are non-optional and always populated by Prisma, so there is no null-safety risk. The ISO serialisation is correct, the type declarations match the Prisma column types, and the change is backward-compatible for existing MCP consumers (new keys in _meta do not break parsers that ignore unknown fields). No tests exist for this module, but the change is too simple to introduce a regression.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/builder/src/features/mcp/types.ts | Extended WorkflowTool interface with required (non-optional) createdAt/updatedAt Date fields — correct since Prisma never returns null for these columns. |
| apps/builder/src/features/mcp/services/getWorkflowTools.ts | Added createdAt/updatedAt to the Prisma select and to the mapped return object; straightforward and consistent with the rest of the mapping logic. |
| apps/builder/src/features/mcp/helpers/transformToMCPTool.ts | Serialises createdAt/updatedAt to ISO strings in _meta; follows existing _meta pattern and is safe because the fields are non-nullable. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant API as /api/mcp
    participant GWT as getWorkflowTools
    participant DB as Prisma / PostgreSQL
    participant TTM as transformToMCPTool

    Client->>API: POST tools/list (x-tenant header)
    API->>GWT: getWorkflowTools({ tenant, includeDrafts })
    GWT->>DB: typebot.findMany({ select: { ..., createdAt, updatedAt } })
    DB-->>GWT: typebots[] with Date fields
    GWT-->>API: { tools: WorkflowTool[] } (includes createdAt, updatedAt as Date)
    loop for each tool
        API->>TTM: transformToMCPTool(tool)
        TTM-->>API: { name, description, inputSchema, _meta: { workflowId, isPublished, createdAt (ISO), updatedAt (ISO) } }
    end
    API-->>Client: tools/list response with _meta timestamps
```

<sub>Reviews (1): Last reviewed commit: ["Remove comments from Typebot timestamp"](https://github.com/cloudhumans/typebot.io/commit/45a7f28183cb7893673edfb11551632d1aa51c1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28807941)</sub>

<!-- /greptile_comment -->