### PR TITLE
🔒 Fix authorization for Cognito users across multiple endpoints

### DIFF
--- a/apps/builder/src/features/blocks/integrations/openai/api/listModels.ts
+++ b/apps/builder/src/features/blocks/integrations/openai/api/listModels.ts
@@ -27,6 +27,7 @@ export const listModels = authenticatedProcedure
       const workspace = await prisma.workspace.findFirst({
         where: { id: workspaceId },
         select: {
+          id: true,
           members: {
             select: {
               userId: true,

--- a/apps/builder/src/features/credentials/api/deleteCredentials.ts
+++ b/apps/builder/src/features/credentials/api/deleteCredentials.ts
@@ -39,11 +39,17 @@ export const deleteCredentials = authenticatedProcedure
           message: 'Workspace not found',
         })
 
-      await prisma.credentials.delete({
+      const deletedCount = await prisma.credentials.deleteMany({
         where: {
           id: credentialsId,
+          workspaceId,
         },
       })
+      if (deletedCount.count === 0)
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Credentials not found',
+        })
       return { credentialsId }
     }
   )

--- a/apps/builder/src/features/credentials/api/deleteCredentials.ts
+++ b/apps/builder/src/features/credentials/api/deleteCredentials.ts
@@ -30,9 +30,6 @@ export const deleteCredentials = authenticatedProcedure
       const workspace = await prisma.workspace.findFirst({
         where: {
           id: workspaceId,
-          members: {
-            some: { userId: user.id, role: { in: ['ADMIN', 'MEMBER'] } },
-          },
         },
         select: { id: true, members: true },
       })

--- a/apps/builder/src/features/credentials/api/deleteCredentials.ts
+++ b/apps/builder/src/features/credentials/api/deleteCredentials.ts
@@ -27,7 +27,7 @@ export const deleteCredentials = authenticatedProcedure
   )
   .mutation(
     async ({ input: { credentialsId, workspaceId }, ctx: { user } }) => {
-      const workspace = await prisma.workspace.findFirst({
+      const workspace = await prisma.workspace.findUnique({
         where: {
           id: workspaceId,
         },

--- a/apps/builder/src/features/forge/api/credentials/deleteCredentials.ts
+++ b/apps/builder/src/features/forge/api/credentials/deleteCredentials.ts
@@ -25,11 +25,17 @@ export const deleteCredentials = authenticatedProcedure
           message: 'Workspace not found',
         })
 
-      await prisma.credentials.delete({
+      const deletedCount = await prisma.credentials.deleteMany({
         where: {
           id: credentialsId,
+          workspaceId,
         },
       })
+      if (deletedCount.count === 0)
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Credentials not found',
+        })
       return { credentialsId }
     }
   )

--- a/apps/builder/src/features/forge/api/credentials/deleteCredentials.ts
+++ b/apps/builder/src/features/forge/api/credentials/deleteCredentials.ts
@@ -16,9 +16,6 @@ export const deleteCredentials = authenticatedProcedure
       const workspace = await prisma.workspace.findFirst({
         where: {
           id: workspaceId,
-          members: {
-            some: { userId: user.id, role: { in: ['ADMIN', 'MEMBER'] } },
-          },
         },
         select: { id: true, members: true },
       })

--- a/apps/builder/src/features/forge/api/credentials/deleteCredentials.ts
+++ b/apps/builder/src/features/forge/api/credentials/deleteCredentials.ts
@@ -13,7 +13,7 @@ export const deleteCredentials = authenticatedProcedure
   )
   .mutation(
     async ({ input: { credentialsId, workspaceId }, ctx: { user } }) => {
-      const workspace = await prisma.workspace.findFirst({
+      const workspace = await prisma.workspace.findUnique({
         where: {
           id: workspaceId,
         },

--- a/apps/builder/src/features/forge/api/fetchSelectItems.ts
+++ b/apps/builder/src/features/forge/api/fetchSelectItems.ts
@@ -24,6 +24,7 @@ export const fetchSelectItems = authenticatedProcedure
       const workspace = await prisma.workspace.findFirst({
         where: { id: workspaceId },
         select: {
+          id: true,
           members: {
             select: {
               userId: true,

--- a/apps/builder/src/helpers/databaseRules.ts
+++ b/apps/builder/src/helpers/databaseRules.ts
@@ -1,18 +1,39 @@
 import {
   CollaborationType,
-  Plan,
   Prisma,
   User,
   WorkspaceRole,
 } from '@typebot.io/prisma'
-import prisma from '@typebot.io/lib/prisma'
-import { NextApiResponse } from 'next'
-import { forbidden } from '@typebot.io/lib/api'
 import { env } from '@typebot.io/env'
+import {
+  getCognitoAccessibleWorkspaceIds,
+  type CognitoUserClaims,
+} from '@/features/workspace/helpers/cognitoUtils'
+
+const workspaceMemberFilter = (
+  user: Pick<User, 'email' | 'id'> & { cognitoClaims?: CognitoUserClaims },
+  roleFilter?: Prisma.MemberInWorkspaceWhereInput
+): Prisma.WorkspaceWhereInput => {
+  const cognitoAccess = getCognitoAccessibleWorkspaceIds(user)
+
+  switch (cognitoAccess.type) {
+    case 'admin':
+      return {}
+    case 'restricted':
+      return {
+        OR: [
+          { members: { some: { userId: user.id, ...roleFilter } } },
+          { id: { in: cognitoAccess.ids } },
+        ],
+      }
+    case 'none':
+      return { members: { some: { userId: user.id, ...roleFilter } } }
+  }
+}
 
 export const canWriteTypebots = (
   typebotIds: string[] | string,
-  user: Pick<User, 'email' | 'id'>
+  user: Pick<User, 'email' | 'id'> & { cognitoClaims?: CognitoUserClaims }
 ): Prisma.TypebotWhereInput =>
   env.NEXT_PUBLIC_E2E_TEST
     ? { id: typeof typebotIds === 'string' ? typebotIds : { in: typebotIds } }
@@ -20,11 +41,9 @@ export const canWriteTypebots = (
         id: typeof typebotIds === 'string' ? typebotIds : { in: typebotIds },
         OR: [
           {
-            workspace: {
-              members: {
-                some: { userId: user.id, role: { not: WorkspaceRole.GUEST } },
-              },
-            },
+            workspace: workspaceMemberFilter(user, {
+              role: { not: WorkspaceRole.GUEST },
+            }),
           },
           {
             collaborators: {
@@ -36,18 +55,14 @@ export const canWriteTypebots = (
 
 export const canReadTypebots = (
   typebotIds: string | string[],
-  user: Pick<User, 'email' | 'id'>
+  user: Pick<User, 'email' | 'id'> & { cognitoClaims?: CognitoUserClaims }
 ) => ({
   id: typeof typebotIds === 'string' ? typebotIds : { in: typebotIds },
   workspace:
     env.ADMIN_EMAIL?.some((email) => email === user.email) ||
     env.NEXT_PUBLIC_E2E_TEST
       ? undefined
-      : {
-          members: {
-            some: { userId: user.id },
-          },
-        },
+      : workspaceMemberFilter(user),
 })
 
 export const canEditGuests = (user: User, typebotId: string) => ({
@@ -58,30 +73,6 @@ export const canEditGuests = (user: User, typebotId: string) => ({
     },
   },
 })
-
-export const canPublishFileInput = async ({
-  userId,
-  workspaceId,
-  res,
-}: {
-  userId: string
-  workspaceId: string
-  res: NextApiResponse
-}) => {
-  const workspace = await prisma.workspace.findFirst({
-    where: { id: workspaceId, members: { some: { userId } } },
-    select: { plan: true },
-  })
-  if (!workspace) {
-    forbidden(res, 'workspace not found')
-    return false
-  }
-  if (workspace?.plan === Plan.FREE) {
-    forbidden(res, 'You need to upgrade your plan to use file input blocks')
-    return false
-  }
-  return true
-}
 
 export const isUniqueConstraintError = (error: unknown) =>
   typeof error === 'object' &&

--- a/apps/builder/src/lib/googleSheets.ts
+++ b/apps/builder/src/lib/googleSheets.ts
@@ -1,4 +1,4 @@
-import { Credentials as CredentialsFromDb } from '@typebot.io/prisma'
+import { Credentials as CredentialsFromDb, User } from '@typebot.io/prisma'
 import { OAuth2Client, Credentials } from 'google-auth-library'
 import { GoogleSheetsCredentials } from '@typebot.io/schemas'
 import { isDefined } from '@typebot.io/lib'
@@ -6,9 +6,10 @@ import { env } from '@typebot.io/env'
 import prisma from '@typebot.io/lib/prisma'
 import { decrypt } from '@typebot.io/lib/api/encryption/decrypt'
 import { encrypt } from '@typebot.io/lib/api/encryption/encrypt'
+import { isReadWorkspaceFobidden } from '@/features/workspace/helpers/isReadWorkspaceFobidden'
 
 export const getAuthenticatedGoogleClient = async (
-  userId: string,
+  user: Pick<User, 'email' | 'id'> & { cognitoClaims?: unknown },
   credentialsId: string
 ): Promise<
   { client: OAuth2Client; credentials: CredentialsFromDb } | undefined
@@ -18,10 +19,19 @@ export const getAuthenticatedGoogleClient = async (
     env.GOOGLE_CLIENT_SECRET,
     `${env.NEXTAUTH_URL}/api/credentials/google-sheets/callback`
   )
-  const credentials = (await prisma.credentials.findFirst({
-    where: { id: credentialsId, workspace: { members: { some: { userId } } } },
-  })) as CredentialsFromDb | undefined
-  if (!credentials) return
+  const credentials = await prisma.credentials.findFirst({
+    where: { id: credentialsId },
+    include: {
+      workspace: {
+        select: {
+          id: true,
+          members: { select: { userId: true } },
+        },
+      },
+    },
+  })
+  if (!credentials || isReadWorkspaceFobidden(credentials.workspace, user))
+    return
   const data = (await decrypt(
     credentials.data,
     credentials.iv

--- a/apps/builder/src/pages/api/integrations/google-sheets/spreadsheets.ts
+++ b/apps/builder/src/pages/api/integrations/google-sheets/spreadsheets.ts
@@ -18,7 +18,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method === 'GET') {
     const credentialsId = req.query.credentialsId as string | undefined
     if (!credentialsId) return badRequest(res)
-    const auth = await getAuthenticatedGoogleClient(user.id, credentialsId)
+    const auth = await getAuthenticatedGoogleClient(user, credentialsId)
     if (!auth)
       return res.status(404).send("Couldn't find credentials in database")
     const response = await drive({

--- a/apps/builder/src/pages/api/integrations/google-sheets/spreadsheets/[id]/sheets.ts
+++ b/apps/builder/src/pages/api/integrations/google-sheets/spreadsheets/[id]/sheets.ts
@@ -20,7 +20,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const credentialsId = req.query.credentialsId as string | undefined
     if (!credentialsId) return badRequest(res)
     const spreadsheetId = req.query.id as string
-    const auth = await getAuthenticatedGoogleClient(user.id, credentialsId)
+    const auth = await getAuthenticatedGoogleClient(user, credentialsId)
     if (!auth)
       return res
         .status(404)


### PR DESCRIPTION
## Resumo

Corrige a autorização para usuários autenticados via Cognito que não estão na tabela `MemberInWorkspace`. Esses usuários não conseguiam:

- Deletar credenciais do workspace
- Usar o card do Google Sheets (selecionar spreadsheets/sheets)
- Usar o card do GPT/OpenAI (listar modelos, assistants, modelos de speech)

### Mudanças

- **`databaseRules.ts`** — Novo helper `workspaceMemberFilter` que considera acesso Cognito (admin/restricted/none) nos filtros `canWriteTypebots` e `canReadTypebots`
- **`googleSheets.ts`** — `getAuthenticatedGoogleClient` agora recebe o objeto `user` (com `cognitoClaims`) e usa `isReadWorkspaceFobidden` ao invés de filtrar por `members`
- **`listModels.ts`** / **`fetchSelectItems.ts`** — Adicionado `id: true` no `select` do workspace para que `isReadWorkspaceFobidden` consiga verificar acesso Cognito via `workspace.id`
- **`deleteCredentials.ts`** (credentials + forge) — Usa `deleteMany` com `{ id, workspaceId }` para prevenir deleção cross-workspace

## Plano de teste

- [ ] Usuário Cognito (não member) consegue deletar credenciais do próprio workspace
- [ ] Usuário Cognito consegue selecionar spreadsheets/sheets no card do Google Sheets
- [ ] Usuário Cognito consegue listar modelos GPT no card do OpenAI
- [ ] Usuário Cognito consegue listar assistants e modelos de speech no card do OpenAI
- [ ] Usuário member (sem Cognito) continua funcionando normalmente
- [ ] Não é possível deletar credenciais de outro workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Este PR corrige a autorização para usuários Cognito que não estão na tabela `MemberInWorkspace`, permitindo que eles deletem credenciais, usem o Google Sheets e listem modelos OpenAI. As mudanças são focadas e bem estruturadas: o novo helper `workspaceMemberFilter` centraliza a lógica Cognito nos filtros Prisma, e `deleteMany` com `workspaceId` elimina o risco de deleção cross-workspace.

<h3>Confidence Score: 5/5</h3>

PR seguro para merge; todos os findings são P2 (estilo/qualidade) sem impacto em comportamento ou segurança.

As correções de autorização são logicamente corretas e consistentes com os helpers existentes. Os únicos findings são overfetch de campos de `members` e uma inconsistência de tipo no retorno de `getAuthenticatedGoogleClient` — nenhum deles causa defeito em produção.

Nenhum arquivo requer atenção especial além das sugestões P2 em `deleteCredentials.ts` (ambos) e `googleSheets.ts`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/builder/src/helpers/databaseRules.ts | Novo helper `workspaceMemberFilter` centraliza a lógica Cognito nos filtros Prisma de leitura e escrita; remove `canPublishFileInput` não relacionado. |
| apps/builder/src/lib/googleSheets.ts | Autorização migrada para `isReadWorkspaceFobidden` em memória após busca; tipo de retorno não reflete a relação `workspace` incluída no objeto `credentials`. |
| apps/builder/src/features/credentials/api/deleteCredentials.ts | Usa `findUnique` + `isWriteWorkspaceForbidden` para checar acesso Cognito; `deleteMany` previne deleção cross-workspace, mas `members: true` busca campos desnecessários. |
| apps/builder/src/features/forge/api/credentials/deleteCredentials.ts | Mesma correção do outro `deleteCredentials.ts` para endpoints forge; mesmo problema de `members: true` overfetch. |
| apps/builder/src/features/blocks/integrations/openai/api/listModels.ts | Adiciona `id: true` ao select para que `isReadWorkspaceFobidden` possa verificar acesso Cognito; sem outros problemas. |
| apps/builder/src/features/forge/api/fetchSelectItems.ts | Adiciona `id: true` ao select do workspace para habilitar verificação Cognito; mudança cirúrgica sem impacto na lógica. |
| apps/builder/src/pages/api/integrations/google-sheets/spreadsheets.ts | Passa o objeto `user` completo para `getAuthenticatedGoogleClient`; mudança de uma linha, sem problemas. |
| apps/builder/src/pages/api/integrations/google-sheets/spreadsheets/[id]/sheets.ts | Idem — passa `user` em vez de `user.id` para `getAuthenticatedGoogleClient`. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Requisição autenticada] --> B{cognitoClaims presente?}
    B -- Não --> C[Verificar MemberInWorkspace no BD]
    B -- Sim --> D{hub_role = ADMIN?}
    D -- Sim --> E[Acesso total — filtro vazio]
    D -- Não --> F{eddie_workspaces contém workspaceId?}
    F -- Sim --> G[Acesso concedido via Cognito]
    F -- Não --> C
    C --> H{userId em members?}
    H -- Sim --> I[Acesso concedido via BD]
    H -- Não --> J[Acesso negado 403/404]
    E --> K[Operação executada]
    G --> K
    I --> K
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/builder/src/features/workspace/helpers/isReadWorkspaceFobidden.ts`, line 5 ([link](https://github.com/cloudhumans/typebot.io/blob/9e36d52ef10e3b0fa9ec2aed40445347e53938b6/apps/builder/src/features/workspace/helpers/isReadWorkspaceFobidden.ts#L5)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Typo persistente no nome do arquivo e da função**

   O nome `isReadWorkspaceFobidden` está com erro de ortografia — falta o `r` em "Forbidden". Este PR adicionou mais referências a esse arquivo (`googleSheets.ts`, `listModels.ts`, `fetchSelectItems.ts`, `databaseRules.ts`). Aproveitar a oportunidade para corrigir o nome evitaria que o erro se propagasse ainda mais pelo codebase.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/builder/src/features/workspace/helpers/isReadWorkspaceFobidden.ts
   Line: 5

   Comment:
   **Typo persistente no nome do arquivo e da função**

   O nome `isReadWorkspaceFobidden` está com erro de ortografia — falta o `r` em "Forbidden". Este PR adicionou mais referências a esse arquivo (`googleSheets.ts`, `listModels.ts`, `fetchSelectItems.ts`, `databaseRules.ts`). Aproveitar a oportunidade para corrigir o nome evitaria que o erro se propagasse ainda mais pelo codebase.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fbuilder%2Fsrc%2Ffeatures%2Fworkspace%2Fhelpers%2FisReadWorkspaceFobidden.ts%0ALine%3A%205%0A%0AComment%3A%0A**Typo%20persistente%20no%20nome%20do%20arquivo%20e%20da%20fun%C3%A7%C3%A3o**%0A%0AO%20nome%20%60isReadWorkspaceFobidden%60%20est%C3%A1%20com%20erro%20de%20ortografia%20%E2%80%94%20falta%20o%20%60r%60%20em%20%22Forbidden%22.%20Este%20PR%20adicionou%20mais%20refer%C3%AAncias%20a%20esse%20arquivo%20%28%60googleSheets.ts%60%2C%20%60listModels.ts%60%2C%20%60fetchSelectItems.ts%60%2C%20%60databaseRules.ts%60%29.%20Aproveitar%20a%20oportunidade%20para%20corrigir%20o%20nome%20evitaria%20que%20o%20erro%20se%20propagasse%20ainda%20mais%20pelo%20codebase.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudhumans%2Ftypebot.io&pr=192&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fbuilder%2Fsrc%2Ffeatures%2Fworkspace%2Fhelpers%2FisReadWorkspaceFobidden.ts%0ALine%3A%205%0A%0AComment%3A%0A**Typo%20persistente%20no%20nome%20do%20arquivo%20e%20da%20fun%C3%A7%C3%A3o**%0A%0AO%20nome%20%60isReadWorkspaceFobidden%60%20est%C3%A1%20com%20erro%20de%20ortografia%20%E2%80%94%20falta%20o%20%60r%60%20em%20%22Forbidden%22.%20Este%20PR%20adicionou%20mais%20refer%C3%AAncias%20a%20esse%20arquivo%20%28%60googleSheets.ts%60%2C%20%60listModels.ts%60%2C%20%60fetchSelectItems.ts%60%2C%20%60databaseRules.ts%60%29.%20Aproveitar%20a%20oportunidade%20para%20corrigir%20o%20nome%20evitaria%20que%20o%20erro%20se%20propagasse%20ainda%20mais%20pelo%20codebase.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=192&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fcredentials%2Fapi%2FdeleteCredentials.ts%3A34%0A**Sele%C3%A7%C3%A3o%20desnecess%C3%A1ria%20de%20todos%20os%20campos%20de%20%60members%60**%0A%0A%60members%3A%20true%60%20busca%20todas%20as%20colunas%20da%20tabela%20%60MemberInWorkspace%60%2C%20mas%20%60isWriteWorkspaceForbidden%60%20s%C3%B3%20precisa%20de%20%60userId%60%20e%20%60role%60.%20As%20demais%20colunas%20s%C3%A3o%20trazidas%20sem%20utilidade.%20Use%20um%20%60select%60%20expl%C3%ADcito%20para%20seguir%20o%20padr%C3%A3o%20dos%20outros%20endpoints.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20select%3A%20%7B%20id%3A%20true%2C%20members%3A%20%7B%20select%3A%20%7B%20userId%3A%20true%2C%20role%3A%20true%20%7D%20%7D%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fforge%2Fapi%2Fcredentials%2FdeleteCredentials.ts%3A20%0A**Sele%C3%A7%C3%A3o%20desnecess%C3%A1ria%20de%20todos%20os%20campos%20de%20%60members%60**%0A%0AMesmo%20problema%20do%20outro%20%60deleteCredentials.ts%60%3A%20%60members%3A%20true%60%20busca%20todos%20os%20campos%2C%20mas%20%60isWriteWorkspaceForbidden%60%20usa%20apenas%20%60userId%60%20e%20%60role%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20select%3A%20%7B%20id%3A%20true%2C%20members%3A%20%7B%20select%3A%20%7B%20userId%3A%20true%2C%20role%3A%20true%20%7D%20%7D%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fbuilder%2Fsrc%2Flib%2FgoogleSheets.ts%3A15%0A**Tipo%20de%20retorno%20desatualizado%20ap%C3%B3s%20inclus%C3%A3o%20da%20rela%C3%A7%C3%A3o%20%60workspace%60**%0A%0AA%20assinatura%20declara%20%60credentials%3A%20CredentialsFromDb%60%20no%20retorno%2C%20mas%20o%20objeto%20retornado%20agora%20carrega%20a%20rela%C3%A7%C3%A3o%20%60workspace%60%20%28resultado%20do%20%60include%60%29.%20Embora%20o%20TypeScript%20aceite%20via%20subtipagem%20estrutural%2C%20o%20tipo%20anunciado%20ao%20chamador%20esconde%20o%20campo%20%60workspace%60%20e%20pode%20causar%20confus%C3%A3o.%20Considere%20remover%20o%20campo%20%60workspace%60%20do%20objeto%20retornado%20ou%20atualizar%20o%20tipo%20de%20retorno%20para%20refletir%20a%20forma%20real.%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=192&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fcredentials%2Fapi%2FdeleteCredentials.ts%3A34%0A**Sele%C3%A7%C3%A3o%20desnecess%C3%A1ria%20de%20todos%20os%20campos%20de%20%60members%60**%0A%0A%60members%3A%20true%60%20busca%20todas%20as%20colunas%20da%20tabela%20%60MemberInWorkspace%60%2C%20mas%20%60isWriteWorkspaceForbidden%60%20s%C3%B3%20precisa%20de%20%60userId%60%20e%20%60role%60.%20As%20demais%20colunas%20s%C3%A3o%20trazidas%20sem%20utilidade.%20Use%20um%20%60select%60%20expl%C3%ADcito%20para%20seguir%20o%20padr%C3%A3o%20dos%20outros%20endpoints.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20select%3A%20%7B%20id%3A%20true%2C%20members%3A%20%7B%20select%3A%20%7B%20userId%3A%20true%2C%20role%3A%20true%20%7D%20%7D%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fforge%2Fapi%2Fcredentials%2FdeleteCredentials.ts%3A20%0A**Sele%C3%A7%C3%A3o%20desnecess%C3%A1ria%20de%20todos%20os%20campos%20de%20%60members%60**%0A%0AMesmo%20problema%20do%20outro%20%60deleteCredentials.ts%60%3A%20%60members%3A%20true%60%20busca%20todos%20os%20campos%2C%20mas%20%60isWriteWorkspaceForbidden%60%20usa%20apenas%20%60userId%60%20e%20%60role%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20select%3A%20%7B%20id%3A%20true%2C%20members%3A%20%7B%20select%3A%20%7B%20userId%3A%20true%2C%20role%3A%20true%20%7D%20%7D%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fbuilder%2Fsrc%2Flib%2FgoogleSheets.ts%3A15%0A**Tipo%20de%20retorno%20desatualizado%20ap%C3%B3s%20inclus%C3%A3o%20da%20rela%C3%A7%C3%A3o%20%60workspace%60**%0A%0AA%20assinatura%20declara%20%60credentials%3A%20CredentialsFromDb%60%20no%20retorno%2C%20mas%20o%20objeto%20retornado%20agora%20carrega%20a%20rela%C3%A7%C3%A3o%20%60workspace%60%20%28resultado%20do%20%60include%60%29.%20Embora%20o%20TypeScript%20aceite%20via%20subtipagem%20estrutural%2C%20o%20tipo%20anunciado%20ao%20chamador%20esconde%20o%20campo%20%60workspace%60%20e%20pode%20causar%20confus%C3%A3o.%20Considere%20remover%20o%20campo%20%60workspace%60%20do%20objeto%20retornado%20ou%20atualizar%20o%20tipo%20de%20retorno%20para%20refletir%20a%20forma%20real.%0A%0A&pr=192&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/builder/src/features/credentials/api/deleteCredentials.ts
Line: 34

Comment:
**Seleção desnecessária de todos os campos de `members`**

`members: true` busca todas as colunas da tabela `MemberInWorkspace`, mas `isWriteWorkspaceForbidden` só precisa de `userId` e `role`. As demais colunas são trazidas sem utilidade. Use um `select` explícito para seguir o padrão dos outros endpoints.

```suggestion
        select: { id: true, members: { select: { userId: true, role: true } } },
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/builder/src/features/forge/api/credentials/deleteCredentials.ts
Line: 20

Comment:
**Seleção desnecessária de todos os campos de `members`**

Mesmo problema do outro `deleteCredentials.ts`: `members: true` busca todos os campos, mas `isWriteWorkspaceForbidden` usa apenas `userId` e `role`.

```suggestion
        select: { id: true, members: { select: { userId: true, role: true } } },
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/builder/src/lib/googleSheets.ts
Line: 15

Comment:
**Tipo de retorno desatualizado após inclusão da relação `workspace`**

A assinatura declara `credentials: CredentialsFromDb` no retorno, mas o objeto retornado agora carrega a relação `workspace` (resultado do `include`). Embora o TypeScript aceite via subtipagem estrutural, o tipo anunciado ao chamador esconde o campo `workspace` e pode causar confusão. Considere remover o campo `workspace` do objeto retornado ou atualizar o tipo de retorno para refletir a forma real.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["♻️refactor: use findUnique for workspace..."](https://github.com/cloudhumans/typebot.io/commit/2273def2bb1a60086d0be22b18bcd9a7bb5fe89a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30081715)</sub>

<!-- /greptile_comment -->