### PR TITLE
🐛 fix Cognito workspace auth across endpoints

### DIFF
--- a/apps/builder/src/features/blocks/integrations/openai/api/listModels.ts
+++ b/apps/builder/src/features/blocks/integrations/openai/api/listModels.ts
@@ -27,6 +27,7 @@ export const listModels = authenticatedProcedure
       const workspace = await prisma.workspace.findFirst({
         where: { id: workspaceId },
         select: {
+          id: true,
           members: {
             select: {
               userId: true,

--- a/apps/builder/src/features/credentials/api/deleteCredentials.ts
+++ b/apps/builder/src/features/credentials/api/deleteCredentials.ts
@@ -39,11 +39,17 @@ export const deleteCredentials = authenticatedProcedure
           message: 'Workspace not found',
         })
 
-      await prisma.credentials.delete({
+      const deletedCount = await prisma.credentials.deleteMany({
         where: {
           id: credentialsId,
+          workspaceId,
         },
       })
+      if (deletedCount.count === 0)
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Credentials not found',
+        })
       return { credentialsId }
     }
   )

--- a/apps/builder/src/features/credentials/api/deleteCredentials.ts
+++ b/apps/builder/src/features/credentials/api/deleteCredentials.ts
@@ -30,9 +30,6 @@ export const deleteCredentials = authenticatedProcedure
       const workspace = await prisma.workspace.findFirst({
         where: {
           id: workspaceId,
-          members: {
-            some: { userId: user.id, role: { in: ['ADMIN', 'MEMBER'] } },
-          },
         },
         select: { id: true, members: true },
       })

--- a/apps/builder/src/features/forge/api/credentials/deleteCredentials.ts
+++ b/apps/builder/src/features/forge/api/credentials/deleteCredentials.ts
@@ -25,11 +25,17 @@ export const deleteCredentials = authenticatedProcedure
           message: 'Workspace not found',
         })
 
-      await prisma.credentials.delete({
+      const deletedCount = await prisma.credentials.deleteMany({
         where: {
           id: credentialsId,
+          workspaceId,
         },
       })
+      if (deletedCount.count === 0)
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Credentials not found',
+        })
       return { credentialsId }
     }
   )

--- a/apps/builder/src/features/forge/api/credentials/deleteCredentials.ts
+++ b/apps/builder/src/features/forge/api/credentials/deleteCredentials.ts
@@ -16,9 +16,6 @@ export const deleteCredentials = authenticatedProcedure
       const workspace = await prisma.workspace.findFirst({
         where: {
           id: workspaceId,
-          members: {
-            some: { userId: user.id, role: { in: ['ADMIN', 'MEMBER'] } },
-          },
         },
         select: { id: true, members: true },
       })

--- a/apps/builder/src/helpers/databaseRules.ts
+++ b/apps/builder/src/helpers/databaseRules.ts
@@ -1,18 +1,39 @@
 import {
   CollaborationType,
-  Plan,
   Prisma,
   User,
   WorkspaceRole,
 } from '@typebot.io/prisma'
-import prisma from '@typebot.io/lib/prisma'
-import { NextApiResponse } from 'next'
-import { forbidden } from '@typebot.io/lib/api'
 import { env } from '@typebot.io/env'
+import {
+  getCognitoAccessibleWorkspaceIds,
+  type CognitoUserClaims,
+} from '@/features/workspace/helpers/cognitoUtils'
+
+const workspaceMemberFilter = (
+  user: Pick<User, 'email' | 'id'> & { cognitoClaims?: CognitoUserClaims },
+  roleFilter?: Prisma.MemberInWorkspaceWhereInput
+): Prisma.WorkspaceWhereInput => {
+  const cognitoAccess = getCognitoAccessibleWorkspaceIds(user)
+
+  switch (cognitoAccess.type) {
+    case 'admin':
+      return {}
+    case 'restricted':
+      return {
+        OR: [
+          { members: { some: { userId: user.id, ...roleFilter } } },
+          { id: { in: cognitoAccess.ids } },
+        ],
+      }
+    case 'none':
+      return { members: { some: { userId: user.id, ...roleFilter } } }
+  }
+}
 
 export const canWriteTypebots = (
   typebotIds: string[] | string,
-  user: Pick<User, 'email' | 'id'>
+  user: Pick<User, 'email' | 'id'> & { cognitoClaims?: CognitoUserClaims }
 ): Prisma.TypebotWhereInput =>
   env.NEXT_PUBLIC_E2E_TEST
     ? { id: typeof typebotIds === 'string' ? typebotIds : { in: typebotIds } }
@@ -20,11 +41,9 @@ export const canWriteTypebots = (
         id: typeof typebotIds === 'string' ? typebotIds : { in: typebotIds },
         OR: [
           {
-            workspace: {
-              members: {
-                some: { userId: user.id, role: { not: WorkspaceRole.GUEST } },
-              },
-            },
+            workspace: workspaceMemberFilter(user, {
+              role: { not: WorkspaceRole.GUEST },
+            }),
           },
           {
             collaborators: {
@@ -36,18 +55,14 @@ export const canWriteTypebots = (
 
 export const canReadTypebots = (
   typebotIds: string | string[],
-  user: Pick<User, 'email' | 'id'>
+  user: Pick<User, 'email' | 'id'> & { cognitoClaims?: CognitoUserClaims }
 ) => ({
   id: typeof typebotIds === 'string' ? typebotIds : { in: typebotIds },
   workspace:
     env.ADMIN_EMAIL?.some((email) => email === user.email) ||
     env.NEXT_PUBLIC_E2E_TEST
       ? undefined
-      : {
-          members: {
-            some: { userId: user.id },
-          },
-        },
+      : workspaceMemberFilter(user),
 })
 
 export const canEditGuests = (user: User, typebotId: string) => ({
@@ -58,30 +73,6 @@ export const canEditGuests = (user: User, typebotId: string) => ({
     },
   },
 })
-
-export const canPublishFileInput = async ({
-  userId,
-  workspaceId,
-  res,
-}: {
-  userId: string
-  workspaceId: string
-  res: NextApiResponse
-}) => {
-  const workspace = await prisma.workspace.findFirst({
-    where: { id: workspaceId, members: { some: { userId } } },
-    select: { plan: true },
-  })
-  if (!workspace) {
-    forbidden(res, 'workspace not found')
-    return false
-  }
-  if (workspace?.plan === Plan.FREE) {
-    forbidden(res, 'You need to upgrade your plan to use file input blocks')
-    return false
-  }
-  return true
-}
 
 export const isUniqueConstraintError = (error: unknown) =>
   typeof error === 'object' &&

--- a/apps/builder/src/lib/googleSheets.ts
+++ b/apps/builder/src/lib/googleSheets.ts
@@ -1,4 +1,4 @@
-import { Credentials as CredentialsFromDb } from '@typebot.io/prisma'
+import { Credentials as CredentialsFromDb, User } from '@typebot.io/prisma'
 import { OAuth2Client, Credentials } from 'google-auth-library'
 import { GoogleSheetsCredentials } from '@typebot.io/schemas'
 import { isDefined } from '@typebot.io/lib'
@@ -6,9 +6,10 @@ import { env } from '@typebot.io/env'
 import prisma from '@typebot.io/lib/prisma'
 import { decrypt } from '@typebot.io/lib/api/encryption/decrypt'
 import { encrypt } from '@typebot.io/lib/api/encryption/encrypt'
+import { isReadWorkspaceFobidden } from '@/features/workspace/helpers/isReadWorkspaceFobidden'
 
 export const getAuthenticatedGoogleClient = async (
-  userId: string,
+  user: Pick<User, 'email' | 'id'> & { cognitoClaims?: unknown },
   credentialsId: string
 ): Promise<
   { client: OAuth2Client; credentials: CredentialsFromDb } | undefined
@@ -18,10 +19,19 @@ export const getAuthenticatedGoogleClient = async (
     env.GOOGLE_CLIENT_SECRET,
     `${env.NEXTAUTH_URL}/api/credentials/google-sheets/callback`
   )
-  const credentials = (await prisma.credentials.findFirst({
-    where: { id: credentialsId, workspace: { members: { some: { userId } } } },
-  })) as CredentialsFromDb | undefined
-  if (!credentials) return
+  const credentials = await prisma.credentials.findFirst({
+    where: { id: credentialsId },
+    include: {
+      workspace: {
+        select: {
+          id: true,
+          members: { select: { userId: true } },
+        },
+      },
+    },
+  })
+  if (!credentials || isReadWorkspaceFobidden(credentials.workspace, user))
+    return
   const data = (await decrypt(
     credentials.data,
     credentials.iv

--- a/apps/builder/src/pages/api/integrations/google-sheets/spreadsheets.ts
+++ b/apps/builder/src/pages/api/integrations/google-sheets/spreadsheets.ts
@@ -18,7 +18,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method === 'GET') {
     const credentialsId = req.query.credentialsId as string | undefined
     if (!credentialsId) return badRequest(res)
-    const auth = await getAuthenticatedGoogleClient(user.id, credentialsId)
+    const auth = await getAuthenticatedGoogleClient(user, credentialsId)
     if (!auth)
       return res.status(404).send("Couldn't find credentials in database")
     const response = await drive({

--- a/apps/builder/src/pages/api/integrations/google-sheets/spreadsheets/[id]/sheets.ts
+++ b/apps/builder/src/pages/api/integrations/google-sheets/spreadsheets/[id]/sheets.ts
@@ -20,7 +20,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const credentialsId = req.query.credentialsId as string | undefined
     if (!credentialsId) return badRequest(res)
     const spreadsheetId = req.query.id as string
-    const auth = await getAuthenticatedGoogleClient(user.id, credentialsId)
+    const auth = await getAuthenticatedGoogleClient(user, credentialsId)
     if (!auth)
       return res
         .status(404)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authorization logic for credential deletion; a mistake could allow unauthorized deletes or block legitimate users, especially with Cognito-claim-based access.
> 
> **Overview**
> Fixes credential deletion authorization by **removing the Prisma query-time `members` role filter** and relying solely on `isWriteWorkspaceForbidden` after fetching the workspace by `id`.
> 
> Applies the same change to both the public credentials delete endpoint (`/v1/credentials/:credentialsId`) and the Forge credentials delete mutation, aligning behavior with other write checks (including Cognito-claim access).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 600a38bd6bb27730d245edb0a796439e88381220. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Esta PR corrige a autorização ao deletar credenciais de workspace, removendo o filtro de membros da consulta Prisma e delegando a verificação para `isWriteWorkspaceForbidden`, que suporta tanto acesso via Cognito quanto via banco de dados. As operações de deleção agora usam `deleteMany` com filtro `workspaceId`, prevenindo remoções entre workspaces distintos. As mesmas mudanças são aplicadas consistentemente ao endpoint público `/v1/credentials/:credentialsId` e à mutation Forge, e as funções de leitura do Google Sheets recebem o objeto `user` completo para habilitarem a verificação Cognito.

<h3>Confidence Score: 5/5</h3>

Esta PR é segura para merge — a lógica de autorização foi alinhada corretamente com isWriteWorkspaceForbidden, sem brechas identificadas.

Todas as mudanças são P2 ou menores. A remoção do filtro de membro da query Prisma e substituição por isWriteWorkspaceForbidden é uma abordagem bem estabelecida no codebase. O escopo workspaceId no deleteMany melhora o isolamento. Nenhum bug de autorização, perda de dados ou problema de segurança identificado.

Nenhum arquivo requer atenção especial.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/builder/src/features/credentials/api/deleteCredentials.ts | Removes in-query member-role filter and replaces with post-fetch isWriteWorkspaceForbidden check; adds workspaceId scope to deleteMany for safer cross-workspace isolation. |
| apps/builder/src/features/forge/api/credentials/deleteCredentials.ts | Mirrors the same fix as the public credentials delete endpoint — workspace fetched by id only, then isWriteWorkspaceForbidden checks auth, deleteMany scoped to workspaceId. |
| apps/builder/src/helpers/databaseRules.ts | Refactors canWriteTypebots/canReadTypebots to use a new workspaceMemberFilter helper that supports Cognito claims; removes dead canPublishFileInput function. |
| apps/builder/src/lib/googleSheets.ts | getAuthenticatedGoogleClient now accepts a full user object and uses isReadWorkspaceFobidden for workspace access check, enabling Cognito-claim-based auth for Google Sheets. |
| apps/builder/src/features/blocks/integrations/openai/api/listModels.ts | Adds id: true to the workspace select so isReadWorkspaceFobidden can perform Cognito-claim-based checks that require workspace.id. |
| apps/builder/src/pages/api/integrations/google-sheets/spreadsheets.ts | Updates call site to pass user object instead of user.id to match the new getAuthenticatedGoogleClient signature. |
| apps/builder/src/pages/api/integrations/google-sheets/spreadsheets/[id]/sheets.ts | Updates call site to pass user object instead of user.id to match the new getAuthenticatedGoogleClient signature. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DELETE /v1/credentials/:credentialsId] --> B[Fetch workspace by id only]
    B --> C{workspace found?}
    C -- No --> D[NOT_FOUND error]
    C -- Yes --> E{isWriteWorkspaceForbidden?}
    E -- Has Cognito claims AND workspace access --> F[Allow write]
    E -- No Cognito / fallback to DB --> G{DB member role?}
    G -- ADMIN or MEMBER --> F
    G -- GUEST or not a member --> H[NOT_FOUND error]
    F --> I[deleteMany where id = credentialsId AND workspaceId = workspaceId]
    I --> J{deletedCount > 0?}
    J -- No --> K[NOT_FOUND: Credentials not found]
    J -- Yes --> L[Return credentialsId]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `apps/builder/src/features/credentials/api/deleteCredentials.ts`, line 42-46 ([link](https://github.com/cloudhumans/typebot.io/blob/600a38bd6bb27730d245edb0a796439e88381220/apps/builder/src/features/credentials/api/deleteCredentials.ts#L42-L46)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> **Verificação de propriedade da credencial ausente**

   A exclusão da credencial usa apenas `credentialsId`, sem verificar se ela pertence ao `workspaceId` autorizado. Isso significa que um usuário com acesso legítimo ao workspace A pode passar o `credentialsId` de uma credencial pertencente ao workspace B para excluí-la, desde que conheça o ID.

   Embora a autorização de workspace já esteja validada, a ausência de um filtro adicional abre espaço para exclusão cruzada de credenciais entre workspaces. Considere adicionar o `workspaceId` ao critério de deleção:

   ```typescript
   await prisma.credentials.delete({
     where: {
       id: credentialsId,
       workspaceId: workspaceId,
     },
   })
   ```

   Obs.: este problema é pré-existente e não foi introduzido por este PR, mas vale corrigi-lo aqui enquanto o contexto está aberto.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/builder/src/features/credentials/api/deleteCredentials.ts
   Line: 42-46

   Comment:
   **Verificação de propriedade da credencial ausente**

   A exclusão da credencial usa apenas `credentialsId`, sem verificar se ela pertence ao `workspaceId` autorizado. Isso significa que um usuário com acesso legítimo ao workspace A pode passar o `credentialsId` de uma credencial pertencente ao workspace B para excluí-la, desde que conheça o ID.

   Embora a autorização de workspace já esteja validada, a ausência de um filtro adicional abre espaço para exclusão cruzada de credenciais entre workspaces. Considere adicionar o `workspaceId` ao critério de deleção:

   ```typescript
   await prisma.credentials.delete({
     where: {
       id: credentialsId,
       workspaceId: workspaceId,
     },
   })
   ```

   Obs.: este problema é pré-existente e não foi introduzido por este PR, mas vale corrigi-lo aqui enquanto o contexto está aberto.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fbuilder%2Fsrc%2Ffeatures%2Fcredentials%2Fapi%2FdeleteCredentials.ts%0ALine%3A%2042-46%0A%0AComment%3A%0A**Verifica%C3%A7%C3%A3o%20de%20propriedade%20da%20credencial%20ausente**%0A%0AA%20exclus%C3%A3o%20da%20credencial%20usa%20apenas%20%60credentialsId%60%2C%20sem%20verificar%20se%20ela%20pertence%20ao%20%60workspaceId%60%20autorizado.%20Isso%20significa%20que%20um%20usu%C3%A1rio%20com%20acesso%20leg%C3%ADtimo%20ao%20workspace%20A%20pode%20passar%20o%20%60credentialsId%60%20de%20uma%20credencial%20pertencente%20ao%20workspace%20B%20para%20exclu%C3%AD-la%2C%20desde%20que%20conhe%C3%A7a%20o%20ID.%0A%0AEmbora%20a%20autoriza%C3%A7%C3%A3o%20de%20workspace%20j%C3%A1%20esteja%20validada%2C%20a%20aus%C3%AAncia%20de%20um%20filtro%20adicional%20abre%20espa%C3%A7o%20para%20exclus%C3%A3o%20cruzada%20de%20credenciais%20entre%20workspaces.%20Considere%20adicionar%20o%20%60workspaceId%60%20ao%20crit%C3%A9rio%20de%20dele%C3%A7%C3%A3o%3A%0A%0A%60%60%60typescript%0Aawait%20prisma.credentials.delete%28%7B%0A%20%20where%3A%20%7B%0A%20%20%20%20id%3A%20credentialsId%2C%0A%20%20%20%20workspaceId%3A%20workspaceId%2C%0A%20%20%7D%2C%0A%7D%29%0A%60%60%60%0A%0AObs.%3A%20este%20problema%20%C3%A9%20pr%C3%A9-existente%20e%20n%C3%A3o%20foi%20introduzido%20por%20este%20PR%2C%20mas%20vale%20corrigi-lo%20aqui%20enquanto%20o%20contexto%20est%C3%A1%20aberto.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudhumans%2Ftypebot.io&pr=190&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fbuilder%2Fsrc%2Ffeatures%2Fcredentials%2Fapi%2FdeleteCredentials.ts%0ALine%3A%2042-46%0A%0AComment%3A%0A**Verifica%C3%A7%C3%A3o%20de%20propriedade%20da%20credencial%20ausente**%0A%0AA%20exclus%C3%A3o%20da%20credencial%20usa%20apenas%20%60credentialsId%60%2C%20sem%20verificar%20se%20ela%20pertence%20ao%20%60workspaceId%60%20autorizado.%20Isso%20significa%20que%20um%20usu%C3%A1rio%20com%20acesso%20leg%C3%ADtimo%20ao%20workspace%20A%20pode%20passar%20o%20%60credentialsId%60%20de%20uma%20credencial%20pertencente%20ao%20workspace%20B%20para%20exclu%C3%AD-la%2C%20desde%20que%20conhe%C3%A7a%20o%20ID.%0A%0AEmbora%20a%20autoriza%C3%A7%C3%A3o%20de%20workspace%20j%C3%A1%20esteja%20validada%2C%20a%20aus%C3%AAncia%20de%20um%20filtro%20adicional%20abre%20espa%C3%A7o%20para%20exclus%C3%A3o%20cruzada%20de%20credenciais%20entre%20workspaces.%20Considere%20adicionar%20o%20%60workspaceId%60%20ao%20crit%C3%A9rio%20de%20dele%C3%A7%C3%A3o%3A%0A%0A%60%60%60typescript%0Aawait%20prisma.credentials.delete%28%7B%0A%20%20where%3A%20%7B%0A%20%20%20%20id%3A%20credentialsId%2C%0A%20%20%20%20workspaceId%3A%20workspaceId%2C%0A%20%20%7D%2C%0A%7D%29%0A%60%60%60%0A%0AObs.%3A%20este%20problema%20%C3%A9%20pr%C3%A9-existente%20e%20n%C3%A3o%20foi%20introduzido%20por%20este%20PR%2C%20mas%20vale%20corrigi-lo%20aqui%20enquanto%20o%20contexto%20est%C3%A1%20aberto.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=190&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

2. `apps/builder/src/features/forge/api/credentials/deleteCredentials.ts`, line 28-32 ([link](https://github.com/cloudhumans/typebot.io/blob/600a38bd6bb27730d245edb0a796439e88381220/apps/builder/src/features/forge/api/credentials/deleteCredentials.ts#L28-L32)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> **Verificação de propriedade da credencial ausente**

   O mesmo problema existe neste endpoint: a deleção usa apenas `credentialsId` sem verificar se a credencial pertence ao `workspaceId` validado. Um usuário autorizado num workspace poderia deletar credenciais de outro workspace se souber o ID da credencial.

   ```typescript
   await prisma.credentials.delete({
     where: {
       id: credentialsId,
       workspaceId: workspaceId,
     },
   })
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/builder/src/features/forge/api/credentials/deleteCredentials.ts
   Line: 28-32

   Comment:
   **Verificação de propriedade da credencial ausente**

   O mesmo problema existe neste endpoint: a deleção usa apenas `credentialsId` sem verificar se a credencial pertence ao `workspaceId` validado. Um usuário autorizado num workspace poderia deletar credenciais de outro workspace se souber o ID da credencial.

   ```typescript
   await prisma.credentials.delete({
     where: {
       id: credentialsId,
       workspaceId: workspaceId,
     },
   })
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fbuilder%2Fsrc%2Ffeatures%2Fforge%2Fapi%2Fcredentials%2FdeleteCredentials.ts%0ALine%3A%2028-32%0A%0AComment%3A%0A**Verifica%C3%A7%C3%A3o%20de%20propriedade%20da%20credencial%20ausente**%0A%0AO%20mesmo%20problema%20existe%20neste%20endpoint%3A%20a%20dele%C3%A7%C3%A3o%20usa%20apenas%20%60credentialsId%60%20sem%20verificar%20se%20a%20credencial%20pertence%20ao%20%60workspaceId%60%20validado.%20Um%20usu%C3%A1rio%20autorizado%20num%20workspace%20poderia%20deletar%20credenciais%20de%20outro%20workspace%20se%20souber%20o%20ID%20da%20credencial.%0A%0A%60%60%60typescript%0Aawait%20prisma.credentials.delete%28%7B%0A%20%20where%3A%20%7B%0A%20%20%20%20id%3A%20credentialsId%2C%0A%20%20%20%20workspaceId%3A%20workspaceId%2C%0A%20%20%7D%2C%0A%7D%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudhumans%2Ftypebot.io&pr=190&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fbuilder%2Fsrc%2Ffeatures%2Fforge%2Fapi%2Fcredentials%2FdeleteCredentials.ts%0ALine%3A%2028-32%0A%0AComment%3A%0A**Verifica%C3%A7%C3%A3o%20de%20propriedade%20da%20credencial%20ausente**%0A%0AO%20mesmo%20problema%20existe%20neste%20endpoint%3A%20a%20dele%C3%A7%C3%A3o%20usa%20apenas%20%60credentialsId%60%20sem%20verificar%20se%20a%20credencial%20pertence%20ao%20%60workspaceId%60%20validado.%20Um%20usu%C3%A1rio%20autorizado%20num%20workspace%20poderia%20deletar%20credenciais%20de%20outro%20workspace%20se%20souber%20o%20ID%20da%20credencial.%0A%0A%60%60%60typescript%0Aawait%20prisma.credentials.delete%28%7B%0A%20%20where%3A%20%7B%0A%20%20%20%20id%3A%20credentialsId%2C%0A%20%20%20%20workspaceId%3A%20workspaceId%2C%0A%20%20%7D%2C%0A%7D%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=190&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

3. `apps/builder/src/features/credentials/api/deleteCredentials.ts`, line 42-45 ([link](https://github.com/cloudhumans/typebot.io/blob/162fe423c6cb085a9d36b0fb53a87677624976e3/apps/builder/src/features/credentials/api/deleteCredentials.ts#L42-L45)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> **Credential not scoped to workspace on delete**

   The code confirms the user has write access to `workspaceId`, but the `prisma.credentials.delete` call filters only by `credentialsId`. An authorized member of workspace A can supply workspace A's ID (passes the `isWriteWorkspaceForbidden` check) together with any credential ID belonging to workspace B, and the credential from workspace B will be deleted without any ownership check.

   Fix: add `workspaceId` to the delete predicate:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/builder/src/features/credentials/api/deleteCredentials.ts
   Line: 42-45

   Comment:
   **Credential not scoped to workspace on delete**

   The code confirms the user has write access to `workspaceId`, but the `prisma.credentials.delete` call filters only by `credentialsId`. An authorized member of workspace A can supply workspace A's ID (passes the `isWriteWorkspaceForbidden` check) together with any credential ID belonging to workspace B, and the credential from workspace B will be deleted without any ownership check.

   Fix: add `workspaceId` to the delete predicate:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fbuilder%2Fsrc%2Ffeatures%2Fcredentials%2Fapi%2FdeleteCredentials.ts%0ALine%3A%2042-45%0A%0AComment%3A%0A**Credential%20not%20scoped%20to%20workspace%20on%20delete**%0A%0AThe%20code%20confirms%20the%20user%20has%20write%20access%20to%20%60workspaceId%60%2C%20but%20the%20%60prisma.credentials.delete%60%20call%20filters%20only%20by%20%60credentialsId%60.%20An%20authorized%20member%20of%20workspace%20A%20can%20supply%20workspace%20A's%20ID%20%28passes%20the%20%60isWriteWorkspaceForbidden%60%20check%29%20together%20with%20any%20credential%20ID%20belonging%20to%20workspace%20B%2C%20and%20the%20credential%20from%20workspace%20B%20will%20be%20deleted%20without%20any%20ownership%20check.%0A%0AFix%3A%20add%20%60workspaceId%60%20to%20the%20delete%20predicate%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20await%20prisma.credentials.delete%28%7B%0A%20%20%20%20%20%20%20%20where%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20id%3A%20credentialsId%2C%0A%20%20%20%20%20%20%20%20%20%20workspaceId%3A%20workspaceId%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%7D%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudhumans%2Ftypebot.io&pr=190&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fbuilder%2Fsrc%2Ffeatures%2Fcredentials%2Fapi%2FdeleteCredentials.ts%0ALine%3A%2042-45%0A%0AComment%3A%0A**Credential%20not%20scoped%20to%20workspace%20on%20delete**%0A%0AThe%20code%20confirms%20the%20user%20has%20write%20access%20to%20%60workspaceId%60%2C%20but%20the%20%60prisma.credentials.delete%60%20call%20filters%20only%20by%20%60credentialsId%60.%20An%20authorized%20member%20of%20workspace%20A%20can%20supply%20workspace%20A's%20ID%20%28passes%20the%20%60isWriteWorkspaceForbidden%60%20check%29%20together%20with%20any%20credential%20ID%20belonging%20to%20workspace%20B%2C%20and%20the%20credential%20from%20workspace%20B%20will%20be%20deleted%20without%20any%20ownership%20check.%0A%0AFix%3A%20add%20%60workspaceId%60%20to%20the%20delete%20predicate%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20await%20prisma.credentials.delete%28%7B%0A%20%20%20%20%20%20%20%20where%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20id%3A%20credentialsId%2C%0A%20%20%20%20%20%20%20%20%20%20workspaceId%3A%20workspaceId%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%7D%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=190&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

4. `apps/builder/src/features/forge/api/credentials/deleteCredentials.ts`, line 28-31 ([link](https://github.com/cloudhumans/typebot.io/blob/162fe423c6cb085a9d36b0fb53a87677624976e3/apps/builder/src/features/forge/api/credentials/deleteCredentials.ts#L28-L31)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> **Credential not scoped to workspace on delete**

   Same issue as the public credentials endpoint: the delete only filters by `credentialsId`, so a user with write access to any workspace can delete credentials that belong to a different workspace. Add `workspaceId` to the where clause to enforce ownership.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/builder/src/features/forge/api/credentials/deleteCredentials.ts
   Line: 28-31

   Comment:
   **Credential not scoped to workspace on delete**

   Same issue as the public credentials endpoint: the delete only filters by `credentialsId`, so a user with write access to any workspace can delete credentials that belong to a different workspace. Add `workspaceId` to the where clause to enforce ownership.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fbuilder%2Fsrc%2Ffeatures%2Fforge%2Fapi%2Fcredentials%2FdeleteCredentials.ts%0ALine%3A%2028-31%0A%0AComment%3A%0A**Credential%20not%20scoped%20to%20workspace%20on%20delete**%0A%0ASame%20issue%20as%20the%20public%20credentials%20endpoint%3A%20the%20delete%20only%20filters%20by%20%60credentialsId%60%2C%20so%20a%20user%20with%20write%20access%20to%20any%20workspace%20can%20delete%20credentials%20that%20belong%20to%20a%20different%20workspace.%20Add%20%60workspaceId%60%20to%20the%20where%20clause%20to%20enforce%20ownership.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20await%20prisma.credentials.delete%28%7B%0A%20%20%20%20%20%20%20%20where%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20id%3A%20credentialsId%2C%0A%20%20%20%20%20%20%20%20%20%20workspaceId%3A%20workspaceId%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%7D%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudhumans%2Ftypebot.io&pr=190&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fbuilder%2Fsrc%2Ffeatures%2Fforge%2Fapi%2Fcredentials%2FdeleteCredentials.ts%0ALine%3A%2028-31%0A%0AComment%3A%0A**Credential%20not%20scoped%20to%20workspace%20on%20delete**%0A%0ASame%20issue%20as%20the%20public%20credentials%20endpoint%3A%20the%20delete%20only%20filters%20by%20%60credentialsId%60%2C%20so%20a%20user%20with%20write%20access%20to%20any%20workspace%20can%20delete%20credentials%20that%20belong%20to%20a%20different%20workspace.%20Add%20%60workspaceId%60%20to%20the%20where%20clause%20to%20enforce%20ownership.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20await%20prisma.credentials.delete%28%7B%0A%20%20%20%20%20%20%20%20where%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20id%3A%20credentialsId%2C%0A%20%20%20%20%20%20%20%20%20%20workspaceId%3A%20workspaceId%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%7D%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=190&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["🔒security: scope credential deletion to..."](https://github.com/cloudhumans/typebot.io/commit/78af15055d0b7c232a601b8091b2a57a964abc05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29305489)</sub>

<!-- /greptile_comment -->