### PR TITLE
feat(auth): cloudchat-embedded JIT user provisioning

### DIFF
--- a/apps/builder/src/features/auth/helpers/cloudchatEmbeddedAuthorize.test.ts
+++ b/apps/builder/src/features/auth/helpers/cloudchatEmbeddedAuthorize.test.ts
@@ -1,0 +1,316 @@
+import { vi } from 'vitest'
+
+vi.mock('@typebot.io/env', () => ({
+  env: {
+    COGNITO_ISSUER_URL: 'https://cognito.test/issuer',
+    CLOUDCHAT_COGNITO_APP_CLIENT_ID: 'test-client-id',
+  },
+}))
+
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('@/features/auth/helpers/verifyCognitoToken', () => ({
+  verifyCognitoToken: vi.fn(),
+}))
+
+vi.mock('./createCloudChatEmbeddedUser', () => ({
+  createCloudChatEmbeddedUser: vi.fn(),
+}))
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Prisma } from '@typebot.io/prisma'
+import logger from '@/helpers/logger'
+import { verifyCognitoToken } from '@/features/auth/helpers/verifyCognitoToken'
+import { createCloudChatEmbeddedUser } from './createCloudChatEmbeddedUser'
+import { cloudchatEmbeddedAuthorize } from './cloudchatEmbeddedAuthorize'
+
+const verifyMock = verifyCognitoToken as ReturnType<typeof vi.fn>
+const createMock = createCloudChatEmbeddedUser as ReturnType<typeof vi.fn>
+const loggerInfo = logger.info as unknown as ReturnType<typeof vi.fn>
+const loggerWarn = logger.warn as unknown as ReturnType<typeof vi.fn>
+const loggerError = logger.error as unknown as ReturnType<typeof vi.fn>
+
+const userFixture = {
+  id: 'user-1',
+  email: 'jit@local.test',
+  name: 'JIT',
+  image: null,
+  emailVerified: new Date('2026-05-06T00:00:00Z'),
+}
+
+const buildPrismaMock = (
+  findUniqueImpl?: ReturnType<typeof vi.fn>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): any => ({
+  user: {
+    findUnique: findUniqueImpl ?? vi.fn(async () => null),
+  },
+})
+
+const basePayload = {
+  email: 'jit@local.test',
+  email_verified: true,
+  name: 'JIT',
+  'custom:hub_role': 'CLIENT',
+  'custom:eddie_workspaces': 'ws-a,ws-b',
+  sub: 'sub-1',
+  exp: 9999999999,
+}
+
+describe('cloudchatEmbeddedAuthorize', () => {
+  beforeEach(() => {
+    verifyMock.mockReset()
+    createMock.mockReset()
+    loggerInfo.mockReset()
+    loggerWarn.mockReset()
+    loggerError.mockReset()
+  })
+
+  it('returns null when credentials.token is missing', async () => {
+    const p = buildPrismaMock()
+    const result = await cloudchatEmbeddedAuthorize(p, undefined)
+    expect(result).toBeNull()
+    expect(verifyMock).not.toHaveBeenCalled()
+  })
+
+  it('returns null and logs error when verifyCognitoToken throws', async () => {
+    verifyMock.mockRejectedValueOnce(new Error('bad signature'))
+    const p = buildPrismaMock()
+
+    const result = await cloudchatEmbeddedAuthorize(p, { token: 'bad' })
+
+    expect(result).toBeNull()
+    expect(loggerError).toHaveBeenCalledWith(
+      'Error in cloudchat-embedded authorize',
+      expect.objectContaining({ error: expect.any(Error) })
+    )
+  })
+
+  it('returns null and logs warn when payload has no email', async () => {
+    verifyMock.mockResolvedValueOnce({ sub: 'sub-x', 'cognito:username': 'u' })
+    const p = buildPrismaMock()
+
+    const result = await cloudchatEmbeddedAuthorize(p, { token: 't' })
+
+    expect(result).toBeNull()
+    expect(loggerWarn).toHaveBeenCalledWith(
+      'cloudchat-embedded payload missing email',
+      { sub: 'sub-x', cognitoUsername: 'u' }
+    )
+    expect(p.user.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('returns existing user when findUnique hits (does not call createCloudChatEmbeddedUser)', async () => {
+    verifyMock.mockResolvedValueOnce(basePayload)
+    const findUnique = vi.fn(async () => userFixture)
+    const p = buildPrismaMock(findUnique)
+
+    const result = await cloudchatEmbeddedAuthorize(p, { token: 't' })
+
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { email: 'jit@local.test' },
+    })
+    expect(createMock).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      id: 'user-1',
+      email: 'jit@local.test',
+      cloudChatAuthorization: true,
+    })
+  })
+
+  it("creates user via createCloudChatEmbeddedUser and logs info 'JIT-provisioned'", async () => {
+    verifyMock.mockResolvedValueOnce(basePayload)
+    const findUnique = vi.fn(async () => null)
+    const p = buildPrismaMock(findUnique)
+    createMock.mockResolvedValueOnce(userFixture)
+
+    const result = await cloudchatEmbeddedAuthorize(p, { token: 't' })
+
+    expect(createMock).toHaveBeenCalledWith({
+      p,
+      email: 'jit@local.test',
+      name: 'JIT',
+      emailVerified: expect.any(Date),
+    })
+    expect(loggerInfo).toHaveBeenCalledWith(
+      'JIT-provisioned cloudchat-embedded user',
+      {
+        userId: 'user-1',
+        email: 'jit@local.test',
+        hubRole: 'CLIENT',
+        eddieWorkspacesCount: 2,
+      }
+    )
+    expect(result).not.toBeNull()
+  })
+
+  it("on P2002: refetches and returns user, logs info 'race resolved'", async () => {
+    verifyMock.mockResolvedValueOnce(basePayload)
+    const findUnique = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(userFixture)
+    const p = buildPrismaMock(findUnique)
+
+    const p2002 = new Prisma.PrismaClientKnownRequestError(
+      'Unique constraint failed',
+      { code: 'P2002', clientVersion: '5.12.1' }
+    )
+    createMock.mockRejectedValueOnce(p2002)
+
+    const result = await cloudchatEmbeddedAuthorize(p, { token: 't' })
+
+    expect(findUnique).toHaveBeenCalledTimes(2)
+    expect(loggerInfo).toHaveBeenCalledWith(
+      'cloudchat-embedded JIT race resolved',
+      { email: 'jit@local.test' }
+    )
+    expect(result).toMatchObject({ id: 'user-1' })
+  })
+
+  it('on P2002 + refetch returns null: rethrows (caught by outer, returns null + error log)', async () => {
+    verifyMock.mockResolvedValueOnce(basePayload)
+    const findUnique = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+    const p = buildPrismaMock(findUnique)
+
+    const p2002 = new Prisma.PrismaClientKnownRequestError(
+      'Unique constraint failed',
+      { code: 'P2002', clientVersion: '5.12.1' }
+    )
+    createMock.mockRejectedValueOnce(p2002)
+
+    const result = await cloudchatEmbeddedAuthorize(p, { token: 't' })
+
+    expect(result).toBeNull()
+    expect(loggerError).toHaveBeenCalledWith(
+      'Error in cloudchat-embedded authorize',
+      expect.objectContaining({ error: expect.any(Error) })
+    )
+  })
+
+  it('on non-P2002 error: logs warn JIT refused + returns null', async () => {
+    verifyMock.mockResolvedValueOnce(basePayload)
+    const findUnique = vi.fn(async () => null)
+    const p = buildPrismaMock(findUnique)
+    createMock.mockRejectedValueOnce(new Error('telemetry endpoint down'))
+
+    const result = await cloudchatEmbeddedAuthorize(p, { token: 't' })
+
+    expect(result).toBeNull()
+    expect(loggerWarn).toHaveBeenCalledWith('cloudchat-embedded JIT refused', {
+      email: 'jit@local.test',
+      reason: 'telemetry endpoint down',
+    })
+    expect(loggerError).not.toHaveBeenCalled()
+  })
+
+  it('returns full DatabaseUserWithCognito shape with cloudChatAuthorization=true and cognitoTokenExp', async () => {
+    verifyMock.mockResolvedValueOnce(basePayload)
+    const findUnique = vi.fn(async () => userFixture)
+    const p = buildPrismaMock(findUnique)
+
+    const result = await cloudchatEmbeddedAuthorize(p, { token: 't' })
+
+    expect(result).toEqual({
+      id: 'user-1',
+      email: 'jit@local.test',
+      name: 'JIT',
+      image: null,
+      emailVerified: userFixture.emailVerified,
+      cognitoClaims: {
+        'custom:hub_role': 'CLIENT',
+        'custom:eddie_workspaces': 'ws-a,ws-b',
+      },
+      cloudChatAuthorization: true,
+      cognitoTokenExp: 9999999999,
+    })
+  })
+
+  it('maps email_verified=true to emailVerified Date; false/undefined to null', async () => {
+    verifyMock.mockResolvedValueOnce({ ...basePayload, email_verified: true })
+    const p1 = buildPrismaMock(vi.fn(async () => null))
+    createMock.mockResolvedValueOnce(userFixture)
+    await cloudchatEmbeddedAuthorize(p1, { token: 't' })
+    expect(createMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ emailVerified: expect.any(Date) })
+    )
+
+    verifyMock.mockResolvedValueOnce({
+      ...basePayload,
+      email: 'a@b',
+      email_verified: false,
+    })
+    const p2 = buildPrismaMock(vi.fn(async () => null))
+    createMock.mockResolvedValueOnce(userFixture)
+    await cloudchatEmbeddedAuthorize(p2, { token: 't' })
+    expect(createMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ emailVerified: null })
+    )
+
+    verifyMock.mockResolvedValueOnce({
+      ...basePayload,
+      email: 'c@d',
+      email_verified: undefined,
+    })
+    const p3 = buildPrismaMock(vi.fn(async () => null))
+    createMock.mockResolvedValueOnce(userFixture)
+    await cloudchatEmbeddedAuthorize(p3, { token: 't' })
+    expect(createMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ emailVerified: null })
+    )
+  })
+
+  it("counts eddie_workspaces correctly: 'ws-a,ws-b' = 2; '' = 0; '*' = 1", async () => {
+    const findUnique = vi.fn(async () => null)
+
+    verifyMock.mockResolvedValueOnce({
+      ...basePayload,
+      'custom:eddie_workspaces': 'ws-a,ws-b',
+    })
+    createMock.mockResolvedValueOnce(userFixture)
+    await cloudchatEmbeddedAuthorize(buildPrismaMock(findUnique), {
+      token: 't',
+    })
+    expect(loggerInfo).toHaveBeenLastCalledWith(
+      'JIT-provisioned cloudchat-embedded user',
+      expect.objectContaining({ eddieWorkspacesCount: 2 })
+    )
+
+    verifyMock.mockResolvedValueOnce({
+      ...basePayload,
+      email: 'b@b',
+      'custom:eddie_workspaces': '',
+    })
+    createMock.mockResolvedValueOnce(userFixture)
+    await cloudchatEmbeddedAuthorize(buildPrismaMock(findUnique), {
+      token: 't',
+    })
+    expect(loggerInfo).toHaveBeenLastCalledWith(
+      'JIT-provisioned cloudchat-embedded user',
+      expect.objectContaining({ eddieWorkspacesCount: 0 })
+    )
+
+    verifyMock.mockResolvedValueOnce({
+      ...basePayload,
+      email: 'c@c',
+      'custom:eddie_workspaces': '*',
+    })
+    createMock.mockResolvedValueOnce(userFixture)
+    await cloudchatEmbeddedAuthorize(buildPrismaMock(findUnique), {
+      token: 't',
+    })
+    expect(loggerInfo).toHaveBeenLastCalledWith(
+      'JIT-provisioned cloudchat-embedded user',
+      expect.objectContaining({ eddieWorkspacesCount: 1 })
+    )
+  })
+})

--- a/apps/builder/src/features/auth/helpers/cloudchatEmbeddedAuthorize.test.ts
+++ b/apps/builder/src/features/auth/helpers/cloudchatEmbeddedAuthorize.test.ts
@@ -42,6 +42,7 @@ const userFixture = {
   name: 'JIT',
   image: null,
   emailVerified: new Date('2026-05-06T00:00:00Z'),
+  createdAt: new Date('2026-05-05T12:00:00Z'),
 }
 
 const buildPrismaMock = (
@@ -201,14 +202,14 @@ describe('cloudchatEmbeddedAuthorize', () => {
     verifyMock.mockResolvedValueOnce(basePayload)
     const findUnique = vi.fn(async () => null)
     const p = buildPrismaMock(findUnique)
-    createMock.mockRejectedValueOnce(new Error('telemetry endpoint down'))
+    createMock.mockRejectedValueOnce(new Error('db: connection lost'))
 
     const result = await cloudchatEmbeddedAuthorize(p, { token: 't' })
 
     expect(result).toBeNull()
     expect(loggerWarn).toHaveBeenCalledWith('cloudchat-embedded JIT refused', {
       email: 'jit@local.test',
-      reason: 'telemetry endpoint down',
+      reason: 'db: connection lost',
     })
     expect(loggerError).not.toHaveBeenCalled()
   })
@@ -226,6 +227,7 @@ describe('cloudchatEmbeddedAuthorize', () => {
       name: 'JIT',
       image: null,
       emailVerified: userFixture.emailVerified,
+      createdAt: userFixture.createdAt,
       cognitoClaims: {
         'custom:hub_role': 'CLIENT',
         'custom:eddie_workspaces': 'ws-a,ws-b',
@@ -233,6 +235,16 @@ describe('cloudchatEmbeddedAuthorize', () => {
       cloudChatAuthorization: true,
       cognitoTokenExp: 9999999999,
     })
+  })
+
+  it("forwards user.createdAt so signIn callback's isNewUser check works for returning users", async () => {
+    verifyMock.mockResolvedValueOnce(basePayload)
+    const findUnique = vi.fn(async () => userFixture)
+    const p = buildPrismaMock(findUnique)
+
+    const result = await cloudchatEmbeddedAuthorize(p, { token: 't' })
+
+    expect(result?.createdAt).toEqual(userFixture.createdAt)
   })
 
   it('maps email_verified=true to emailVerified Date; false/undefined to null', async () => {

--- a/apps/builder/src/features/auth/helpers/cloudchatEmbeddedAuthorize.ts
+++ b/apps/builder/src/features/auth/helpers/cloudchatEmbeddedAuthorize.ts
@@ -1,0 +1,100 @@
+import { PrismaClient } from '@typebot.io/prisma'
+import { env } from '@typebot.io/env'
+import logger from '@/helpers/logger'
+import { verifyCognitoToken } from '@/features/auth/helpers/verifyCognitoToken'
+import { DatabaseUserWithCognito } from '@/features/auth/types/cognito'
+import { isPrismaUniqueViolation } from './isPrismaUniqueViolation'
+import { createCloudChatEmbeddedUser } from './createCloudChatEmbeddedUser'
+
+type Credentials = { token?: string } | undefined
+
+type AuthorizedUser = Pick<
+  DatabaseUserWithCognito,
+  | 'id'
+  | 'name'
+  | 'email'
+  | 'image'
+  | 'emailVerified'
+  | 'cognitoClaims'
+  | 'cloudChatAuthorization'
+  | 'cognitoTokenExp'
+>
+
+export const cloudchatEmbeddedAuthorize = async (
+  p: PrismaClient,
+  credentials: Credentials
+): Promise<AuthorizedUser | null> => {
+  try {
+    if (!credentials?.token) return null
+
+    const payload = await verifyCognitoToken({
+      cognitoAppClientId: env.CLOUDCHAT_COGNITO_APP_CLIENT_ID,
+      cognitoIssuerUrl: env.COGNITO_ISSUER_URL,
+      cognitoToken: credentials.token,
+    })
+
+    if (typeof payload.email !== 'string' || payload.email.length === 0) {
+      logger.warn('cloudchat-embedded payload missing email', {
+        sub: payload.sub,
+        cognitoUsername: payload['cognito:username'],
+      })
+      return null
+    }
+
+    let user = await p.user.findUnique({
+      where: { email: payload.email },
+    })
+
+    if (!user) {
+      try {
+        user = await createCloudChatEmbeddedUser({
+          p,
+          email: payload.email,
+          name: payload.name ?? null,
+          emailVerified: payload.email_verified === true ? new Date() : null,
+        })
+        logger.info('JIT-provisioned cloudchat-embedded user', {
+          userId: user.id,
+          email: user.email,
+          hubRole: payload['custom:hub_role'],
+          eddieWorkspacesCount: (payload['custom:eddie_workspaces'] ?? '')
+            .split(',')
+            .filter(Boolean).length,
+        })
+      } catch (err) {
+        if (isPrismaUniqueViolation(err)) {
+          user = await p.user.findUnique({
+            where: { email: payload.email },
+          })
+          if (!user) throw err
+          logger.info('cloudchat-embedded JIT race resolved', {
+            email: payload.email,
+          })
+        } else {
+          logger.warn('cloudchat-embedded JIT refused', {
+            email: payload.email,
+            reason: err instanceof Error ? err.message : 'unknown',
+          })
+          return null
+        }
+      }
+    }
+
+    return {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      image: user.image,
+      emailVerified: user.emailVerified,
+      cognitoClaims: {
+        'custom:hub_role': payload['custom:hub_role'],
+        'custom:eddie_workspaces': payload['custom:eddie_workspaces'],
+      },
+      cloudChatAuthorization: true,
+      cognitoTokenExp: payload.exp,
+    }
+  } catch (error) {
+    logger.error('Error in cloudchat-embedded authorize', { error })
+    return null
+  }
+}

--- a/apps/builder/src/features/auth/helpers/cloudchatEmbeddedAuthorize.ts
+++ b/apps/builder/src/features/auth/helpers/cloudchatEmbeddedAuthorize.ts
@@ -15,6 +15,7 @@ type AuthorizedUser = Pick<
   | 'email'
   | 'image'
   | 'emailVerified'
+  | 'createdAt'
   | 'cognitoClaims'
   | 'cloudChatAuthorization'
   | 'cognitoTokenExp'
@@ -86,6 +87,11 @@ export const cloudchatEmbeddedAuthorize = async (
       name: user.name,
       image: user.image,
       emailVerified: user.emailVerified,
+      // Forwarded so the signIn callback's `isNewUser` check evaluates correctly.
+      // Without this, every cloudchat-embedded login (new AND returning) is treated
+      // as a new user, triggering the disposable-email blocklist GitHub fetch on
+      // the auth hot path.
+      createdAt: user.createdAt,
       cognitoClaims: {
         'custom:hub_role': payload['custom:hub_role'],
         'custom:eddie_workspaces': payload['custom:eddie_workspaces'],

--- a/apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.test.ts
+++ b/apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.test.ts
@@ -13,7 +13,8 @@ const trackEventsMock = trackEvents as ReturnType<typeof vi.fn>
 const buildPrismaMock = (overrides?: { create?: ReturnType<typeof vi.fn> }) => {
   const create =
     overrides?.create ??
-    vi.fn(async ({ data }) => ({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.fn(async ({ data }: { data: any }) => ({
       id: 'user-fixture-id',
       email: data.email,
       name: data.name ?? null,

--- a/apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.test.ts
+++ b/apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.test.ts
@@ -4,11 +4,21 @@ vi.mock('@typebot.io/telemetry/trackEvents', () => ({
   trackEvents: vi.fn(),
 }))
 
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
 import { describe, it, expect, beforeEach } from 'vitest'
 import { trackEvents } from '@typebot.io/telemetry/trackEvents'
+import logger from '@/helpers/logger'
 import { createCloudChatEmbeddedUser } from './createCloudChatEmbeddedUser'
 
 const trackEventsMock = trackEvents as ReturnType<typeof vi.fn>
+const loggerWarn = logger.warn as unknown as ReturnType<typeof vi.fn>
 
 const buildPrismaMock = (overrides?: { create?: ReturnType<typeof vi.fn> }) => {
   const create =
@@ -34,6 +44,7 @@ describe('createCloudChatEmbeddedUser', () => {
   beforeEach(() => {
     trackEventsMock.mockReset()
     trackEventsMock.mockResolvedValue(undefined)
+    loggerWarn.mockReset()
   })
 
   it('creates a User row with email + name + emailVerified + image', async () => {
@@ -128,12 +139,23 @@ describe('createCloudChatEmbeddedUser', () => {
     expect(trackEventsMock).not.toHaveBeenCalled()
   })
 
-  it('propagates trackEvents errors (does not swallow)', async () => {
+  it('swallows trackEvents errors and returns the user (telemetry is best-effort)', async () => {
     trackEventsMock.mockRejectedValueOnce(new Error('telemetry endpoint down'))
     const p = buildPrismaMock()
 
-    await expect(
-      createCloudChatEmbeddedUser({ p, email: 'tele@local.test' })
-    ).rejects.toThrow('telemetry endpoint down')
+    const user = await createCloudChatEmbeddedUser({
+      p,
+      email: 'tele@local.test',
+    })
+
+    expect(user.email).toBe('tele@local.test')
+    expect(loggerWarn).toHaveBeenCalledWith(
+      'cloudchat-embedded telemetry failed (user provisioned)',
+      {
+        userId: 'user-fixture-id',
+        email: 'tele@local.test',
+        error: 'telemetry endpoint down',
+      }
+    )
   })
 })

--- a/apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.test.ts
+++ b/apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.test.ts
@@ -1,0 +1,138 @@
+import { vi } from 'vitest'
+
+vi.mock('@typebot.io/telemetry/trackEvents', () => ({
+  trackEvents: vi.fn(),
+}))
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { trackEvents } from '@typebot.io/telemetry/trackEvents'
+import { createCloudChatEmbeddedUser } from './createCloudChatEmbeddedUser'
+
+const trackEventsMock = trackEvents as ReturnType<typeof vi.fn>
+
+const buildPrismaMock = (overrides?: { create?: ReturnType<typeof vi.fn> }) => {
+  const create =
+    overrides?.create ??
+    vi.fn(async ({ data }) => ({
+      id: 'user-fixture-id',
+      email: data.email,
+      name: data.name ?? null,
+      emailVerified: data.emailVerified ?? null,
+      image: data.image ?? null,
+      onboardingCategories: data.onboardingCategories ?? [],
+      createdAt: new Date('2026-05-06T00:00:00Z'),
+      updatedAt: new Date('2026-05-06T00:00:00Z'),
+    }))
+  return {
+    user: { create },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any
+}
+
+describe('createCloudChatEmbeddedUser', () => {
+  beforeEach(() => {
+    trackEventsMock.mockReset()
+    trackEventsMock.mockResolvedValue(undefined)
+  })
+
+  it('creates a User row with email + name + emailVerified + image', async () => {
+    const p = buildPrismaMock()
+    const verifiedAt = new Date('2026-05-06T00:00:00Z')
+    const user = await createCloudChatEmbeddedUser({
+      p,
+      email: 'maria@cliente.com',
+      name: 'Maria Cliente',
+      emailVerified: verifiedAt,
+      image: null,
+    })
+
+    expect(p.user.create).toHaveBeenCalledTimes(1)
+    expect(p.user.create).toHaveBeenCalledWith({
+      data: {
+        email: 'maria@cliente.com',
+        name: 'Maria Cliente',
+        emailVerified: verifiedAt,
+        image: undefined,
+        onboardingCategories: [],
+      },
+    })
+    expect(user.email).toBe('maria@cliente.com')
+  })
+
+  it('creates a User row with email only when name and emailVerified absent', async () => {
+    const p = buildPrismaMock()
+    await createCloudChatEmbeddedUser({ p, email: 'minimal@local.test' })
+
+    expect(p.user.create).toHaveBeenCalledWith({
+      data: {
+        email: 'minimal@local.test',
+        name: undefined,
+        emailVerified: undefined,
+        image: undefined,
+        onboardingCategories: [],
+      },
+    })
+  })
+
+  it('does not create workspace, MemberInWorkspace or apiToken (no nested relations)', async () => {
+    const p = buildPrismaMock()
+    await createCloudChatEmbeddedUser({ p, email: 'no-side@local.test' })
+
+    const callArg = p.user.create.mock.calls[0][0]
+    expect(callArg.data).not.toHaveProperty('apiTokens')
+    expect(callArg.data).not.toHaveProperty('workspaces')
+    expect(callArg).not.toHaveProperty('include')
+  })
+
+  it("fires a single 'User created' telemetry event with email and first-name", async () => {
+    const p = buildPrismaMock()
+    await createCloudChatEmbeddedUser({
+      p,
+      email: 'two-words@local.test',
+      name: 'João da Silva',
+    })
+
+    expect(trackEventsMock).toHaveBeenCalledTimes(1)
+    expect(trackEventsMock).toHaveBeenCalledWith([
+      {
+        name: 'User created',
+        userId: 'user-fixture-id',
+        data: { email: 'two-words@local.test', name: 'João' },
+      },
+    ])
+  })
+
+  it('emits telemetry with name=undefined when name is null/absent', async () => {
+    const p = buildPrismaMock()
+    await createCloudChatEmbeddedUser({ p, email: 'no-name@local.test' })
+
+    expect(trackEventsMock).toHaveBeenCalledWith([
+      {
+        name: 'User created',
+        userId: 'user-fixture-id',
+        data: { email: 'no-name@local.test', name: undefined },
+      },
+    ])
+  })
+
+  it('propagates prisma.user.create errors (does not swallow)', async () => {
+    const create = vi.fn(async () => {
+      throw new Error('db connection lost')
+    })
+    const p = buildPrismaMock({ create })
+
+    await expect(
+      createCloudChatEmbeddedUser({ p, email: 'boom@local.test' })
+    ).rejects.toThrow('db connection lost')
+    expect(trackEventsMock).not.toHaveBeenCalled()
+  })
+
+  it('propagates trackEvents errors (does not swallow)', async () => {
+    trackEventsMock.mockRejectedValueOnce(new Error('telemetry endpoint down'))
+    const p = buildPrismaMock()
+
+    await expect(
+      createCloudChatEmbeddedUser({ p, email: 'tele@local.test' })
+    ).rejects.toThrow('telemetry endpoint down')
+  })
+})

--- a/apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.ts
+++ b/apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.ts
@@ -1,0 +1,38 @@
+import { PrismaClient, User } from '@typebot.io/prisma'
+import { trackEvents } from '@typebot.io/telemetry/trackEvents'
+
+type CreateCloudChatEmbeddedUserInput = {
+  p: PrismaClient
+  email: string
+  name?: string | null
+  emailVerified?: Date | null
+  image?: string | null
+}
+
+export const createCloudChatEmbeddedUser = async ({
+  p,
+  email,
+  name,
+  emailVerified,
+  image,
+}: CreateCloudChatEmbeddedUserInput): Promise<User> => {
+  const user = await p.user.create({
+    data: {
+      email,
+      name: name ?? undefined,
+      emailVerified: emailVerified ?? undefined,
+      image: image ?? undefined,
+      onboardingCategories: [],
+    },
+  })
+
+  await trackEvents([
+    {
+      name: 'User created',
+      userId: user.id,
+      data: { email, name: name?.split(' ')[0] },
+    },
+  ])
+
+  return user
+}

--- a/apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.ts
+++ b/apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.ts
@@ -1,5 +1,6 @@
 import { PrismaClient, User } from '@typebot.io/prisma'
 import { trackEvents } from '@typebot.io/telemetry/trackEvents'
+import logger from '@/helpers/logger'
 
 type CreateCloudChatEmbeddedUserInput = {
   p: PrismaClient
@@ -26,13 +27,24 @@ export const createCloudChatEmbeddedUser = async ({
     },
   })
 
-  await trackEvents([
-    {
-      name: 'User created',
+  // Telemetry is best-effort. The user row is the load-bearing side effect;
+  // a telemetry outage must not block the auth path or surface as a JIT refusal.
+  try {
+    await trackEvents([
+      {
+        name: 'User created',
+        userId: user.id,
+        data: { email, name: name?.split(' ')[0] },
+      },
+    ])
+  } catch (telemetryError) {
+    logger.warn('cloudchat-embedded telemetry failed (user provisioned)', {
       userId: user.id,
-      data: { email, name: name?.split(' ')[0] },
-    },
-  ])
+      email: user.email,
+      error:
+        telemetryError instanceof Error ? telemetryError.message : 'unknown',
+    })
+  }
 
   return user
 }

--- a/apps/builder/src/features/auth/helpers/isPrismaUniqueViolation.test.ts
+++ b/apps/builder/src/features/auth/helpers/isPrismaUniqueViolation.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { Prisma } from '@typebot.io/prisma'
+import { isPrismaUniqueViolation } from './isPrismaUniqueViolation'
+
+describe('isPrismaUniqueViolation', () => {
+  it('returns true for PrismaClientKnownRequestError with code P2002', () => {
+    const err = new Prisma.PrismaClientKnownRequestError(
+      'Unique constraint failed on the fields: (`email`)',
+      { code: 'P2002', clientVersion: '5.12.1' }
+    )
+    expect(isPrismaUniqueViolation(err)).toBe(true)
+  })
+
+  it('returns false for PrismaClientKnownRequestError with non-P2002 codes', () => {
+    const err = new Prisma.PrismaClientKnownRequestError('Record not found', {
+      code: 'P2025',
+      clientVersion: '5.12.1',
+    })
+    expect(isPrismaUniqueViolation(err)).toBe(false)
+  })
+
+  it('returns false for a plain Error instance', () => {
+    expect(isPrismaUniqueViolation(new Error('boom'))).toBe(false)
+  })
+
+  it('returns false for non-Error values', () => {
+    expect(isPrismaUniqueViolation(null)).toBe(false)
+    expect(isPrismaUniqueViolation(undefined)).toBe(false)
+    expect(isPrismaUniqueViolation('string')).toBe(false)
+    expect(isPrismaUniqueViolation({ code: 'P2002' })).toBe(false)
+    expect(isPrismaUniqueViolation(42)).toBe(false)
+  })
+})

--- a/apps/builder/src/features/auth/helpers/isPrismaUniqueViolation.ts
+++ b/apps/builder/src/features/auth/helpers/isPrismaUniqueViolation.ts
@@ -1,0 +1,4 @@
+import { Prisma } from '@typebot.io/prisma'
+
+export const isPrismaUniqueViolation = (e: unknown): boolean =>
+  e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002'

--- a/apps/builder/src/pages/api/auth/[...nextauth].ts
+++ b/apps/builder/src/pages/api/auth/[...nextauth].ts
@@ -30,7 +30,7 @@ import {
   CognitoClaims,
 } from '@/features/auth/types/cognito'
 import logger from '@/helpers/logger'
-import { verifyCognitoToken } from '@/features/auth/helpers/verifyCognitoToken'
+import { cloudchatEmbeddedAuthorize } from '@/features/auth/helpers/cloudchatEmbeddedAuthorize'
 
 const providers: Provider[] = []
 
@@ -159,52 +159,8 @@ providers.push(
     credentials: {
       token: { label: 'Token', type: 'text' },
     },
-    async authorize(
-      credentials
-    ): Promise<Pick<
-      DatabaseUserWithCognito,
-      | 'id'
-      | 'name'
-      | 'email'
-      | 'image'
-      | 'emailVerified'
-      | 'cognitoClaims'
-      | 'cloudChatAuthorization'
-      | 'cognitoTokenExp'
-    > | null> {
-      try {
-        if (!credentials?.token) return null
-
-        const payload = await verifyCognitoToken({
-          cognitoAppClientId: env.CLOUDCHAT_COGNITO_APP_CLIENT_ID,
-          cognitoIssuerUrl: env.COGNITO_ISSUER_URL,
-          cognitoToken: credentials.token,
-        })
-
-        const user = await prisma.user.findUnique({
-          where: { email: payload.email },
-        })
-
-        if (!user) return null
-
-        return {
-          id: user.id,
-          email: user.email,
-          name: user.name,
-          image: user.image,
-          emailVerified: user.emailVerified,
-          cognitoClaims: {
-            'custom:hub_role': payload['custom:hub_role'],
-            'custom:eddie_workspaces': payload['custom:eddie_workspaces'],
-          },
-          cloudChatAuthorization: true,
-          cognitoTokenExp: payload.exp,
-        }
-      } catch (error) {
-        logger.error('Error in cloudchat-embedded authorize', { error })
-        return null
-      }
-    },
+    authorize: (credentials) =>
+      cloudchatEmbeddedAuthorize(prisma, credentials ?? undefined),
   })
 )
 

--- a/docs/superpowers/plans/2026-05-06-cloudchat-embedded-jit-provisioning.md
+++ b/docs/superpowers/plans/2026-05-06-cloudchat-embedded-jit-provisioning.md
@@ -1,0 +1,1168 @@
+# CloudChat-Embedded JIT User Provisioning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Provision the typebot `User` row just-in-time when a valid CloudChat Cognito JWT is presented in the embedded auth flow, eliminating the "Failed to load flow builder. Please reload the page." error on first-time CloudChat embed.
+
+**Architecture:** Pure-additive on the `cloudchat-embedded` NextAuth provider path. The OAuth flow (`customAdapter.createUser`) and `verifyCognitoToken` stay byte-for-byte unchanged. Two new tiny helpers (`isPrismaUniqueViolation`, `createCloudChatEmbeddedUser`), one extracted authorize function (`cloudchatEmbeddedAuthorize`) for testability, and a wiring change in `[...nextauth].ts`.
+
+**Tech Stack:** TypeScript, Next.js (NextAuth `CredentialsProvider`), Prisma 5.12, Vitest 4.1 (matches `accessControl.test.ts` convention), pnpm + turbo monorepo.
+
+**Source spec:** `docs/superpowers/specs/2026-05-06-cloudchat-embedded-jit-provisioning-design.md` (PR #193).
+
+**Working branch:** `feat/cloudchat-embedded-jit-provisioning` (already exists; spec doc commit on top).
+
+---
+
+## Prerequisites (one-time per machine)
+
+Run before starting Task 1:
+
+```bash
+# from typebot.io root
+pnpm install
+pnpm --filter @typebot.io/prisma db:generate
+
+# Confirm vitest can find prisma client by running an existing test
+cd apps/builder
+npx vitest@4.1.5 run src/features/workspace/helpers/accessControl.test.ts --reporter=verbose
+# Expected: PASS (existing repo test).
+# If it errors with "Cannot find module '.prisma/client/default'", re-run db:generate.
+```
+
+The `.env` at typebot.io root must have `COGNITO_ISSUER_URL` and `CLOUDCHAT_COGNITO_APP_CLIENT_ID` populated. Values are in `.env.dev.example`. The husky pre-commit hook (`pnpm lint && pnpm format:check`) reads them via `next lint`.
+
+---
+
+## File Structure
+
+```
+apps/builder/src/features/auth/helpers/
+  isPrismaUniqueViolation.ts            (NEW, Task 1)
+  isPrismaUniqueViolation.test.ts       (NEW, Task 1)
+  createCloudChatEmbeddedUser.ts        (NEW, Task 2)
+  createCloudChatEmbeddedUser.test.ts   (NEW, Task 2)
+  cloudchatEmbeddedAuthorize.ts         (NEW, Task 3)
+  cloudchatEmbeddedAuthorize.test.ts    (NEW, Task 3)
+
+apps/builder/src/pages/api/auth/
+  [...nextauth].ts                      (MODIFY, Task 4 — replace inline authorize block)
+```
+
+**Boundaries:**
+- `isPrismaUniqueViolation` — generic Prisma `P2002` guard. Pure function, no side effects.
+- `createCloudChatEmbeddedUser` — minimal `User` row creation + `'User created'` telemetry. Takes `p` as DI for testability.
+- `cloudchatEmbeddedAuthorize` — full `authorize` callback for the `cloudchat-embedded` provider, with all JIT logic, race handling, and logging. Takes `p` as DI.
+- `[...nextauth].ts` — provider wiring only; no inline business logic.
+
+**Why extract the authorize function (vs in-place edit per spec):** the spec says "modify in place," but extraction is the only way to unit-test the callback without instantiating the entire NextAuth handler. The behavior the spec describes is preserved exactly; only the location changes.
+
+---
+
+## Task 1: isPrismaUniqueViolation guard
+
+**Files:**
+- Create: `apps/builder/src/features/auth/helpers/isPrismaUniqueViolation.ts`
+- Test: `apps/builder/src/features/auth/helpers/isPrismaUniqueViolation.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/builder/src/features/auth/helpers/isPrismaUniqueViolation.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { Prisma } from '@typebot.io/prisma'
+import { isPrismaUniqueViolation } from './isPrismaUniqueViolation'
+
+describe('isPrismaUniqueViolation', () => {
+  it('returns true for PrismaClientKnownRequestError with code P2002', () => {
+    const err = new Prisma.PrismaClientKnownRequestError(
+      'Unique constraint failed on the fields: (`email`)',
+      { code: 'P2002', clientVersion: '5.12.1' }
+    )
+    expect(isPrismaUniqueViolation(err)).toBe(true)
+  })
+
+  it('returns false for PrismaClientKnownRequestError with non-P2002 codes', () => {
+    const err = new Prisma.PrismaClientKnownRequestError(
+      'Record not found',
+      { code: 'P2025', clientVersion: '5.12.1' }
+    )
+    expect(isPrismaUniqueViolation(err)).toBe(false)
+  })
+
+  it('returns false for a plain Error instance', () => {
+    expect(isPrismaUniqueViolation(new Error('boom'))).toBe(false)
+  })
+
+  it('returns false for non-Error values', () => {
+    expect(isPrismaUniqueViolation(null)).toBe(false)
+    expect(isPrismaUniqueViolation(undefined)).toBe(false)
+    expect(isPrismaUniqueViolation('string')).toBe(false)
+    expect(isPrismaUniqueViolation({ code: 'P2002' })).toBe(false)
+    expect(isPrismaUniqueViolation(42)).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/builder
+npx vitest@4.1.5 run src/features/auth/helpers/isPrismaUniqueViolation.test.ts --reporter=verbose
+```
+
+Expected: FAIL with module-not-found error referencing `./isPrismaUniqueViolation`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/builder/src/features/auth/helpers/isPrismaUniqueViolation.ts`:
+
+```ts
+import { Prisma } from '@typebot.io/prisma'
+
+export const isPrismaUniqueViolation = (e: unknown): boolean =>
+  e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002'
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd apps/builder
+npx vitest@4.1.5 run src/features/auth/helpers/isPrismaUniqueViolation.test.ts --reporter=verbose
+```
+
+Expected: PASS — 4 tests, all green.
+
+- [ ] **Step 5: Run lint to verify the guard satisfies the project style**
+
+```bash
+cd /home/fabio/workspace/composezao-da-massa/typebot.io
+pnpm lint
+```
+
+Expected: `✔ No ESLint warnings or errors` for the builder package.
+
+- [ ] **Step 6: Commit and push**
+
+```bash
+git add apps/builder/src/features/auth/helpers/isPrismaUniqueViolation.ts \
+        apps/builder/src/features/auth/helpers/isPrismaUniqueViolation.test.ts
+git -c commit.gpgsign=false commit -m ":sparkles: feat(auth): add isPrismaUniqueViolation guard"
+git push
+```
+
+---
+
+## Task 2: createCloudChatEmbeddedUser helper
+
+**Files:**
+- Create: `apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.ts`
+- Test: `apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.test.ts`:
+
+```ts
+import { vi } from 'vitest'
+
+vi.mock('@typebot.io/telemetry/trackEvents', () => ({
+  trackEvents: vi.fn(),
+}))
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { trackEvents } from '@typebot.io/telemetry/trackEvents'
+import { createCloudChatEmbeddedUser } from './createCloudChatEmbeddedUser'
+
+const trackEventsMock = trackEvents as ReturnType<typeof vi.fn>
+
+const buildPrismaMock = (overrides?: { create?: ReturnType<typeof vi.fn> }) => {
+  const create =
+    overrides?.create ??
+    vi.fn(async ({ data }) => ({
+      id: 'user-fixture-id',
+      email: data.email,
+      name: data.name ?? null,
+      emailVerified: data.emailVerified ?? null,
+      image: data.image ?? null,
+      onboardingCategories: data.onboardingCategories ?? [],
+      createdAt: new Date('2026-05-06T00:00:00Z'),
+      updatedAt: new Date('2026-05-06T00:00:00Z'),
+    }))
+  return {
+    user: { create },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any
+}
+
+describe('createCloudChatEmbeddedUser', () => {
+  beforeEach(() => {
+    trackEventsMock.mockReset()
+    trackEventsMock.mockResolvedValue(undefined)
+  })
+
+  it('creates a User row with email + name + emailVerified + image', async () => {
+    const p = buildPrismaMock()
+    const verifiedAt = new Date('2026-05-06T00:00:00Z')
+    const user = await createCloudChatEmbeddedUser({
+      p,
+      email: 'maria@cliente.com',
+      name: 'Maria Cliente',
+      emailVerified: verifiedAt,
+      image: null,
+    })
+
+    expect(p.user.create).toHaveBeenCalledTimes(1)
+    expect(p.user.create).toHaveBeenCalledWith({
+      data: {
+        email: 'maria@cliente.com',
+        name: 'Maria Cliente',
+        emailVerified: verifiedAt,
+        image: null,
+        onboardingCategories: [],
+      },
+    })
+    expect(user.email).toBe('maria@cliente.com')
+  })
+
+  it('creates a User row with email only when name and emailVerified absent', async () => {
+    const p = buildPrismaMock()
+    await createCloudChatEmbeddedUser({ p, email: 'minimal@local.test' })
+
+    expect(p.user.create).toHaveBeenCalledWith({
+      data: {
+        email: 'minimal@local.test',
+        name: undefined,
+        emailVerified: undefined,
+        image: undefined,
+        onboardingCategories: [],
+      },
+    })
+  })
+
+  it('does not create workspace, MemberInWorkspace or apiToken (no nested relations)', async () => {
+    const p = buildPrismaMock()
+    await createCloudChatEmbeddedUser({ p, email: 'no-side@local.test' })
+
+    const callArg = p.user.create.mock.calls[0][0]
+    expect(callArg.data).not.toHaveProperty('apiTokens')
+    expect(callArg.data).not.toHaveProperty('workspaces')
+    expect(callArg).not.toHaveProperty('include')
+  })
+
+  it("fires a single 'User created' telemetry event with email and first-name", async () => {
+    const p = buildPrismaMock()
+    await createCloudChatEmbeddedUser({
+      p,
+      email: 'two-words@local.test',
+      name: 'João da Silva',
+    })
+
+    expect(trackEventsMock).toHaveBeenCalledTimes(1)
+    expect(trackEventsMock).toHaveBeenCalledWith([
+      {
+        name: 'User created',
+        userId: 'user-fixture-id',
+        data: { email: 'two-words@local.test', name: 'João' },
+      },
+    ])
+  })
+
+  it("emits telemetry with name=undefined when name is null/absent", async () => {
+    const p = buildPrismaMock()
+    await createCloudChatEmbeddedUser({ p, email: 'no-name@local.test' })
+
+    expect(trackEventsMock).toHaveBeenCalledWith([
+      {
+        name: 'User created',
+        userId: 'user-fixture-id',
+        data: { email: 'no-name@local.test', name: undefined },
+      },
+    ])
+  })
+
+  it('propagates prisma.user.create errors (does not swallow)', async () => {
+    const create = vi.fn(async () => {
+      throw new Error('db connection lost')
+    })
+    const p = buildPrismaMock({ create })
+
+    await expect(
+      createCloudChatEmbeddedUser({ p, email: 'boom@local.test' })
+    ).rejects.toThrow('db connection lost')
+    expect(trackEventsMock).not.toHaveBeenCalled()
+  })
+
+  it('propagates trackEvents errors (does not swallow)', async () => {
+    trackEventsMock.mockRejectedValueOnce(new Error('telemetry endpoint down'))
+    const p = buildPrismaMock()
+
+    await expect(
+      createCloudChatEmbeddedUser({ p, email: 'tele@local.test' })
+    ).rejects.toThrow('telemetry endpoint down')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/builder
+npx vitest@4.1.5 run src/features/auth/helpers/createCloudChatEmbeddedUser.test.ts --reporter=verbose
+```
+
+Expected: FAIL with module-not-found error referencing `./createCloudChatEmbeddedUser`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.ts`:
+
+```ts
+import { PrismaClient, User } from '@typebot.io/prisma'
+import { trackEvents } from '@typebot.io/telemetry/trackEvents'
+
+type CreateCloudChatEmbeddedUserInput = {
+  p: PrismaClient
+  email: string
+  name?: string | null
+  emailVerified?: Date | null
+  image?: string | null
+}
+
+export const createCloudChatEmbeddedUser = async ({
+  p,
+  email,
+  name,
+  emailVerified,
+  image,
+}: CreateCloudChatEmbeddedUserInput): Promise<User> => {
+  const user = await p.user.create({
+    data: {
+      email,
+      name: name ?? undefined,
+      emailVerified: emailVerified ?? undefined,
+      image: image ?? undefined,
+      onboardingCategories: [],
+    },
+  })
+
+  await trackEvents([
+    {
+      name: 'User created',
+      userId: user.id,
+      data: { email, name: name?.split(' ')[0] },
+    },
+  ])
+
+  return user
+}
+```
+
+Note the `?? undefined` coercion: Prisma's `user.create` types reject `null` for `String?` columns when constructed inline, but accept `undefined`. The test checks `data: { ..., name: undefined, ... }` to match.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd apps/builder
+npx vitest@4.1.5 run src/features/auth/helpers/createCloudChatEmbeddedUser.test.ts --reporter=verbose
+```
+
+Expected: PASS — 7 tests, all green.
+
+- [ ] **Step 5: Run lint**
+
+```bash
+cd /home/fabio/workspace/composezao-da-massa/typebot.io
+pnpm lint
+```
+
+Expected: no warnings or errors.
+
+- [ ] **Step 6: Commit and push**
+
+```bash
+git add apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.ts \
+        apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.test.ts
+git -c commit.gpgsign=false commit -m ":sparkles: feat(auth): add createCloudChatEmbeddedUser helper"
+git push
+```
+
+---
+
+## Task 3: cloudchatEmbeddedAuthorize extracted function (with JIT logic)
+
+**Files:**
+- Create: `apps/builder/src/features/auth/helpers/cloudchatEmbeddedAuthorize.ts`
+- Test: `apps/builder/src/features/auth/helpers/cloudchatEmbeddedAuthorize.test.ts`
+
+This task extracts the entire `authorize` callback for `cloudchat-embedded` into a standalone function and adds the full JIT logic from the spec.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/builder/src/features/auth/helpers/cloudchatEmbeddedAuthorize.test.ts`:
+
+```ts
+import { vi } from 'vitest'
+
+vi.mock('@typebot.io/env', () => ({
+  env: {
+    COGNITO_ISSUER_URL: 'https://cognito.test/issuer',
+    CLOUDCHAT_COGNITO_APP_CLIENT_ID: 'test-client-id',
+  },
+}))
+
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('@/features/auth/helpers/verifyCognitoToken', () => ({
+  verifyCognitoToken: vi.fn(),
+}))
+
+vi.mock('./createCloudChatEmbeddedUser', () => ({
+  createCloudChatEmbeddedUser: vi.fn(),
+}))
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Prisma } from '@typebot.io/prisma'
+import logger from '@/helpers/logger'
+import { verifyCognitoToken } from '@/features/auth/helpers/verifyCognitoToken'
+import { createCloudChatEmbeddedUser } from './createCloudChatEmbeddedUser'
+import { cloudchatEmbeddedAuthorize } from './cloudchatEmbeddedAuthorize'
+
+const verifyMock = verifyCognitoToken as ReturnType<typeof vi.fn>
+const createMock = createCloudChatEmbeddedUser as ReturnType<typeof vi.fn>
+const loggerInfo = (logger.info as unknown) as ReturnType<typeof vi.fn>
+const loggerWarn = (logger.warn as unknown) as ReturnType<typeof vi.fn>
+const loggerError = (logger.error as unknown) as ReturnType<typeof vi.fn>
+
+const userFixture = {
+  id: 'user-1',
+  email: 'jit@local.test',
+  name: 'JIT',
+  image: null,
+  emailVerified: new Date('2026-05-06T00:00:00Z'),
+}
+
+const buildPrismaMock = (
+  findUniqueImpl?: ReturnType<typeof vi.fn>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): any => ({
+  user: {
+    findUnique: findUniqueImpl ?? vi.fn(async () => null),
+  },
+})
+
+const basePayload = {
+  email: 'jit@local.test',
+  email_verified: true,
+  name: 'JIT',
+  'custom:hub_role': 'CLIENT',
+  'custom:eddie_workspaces': 'ws-a,ws-b',
+  sub: 'sub-1',
+  exp: 9999999999,
+}
+
+describe('cloudchatEmbeddedAuthorize', () => {
+  beforeEach(() => {
+    verifyMock.mockReset()
+    createMock.mockReset()
+    loggerInfo.mockReset()
+    loggerWarn.mockReset()
+    loggerError.mockReset()
+  })
+
+  it('returns null when credentials.token is missing', async () => {
+    const p = buildPrismaMock()
+    const result = await cloudchatEmbeddedAuthorize(p, undefined)
+    expect(result).toBeNull()
+    expect(verifyMock).not.toHaveBeenCalled()
+  })
+
+  it('returns null and logs error when verifyCognitoToken throws', async () => {
+    verifyMock.mockRejectedValueOnce(new Error('bad signature'))
+    const p = buildPrismaMock()
+
+    const result = await cloudchatEmbeddedAuthorize(p, { token: 'bad' })
+
+    expect(result).toBeNull()
+    expect(loggerError).toHaveBeenCalledWith(
+      'Error in cloudchat-embedded authorize',
+      expect.objectContaining({ error: expect.any(Error) })
+    )
+  })
+
+  it('returns null and logs warn when payload has no email', async () => {
+    verifyMock.mockResolvedValueOnce({ sub: 'sub-x', 'cognito:username': 'u' })
+    const p = buildPrismaMock()
+
+    const result = await cloudchatEmbeddedAuthorize(p, { token: 't' })
+
+    expect(result).toBeNull()
+    expect(loggerWarn).toHaveBeenCalledWith(
+      'cloudchat-embedded payload missing email',
+      { sub: 'sub-x', cognitoUsername: 'u' }
+    )
+    expect(p.user.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('returns existing user when findUnique hits (does not call createCloudChatEmbeddedUser)', async () => {
+    verifyMock.mockResolvedValueOnce(basePayload)
+    const findUnique = vi.fn(async () => userFixture)
+    const p = buildPrismaMock(findUnique)
+
+    const result = await cloudchatEmbeddedAuthorize(p, { token: 't' })
+
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { email: 'jit@local.test' },
+    })
+    expect(createMock).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      id: 'user-1',
+      email: 'jit@local.test',
+      cloudChatAuthorization: true,
+    })
+  })
+
+  it("creates user via createCloudChatEmbeddedUser and logs info 'JIT-provisioned'", async () => {
+    verifyMock.mockResolvedValueOnce(basePayload)
+    const findUnique = vi.fn(async () => null)
+    const p = buildPrismaMock(findUnique)
+    createMock.mockResolvedValueOnce(userFixture)
+
+    const result = await cloudchatEmbeddedAuthorize(p, { token: 't' })
+
+    expect(createMock).toHaveBeenCalledWith({
+      p,
+      email: 'jit@local.test',
+      name: 'JIT',
+      emailVerified: expect.any(Date),
+    })
+    expect(loggerInfo).toHaveBeenCalledWith(
+      'JIT-provisioned cloudchat-embedded user',
+      {
+        userId: 'user-1',
+        email: 'jit@local.test',
+        hubRole: 'CLIENT',
+        eddieWorkspacesCount: 2,
+      }
+    )
+    expect(result).not.toBeNull()
+  })
+
+  it("on P2002: refetches and returns user, logs info 'race resolved'", async () => {
+    verifyMock.mockResolvedValueOnce(basePayload)
+    const findUnique = vi
+      .fn()
+      .mockResolvedValueOnce(null) // first call (before create)
+      .mockResolvedValueOnce(userFixture) // refetch after P2002
+    const p = buildPrismaMock(findUnique)
+
+    const p2002 = new Prisma.PrismaClientKnownRequestError(
+      'Unique constraint failed',
+      { code: 'P2002', clientVersion: '5.12.1' }
+    )
+    createMock.mockRejectedValueOnce(p2002)
+
+    const result = await cloudchatEmbeddedAuthorize(p, { token: 't' })
+
+    expect(findUnique).toHaveBeenCalledTimes(2)
+    expect(loggerInfo).toHaveBeenCalledWith(
+      'cloudchat-embedded JIT race resolved',
+      { email: 'jit@local.test' }
+    )
+    expect(result).toMatchObject({ id: 'user-1' })
+  })
+
+  it('on P2002 + refetch returns null: rethrows (caught by outer, returns null + error log)', async () => {
+    verifyMock.mockResolvedValueOnce(basePayload)
+    const findUnique = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null) // refetch also null — pathological
+    const p = buildPrismaMock(findUnique)
+
+    const p2002 = new Prisma.PrismaClientKnownRequestError(
+      'Unique constraint failed',
+      { code: 'P2002', clientVersion: '5.12.1' }
+    )
+    createMock.mockRejectedValueOnce(p2002)
+
+    const result = await cloudchatEmbeddedAuthorize(p, { token: 't' })
+
+    expect(result).toBeNull()
+    expect(loggerError).toHaveBeenCalledWith(
+      'Error in cloudchat-embedded authorize',
+      expect.objectContaining({ error: expect.any(Error) })
+    )
+  })
+
+  it('on non-P2002 error: logs warn JIT refused + returns null', async () => {
+    verifyMock.mockResolvedValueOnce(basePayload)
+    const findUnique = vi.fn(async () => null)
+    const p = buildPrismaMock(findUnique)
+    createMock.mockRejectedValueOnce(new Error('telemetry endpoint down'))
+
+    const result = await cloudchatEmbeddedAuthorize(p, { token: 't' })
+
+    expect(result).toBeNull()
+    expect(loggerWarn).toHaveBeenCalledWith('cloudchat-embedded JIT refused', {
+      email: 'jit@local.test',
+      reason: 'telemetry endpoint down',
+    })
+    expect(loggerError).not.toHaveBeenCalled()
+  })
+
+  it('returns full DatabaseUserWithCognito shape with cloudChatAuthorization=true and cognitoTokenExp', async () => {
+    verifyMock.mockResolvedValueOnce(basePayload)
+    const findUnique = vi.fn(async () => userFixture)
+    const p = buildPrismaMock(findUnique)
+
+    const result = await cloudchatEmbeddedAuthorize(p, { token: 't' })
+
+    expect(result).toEqual({
+      id: 'user-1',
+      email: 'jit@local.test',
+      name: 'JIT',
+      image: null,
+      emailVerified: userFixture.emailVerified,
+      cognitoClaims: {
+        'custom:hub_role': 'CLIENT',
+        'custom:eddie_workspaces': 'ws-a,ws-b',
+      },
+      cloudChatAuthorization: true,
+      cognitoTokenExp: 9999999999,
+    })
+  })
+
+  it('maps email_verified=true to emailVerified Date; false/undefined to null', async () => {
+    // Case: email_verified === true
+    verifyMock.mockResolvedValueOnce({
+      ...basePayload,
+      email_verified: true,
+    })
+    const p1 = buildPrismaMock(vi.fn(async () => null))
+    createMock.mockResolvedValueOnce(userFixture)
+    await cloudchatEmbeddedAuthorize(p1, { token: 't' })
+    expect(createMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ emailVerified: expect.any(Date) })
+    )
+
+    // Case: email_verified === false
+    verifyMock.mockResolvedValueOnce({
+      ...basePayload,
+      email: 'a@b',
+      email_verified: false,
+    })
+    const p2 = buildPrismaMock(vi.fn(async () => null))
+    createMock.mockResolvedValueOnce(userFixture)
+    await cloudchatEmbeddedAuthorize(p2, { token: 't' })
+    expect(createMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ emailVerified: null })
+    )
+
+    // Case: email_verified absent
+    verifyMock.mockResolvedValueOnce({
+      ...basePayload,
+      email: 'c@d',
+      email_verified: undefined,
+    })
+    const p3 = buildPrismaMock(vi.fn(async () => null))
+    createMock.mockResolvedValueOnce(userFixture)
+    await cloudchatEmbeddedAuthorize(p3, { token: 't' })
+    expect(createMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ emailVerified: null })
+    )
+  })
+
+  it("counts eddie_workspaces correctly: 'ws-a,ws-b' = 2; '' = 0; '*' = 1", async () => {
+    const findUnique = vi.fn(async () => null)
+
+    verifyMock.mockResolvedValueOnce({
+      ...basePayload,
+      'custom:eddie_workspaces': 'ws-a,ws-b',
+    })
+    createMock.mockResolvedValueOnce(userFixture)
+    await cloudchatEmbeddedAuthorize(buildPrismaMock(findUnique), { token: 't' })
+    expect(loggerInfo).toHaveBeenLastCalledWith(
+      'JIT-provisioned cloudchat-embedded user',
+      expect.objectContaining({ eddieWorkspacesCount: 2 })
+    )
+
+    verifyMock.mockResolvedValueOnce({
+      ...basePayload,
+      email: 'b@b',
+      'custom:eddie_workspaces': '',
+    })
+    createMock.mockResolvedValueOnce(userFixture)
+    await cloudchatEmbeddedAuthorize(buildPrismaMock(findUnique), { token: 't' })
+    expect(loggerInfo).toHaveBeenLastCalledWith(
+      'JIT-provisioned cloudchat-embedded user',
+      expect.objectContaining({ eddieWorkspacesCount: 0 })
+    )
+
+    verifyMock.mockResolvedValueOnce({
+      ...basePayload,
+      email: 'c@c',
+      'custom:eddie_workspaces': '*',
+    })
+    createMock.mockResolvedValueOnce(userFixture)
+    await cloudchatEmbeddedAuthorize(buildPrismaMock(findUnique), { token: 't' })
+    expect(loggerInfo).toHaveBeenLastCalledWith(
+      'JIT-provisioned cloudchat-embedded user',
+      expect.objectContaining({ eddieWorkspacesCount: 1 })
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/builder
+npx vitest@4.1.5 run src/features/auth/helpers/cloudchatEmbeddedAuthorize.test.ts --reporter=verbose
+```
+
+Expected: FAIL with module-not-found error referencing `./cloudchatEmbeddedAuthorize`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/builder/src/features/auth/helpers/cloudchatEmbeddedAuthorize.ts`:
+
+```ts
+import { PrismaClient } from '@typebot.io/prisma'
+import { env } from '@typebot.io/env'
+import logger from '@/helpers/logger'
+import { verifyCognitoToken } from '@/features/auth/helpers/verifyCognitoToken'
+import { DatabaseUserWithCognito } from '@/features/auth/types/cognito'
+import { isPrismaUniqueViolation } from './isPrismaUniqueViolation'
+import { createCloudChatEmbeddedUser } from './createCloudChatEmbeddedUser'
+
+type Credentials = { token?: string } | undefined
+
+type AuthorizedUser = Pick<
+  DatabaseUserWithCognito,
+  | 'id'
+  | 'name'
+  | 'email'
+  | 'image'
+  | 'emailVerified'
+  | 'cognitoClaims'
+  | 'cloudChatAuthorization'
+  | 'cognitoTokenExp'
+>
+
+export const cloudchatEmbeddedAuthorize = async (
+  p: PrismaClient,
+  credentials: Credentials
+): Promise<AuthorizedUser | null> => {
+  try {
+    if (!credentials?.token) return null
+
+    const payload = await verifyCognitoToken({
+      cognitoAppClientId: env.CLOUDCHAT_COGNITO_APP_CLIENT_ID,
+      cognitoIssuerUrl: env.COGNITO_ISSUER_URL,
+      cognitoToken: credentials.token,
+    })
+
+    if (typeof payload.email !== 'string' || payload.email.length === 0) {
+      logger.warn('cloudchat-embedded payload missing email', {
+        sub: payload.sub,
+        cognitoUsername: payload['cognito:username'],
+      })
+      return null
+    }
+
+    let user = await p.user.findUnique({
+      where: { email: payload.email },
+    })
+
+    if (!user) {
+      try {
+        user = await createCloudChatEmbeddedUser({
+          p,
+          email: payload.email,
+          name: payload.name ?? null,
+          emailVerified:
+            payload.email_verified === true ? new Date() : null,
+        })
+        logger.info('JIT-provisioned cloudchat-embedded user', {
+          userId: user.id,
+          email: user.email,
+          hubRole: payload['custom:hub_role'],
+          eddieWorkspacesCount: (payload['custom:eddie_workspaces'] ?? '')
+            .split(',')
+            .filter(Boolean).length,
+        })
+      } catch (err) {
+        if (isPrismaUniqueViolation(err)) {
+          user = await p.user.findUnique({
+            where: { email: payload.email },
+          })
+          if (!user) throw err
+          logger.info('cloudchat-embedded JIT race resolved', {
+            email: payload.email,
+          })
+        } else {
+          logger.warn('cloudchat-embedded JIT refused', {
+            email: payload.email,
+            reason: err instanceof Error ? err.message : 'unknown',
+          })
+          return null
+        }
+      }
+    }
+
+    return {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      image: user.image,
+      emailVerified: user.emailVerified,
+      cognitoClaims: {
+        'custom:hub_role': payload['custom:hub_role'],
+        'custom:eddie_workspaces': payload['custom:eddie_workspaces'],
+      },
+      cloudChatAuthorization: true,
+      cognitoTokenExp: payload.exp,
+    }
+  } catch (error) {
+    logger.error('Error in cloudchat-embedded authorize', { error })
+    return null
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd apps/builder
+npx vitest@4.1.5 run src/features/auth/helpers/cloudchatEmbeddedAuthorize.test.ts --reporter=verbose
+```
+
+Expected: PASS — 11 tests, all green.
+
+- [ ] **Step 5: Run lint**
+
+```bash
+cd /home/fabio/workspace/composezao-da-massa/typebot.io
+pnpm lint
+```
+
+Expected: no warnings or errors.
+
+- [ ] **Step 6: Commit and push**
+
+```bash
+git add apps/builder/src/features/auth/helpers/cloudchatEmbeddedAuthorize.ts \
+        apps/builder/src/features/auth/helpers/cloudchatEmbeddedAuthorize.test.ts
+git -c commit.gpgsign=false commit -m ":sparkles: feat(auth): cloudchat-embedded JIT user provisioning"
+git push
+```
+
+---
+
+## Task 4: Wire cloudchatEmbeddedAuthorize into [...nextauth].ts
+
+This is a no-logic-change wiring task. The inline `authorize` block at lines 162-207 of `[...nextauth].ts` is replaced with a single line referencing the new helper. Behavior is preserved (covered by Task 3 tests).
+
+**Files:**
+- Modify: `apps/builder/src/pages/api/auth/[...nextauth].ts`
+
+- [ ] **Step 1: Read current state of the cloudchat-embedded provider block**
+
+Inspect the current file to confirm line numbers before editing:
+
+```bash
+cd /home/fabio/workspace/composezao-da-massa/typebot.io
+sed -n '154,210p' apps/builder/src/pages/api/auth/[...nextauth].ts
+```
+
+Expected: the block starts with `// Add CloudChat embedded provider` and ends after `)` closing `providers.push(`.
+
+- [ ] **Step 2: Replace the inline authorize block**
+
+In `apps/builder/src/pages/api/auth/[...nextauth].ts`, replace the entire `providers.push(...)` block for `cloudchat-embedded` (lines 154-209 in the original file) with:
+
+```ts
+// Add CloudChat embedded provider (using credentials provider)
+providers.push(
+  CredentialsProvider({
+    id: 'cloudchat-embedded',
+    name: 'CloudChat Embedded',
+    credentials: {
+      token: { label: 'Token', type: 'text' },
+    },
+    authorize: (credentials) =>
+      cloudchatEmbeddedAuthorize(prisma, credentials ?? undefined),
+  })
+)
+```
+
+- [ ] **Step 3: Add the import for `cloudchatEmbeddedAuthorize`**
+
+Find the existing imports near the top of the file (around lines 13-35) and add this import alongside the other `@/features/auth/helpers/*` imports:
+
+```ts
+import { cloudchatEmbeddedAuthorize } from '@/features/auth/helpers/cloudchatEmbeddedAuthorize'
+```
+
+- [ ] **Step 4: Remove now-unused imports**
+
+The `verifyCognitoToken` import (line ~36) is no longer used directly in `[...nextauth].ts` after extraction. Search the file for other usages first:
+
+```bash
+grep -n 'verifyCognitoToken' apps/builder/src/pages/api/auth/[...nextauth].ts
+```
+
+If the only line referencing `verifyCognitoToken` is the import statement itself, remove that import. If anything else uses it, keep the import.
+
+`DatabaseUserWithCognito` is still used elsewhere in the file (jwt callback line ~298, 301) — keep this import.
+
+- [ ] **Step 5: Run lint to catch broken imports or formatting**
+
+```bash
+pnpm lint
+```
+
+Expected: no warnings or errors. If lint flags an unused import, remove it.
+
+- [ ] **Step 6: Run all unit tests we added so far to confirm nothing regressed**
+
+```bash
+cd apps/builder
+npx vitest@4.1.5 run \
+  src/features/auth/helpers/isPrismaUniqueViolation.test.ts \
+  src/features/auth/helpers/createCloudChatEmbeddedUser.test.ts \
+  src/features/auth/helpers/cloudchatEmbeddedAuthorize.test.ts \
+  --reporter=verbose
+```
+
+Expected: all suites green (4 + 7 + 11 = 22 tests).
+
+- [ ] **Step 7: Type-check the builder app**
+
+```bash
+cd /home/fabio/workspace/composezao-da-massa/typebot.io
+pnpm --filter builder exec tsc --noEmit
+```
+
+Expected: no type errors. (If your local tsc command differs, follow the project's existing convention. Husky pre-commit only checks lint+format, but a stray type error from the import shuffle can break CI Docker builds.)
+
+- [ ] **Step 8: Commit and push**
+
+```bash
+git add apps/builder/src/pages/api/auth/[...nextauth].ts
+git -c commit.gpgsign=false commit -m ":recycle: refactor(auth): wire cloudchatEmbeddedAuthorize into nextauth"
+git push
+```
+
+---
+
+## Task 5: Run UAT and finalize PR
+
+This task has no commits. It runs the local UAT documented in the spec (Section "Validation plan (local UAT)") and flips the PR from draft to ready-for-review.
+
+- [ ] **Step 1: Compose stack up**
+
+```bash
+cd /home/fabio/workspace/composezao-da-massa
+docker compose up -d --build cloudchat-saas typebot-builder typebot-viewer typebot-postgres claudia-app
+```
+
+Wait until all containers report healthy (`docker compose ps`).
+
+- [ ] **Step 2: Reset typebot DB**
+
+```bash
+docker compose exec typebot-builder pnpm prisma migrate reset --force --schema /app/packages/prisma/postgresql/schema.prisma
+```
+
+Expected: DB recreated, migrations applied. (If the container path differs, run from the host: `cd typebot.io/packages/prisma && pnpm db:migrate`.)
+
+- [ ] **Step 3: UAT Mode 1 — full iframe flow via CloudChat dev login**
+
+```bash
+# Open Rails console in CloudChat container
+docker compose exec cloudchat-saas bundle exec rails console
+```
+
+Inside the console:
+
+```ruby
+User.create!(
+  email: 'jit-uat-001@local.test',
+  uid: 'jit-uat-001@local.test',
+  password: 'devpass123',
+  password_confirmation: 'devpass123',
+  confirmed_at: Time.now
+)
+exit
+```
+
+Then:
+
+1. Open `http://localhost:3000` in browser. Login as `jit-uat-001@local.test` / `devpass123`.
+2. Navigate Claudia menu → Tools → click to edit any tool.
+3. Confirm the Eddie iframe loads (no "Failed to load flow builder" message).
+4. Verify in DB:
+
+```bash
+docker compose exec typebot-postgres psql -U postgres -d typebot -c \
+  "SELECT id, email, name, \"emailVerified\" FROM \"User\" WHERE email = 'jit-uat-001@local.test';"
+```
+
+Expected: 1 row, `name=NULL`, `emailVerified=NULL` (dev token has no `email_verified` or `name` claim — limitation of the CloudChat dev shortcut, not the JIT logic).
+
+5. Verify NO workspace/token side effects:
+
+```bash
+docker compose exec typebot-postgres psql -U postgres -d typebot -c \
+  "SELECT m.\"workspaceId\", m.role FROM \"MemberInWorkspace\" m
+   JOIN \"User\" u ON u.id = m.\"userId\"
+   WHERE u.email = 'jit-uat-001@local.test';"
+docker compose exec typebot-postgres psql -U postgres -d typebot -c \
+  "SELECT id, name FROM \"ApiToken\" o
+   JOIN \"User\" u ON u.id = o.\"ownerId\"
+   WHERE u.email = 'jit-uat-001@local.test';"
+```
+
+Expected: 0 rows in both queries.
+
+6. Verify log:
+
+```bash
+docker compose logs typebot-builder --since=5m | grep -E 'JIT-provisioned|JIT refused|race resolved|payload missing email'
+```
+
+Expected: exactly one `'JIT-provisioned cloudchat-embedded user'` line with `userId, email, hubRole=ADMIN, eddieWorkspacesCount=1`.
+
+- [ ] **Step 4: UAT Mode 2 — hand-crafted JWT (covers email_verified + name + non-ADMIN role)**
+
+```bash
+B64() { echo -n "$1" | base64 -w0 | tr '+/' '-_' | tr -d '='; }
+PAYLOAD='{"email":"jit-uat-002@local.test","email_verified":true,"name":"Maria Cliente","custom:hub_role":"CLIENT","custom:eddie_workspaces":"ws-real-1,ws-real-2","sub":"abc","exp":9999999999}'
+JWT="$(B64 '{"alg":"none","typ":"JWT"}').$(B64 "$PAYLOAD")."
+
+# Get NextAuth CSRF token (cookie + body)
+CSRF_RESP=$(curl -sc /tmp/jit-uat-cookies.txt 'http://localhost:3002/api/auth/csrf')
+CSRF_TOKEN=$(echo "$CSRF_RESP" | python3 -c "import json,sys; print(json.load(sys.stdin)['csrfToken'])")
+
+# Hit the cloudchat-embedded callback
+curl -i -b /tmp/jit-uat-cookies.txt 'http://localhost:3002/api/auth/callback/cloudchat-embedded' \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data-urlencode "csrfToken=$CSRF_TOKEN" \
+  --data-urlencode "token=$JWT" \
+  --data-urlencode "json=true"
+```
+
+Expected: HTTP 200 or 302 (NextAuth typically responds with redirect for credentials sign-in).
+
+Verify in DB:
+
+```bash
+docker compose exec typebot-postgres psql -U postgres -d typebot -c \
+  "SELECT id, email, name, \"emailVerified\" FROM \"User\" WHERE email = 'jit-uat-002@local.test';"
+```
+
+Expected: 1 row, `name='Maria Cliente'`, `emailVerified` populated with a recent timestamp.
+
+Verify log:
+
+```bash
+docker compose logs typebot-builder --since=5m | grep 'jit-uat-002'
+```
+
+Expected: `'JIT-provisioned cloudchat-embedded user'` with `hubRole: 'CLIENT'`, `eddieWorkspacesCount: 2`.
+
+- [ ] **Step 5: UAT Mode 3 — race condition**
+
+```bash
+RACE_PAYLOAD='{"email":"jit-uat-race@local.test","email_verified":true,"sub":"race","exp":9999999999}'
+RACE_JWT="$(B64 '{"alg":"none","typ":"JWT"}').$(B64 "$RACE_PAYLOAD")."
+
+# Fresh CSRF
+CSRF_RESP=$(curl -sc /tmp/jit-race-cookies.txt 'http://localhost:3002/api/auth/csrf')
+CSRF_TOKEN=$(echo "$CSRF_RESP" | python3 -c "import json,sys; print(json.load(sys.stdin)['csrfToken'])")
+
+# Two concurrent callbacks
+for i in 1 2; do
+  curl -s -b /tmp/jit-race-cookies.txt 'http://localhost:3002/api/auth/callback/cloudchat-embedded' \
+    -H 'Content-Type: application/x-www-form-urlencoded' \
+    --data-urlencode "csrfToken=$CSRF_TOKEN" \
+    --data-urlencode "token=$RACE_JWT" \
+    --data-urlencode "json=true" \
+    > /tmp/jit-race-$i.out 2>&1 &
+done
+wait
+```
+
+Verify in DB:
+
+```bash
+docker compose exec typebot-postgres psql -U postgres -d typebot -c \
+  "SELECT count(*) FROM \"User\" WHERE email = 'jit-uat-race@local.test';"
+```
+
+Expected: 1 (single row).
+
+Verify log:
+
+```bash
+docker compose logs typebot-builder --since=2m | grep -E 'jit-uat-race|race resolved'
+```
+
+Expected: exactly one `'JIT-provisioned cloudchat-embedded user'` and exactly one `'cloudchat-embedded JIT race resolved'` log line. (If the timing of the two requests means they didn't actually race, the second log may be absent — re-run the curls a couple of times until the race fires.)
+
+- [ ] **Step 6: Mark PR as ready-for-review and post UAT result**
+
+```bash
+cd /home/fabio/workspace/composezao-da-massa/typebot.io
+gh pr ready 193
+
+# Post a comment with the UAT outcome
+gh pr comment 193 --body "$(cat <<'EOF'
+## Local UAT — passed
+
+- Mode 1 (CloudChat dev iframe): user JIT-provisioned, no Workspace/MemberInWorkspace/ApiToken side effects, single 'JIT-provisioned' log entry.
+- Mode 2 (hand-crafted JWT): emailVerified populated, name = 'Maria Cliente', hubRole=CLIENT, eddieWorkspacesCount=2 logged.
+- Mode 3 (race): single User row, one 'JIT-provisioned' + one 'race resolved' log entry.
+
+OAuth flow regression check: customAdapter.createUser was not modified; no changes to that path.
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+### Spec coverage
+- "Add `createCloudChatEmbeddedUser`" → Task 2.
+- "Add `isPrismaUniqueViolation` guard" → Task 1.
+- "Modify `cloudchat-embedded.authorize`" → Task 3 (function body) + Task 4 (wiring).
+- "Vitest unit on helper" → Task 2 tests.
+- "Vitest unit on authorize" → Task 3 tests.
+- "Local UAT in 3 modes" → Task 5.
+- "Don't touch customAdapter" → respected in every task; Task 4 explicitly only modifies `[...nextauth].ts`.
+- "Don't touch verifyCognitoToken" → respected; Task 4 only removes the import if unused.
+
+### Placeholder scan
+- No "TBD", "TODO", "implement later", or vague "add error handling" steps.
+- Every code block contains the actual implementation.
+- Every test has a real assertion list.
+- Commands include exact paths and expected outputs.
+
+### Type / signature consistency
+- `createCloudChatEmbeddedUser({ p, email, name, emailVerified, image })` — same shape used in Task 2 implementation, Task 2 test, and Task 3 implementation calls.
+- `cloudchatEmbeddedAuthorize(p, credentials)` — same signature in Task 3 implementation, Task 3 tests, and Task 4 wiring (`authorize: (credentials) => cloudchatEmbeddedAuthorize(prisma, credentials ?? undefined)`).
+- `isPrismaUniqueViolation(e: unknown)` — same in Task 1 implementation and Task 3 tests' P2002 case.
+
+### Open follow-ups (intentionally out of scope)
+- The dev `npx vitest@4.1.5 run` command depends on on-demand vitest install (no project devDep). Matches the existing convention from `accessControl.test.ts`. If a future PR adds vitest as a real devDep + a `test:unit` script, these tests run via `pnpm test:unit` automatically.
+- Production deployment validation is done via the Datadog observability plan documented in the spec, not in this implementation plan.

--- a/docs/superpowers/specs/2026-05-06-cloudchat-embedded-jit-provisioning-design.md
+++ b/docs/superpowers/specs/2026-05-06-cloudchat-embedded-jit-provisioning-design.md
@@ -1,0 +1,539 @@
+# CloudChat-Embedded JIT User Provisioning — Design
+
+- Date: 2026-05-06
+- Status: Approved (design)
+- Scope: `typebot.io` only
+- Adjacent PRs / context:
+  - Bug surface: `cloudhumans/cloudchat-saas` (CloudChat embed loads Eddie via `?embedded=true&jwt=...`)
+  - Related infra: `cloudhumans/typebot.io-manifests` (CSP/CORS allowlist for embed)
+
+## Problem
+
+When a CloudChat user opens Eddie embedded for the first time, the iframe shows
+`Failed to load flow builder. Please reload the page.` Cause: the `cloudchat-embedded`
+NextAuth provider in `apps/builder/src/pages/api/auth/[...nextauth].ts` does
+`prisma.user.findUnique({ where: { email } })` and returns `null` if the user does
+not yet exist in typebot's database. The `CredentialsProvider` (which `cloudchat-embedded`
+uses) does not invoke the NextAuth adapter's `createUser` by design, so first-time
+users are stuck.
+
+The current workaround is to force users through the regular `custom-oauth` Cognito
+flow first; that flow runs `customAdapter.createUser` and inserts the row. This is
+manual and hostile to onboarding.
+
+## Goal
+
+Provision the typebot `User` row just-in-time when a valid CloudChat Cognito JWT
+is presented in the embedded auth flow, so that CloudChat-onboarded users land
+directly in Eddie without an extra sign-in step.
+
+## Non-goals
+
+- Refactor or otherwise modify the existing OAuth path (`customAdapter.createUser`).
+  The change is purely additive on the embedded path.
+- Add a default workspace, default API token, or process invitations for JIT users.
+  CloudChat-managed users access workspaces via the `custom:eddie_workspaces` claim
+  (already wired through `getCognitoAccessibleWorkspaceIds` and `listWorkspaces`).
+- Change `verifyCognitoToken`. Signature/issuer/audience verification stays as-is.
+- Rate-limit the embedded auth path. Out of scope; can be revisited if abuse appears.
+- Add staging/integration tests against a real Postgres. Local UAT covers the gap.
+
+## Decisions (with rationale)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Security policy | Any valid Cognito JWT provisions | Parity with the existing `custom-oauth` path. The JWT signature + audience (`CLOUDCHAT_COGNITO_APP_CLIENT_ID`) check is the gate. No extra allowlist. |
+| Code organization | Surgical: new isolated helper for JIT only | Minimize blast radius. `customAdapter.createUser` is byte-for-byte unchanged. Accept ~8 lines of duplication between the two creation paths. |
+| Race handling | Catch Prisma `P2002`, refetch | Two concurrent tabs both miss `findUnique` → both call create → second hits unique violation → catches and refetches the winner's row. |
+| Observability | Structured `info` log on success, `warn` on refusal | Permits Datadog queries (`service:typebot-builder JIT-provisioned`) for monitoring abuse without introducing new telemetry events or rate-limit infra. |
+| `DISABLE_SIGNUP` gate | **Not** enforced on JIT path | The flag exists to hide the self-service signup button. CloudChat users authenticate upstream via Cognito; the gate does not apply. |
+| Default workspace | **Not** created | Workspace access for CloudChat users comes from the `custom:eddie_workspaces` claim. `listWorkspaces.getWorkspaceFilter` already returns workspaces matching `cognitoAccess.ids`. |
+| Default API token | **Not** created | API tokens are for OAuth-flow users calling typebot's REST API. CloudChat-embedded users authenticate via JWT redirect each session. |
+| Invitation processing | **Not** in JIT path | Typebot invitations are an artifact of the standalone product. CloudChat-managed users do not receive them in practice. |
+| Field mapping | `email`, `name`, `emailVerified`, `image` from Cognito payload | `email` ← `payload.email` (validated). `name` ← `payload.name ?? null`. `emailVerified` ← `payload.email_verified === true ? new Date() : null`. `image` ← `null` (Cognito `picture` claim not standardly emitted). |
+| Testing | Vitest unit on helper + Vitest unit on `authorize` + local UAT (3 modes) | Vitest matches existing convention. Unit tests cover logic; UAT covers the embed UX, dev token mapping, and race. No staging available; rely on prod observability for JWKS-real validation. |
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ apps/builder/src/pages/api/auth/[...nextauth].ts               │
+│                                                                 │
+│  cloudchat-embedded provider (CredentialsProvider, ~155-211)   │
+│  ├─ verifyCognitoToken(token)                       (existing) │
+│  ├─ payload email validation                            (NEW)  │
+│  ├─ findUnique({ email })                                       │
+│  ├─ if !user:                                           (NEW)  │
+│  │    try createCloudChatEmbeddedUser(...)                      │
+│  │    catch P2002 → refetch findUnique                          │
+│  │    catch other → logger.warn + return null                   │
+│  └─ return user (with cognitoClaims)                            │
+└─────────────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ apps/builder/src/features/auth/helpers/                        │
+│   createCloudChatEmbeddedUser.ts                       (NEW)   │
+│                                                                 │
+│   createCloudChatEmbeddedUser({                                 │
+│     p, email, name, emailVerified, image                        │
+│   }) → User                                                     │
+│   ├─ p.user.create({ email, name, emailVerified, image,         │
+│   │   onboardingCategories: [] })   ← User row only             │
+│   └─ trackEvents([{ name: 'User created', ... }])               │
+└─────────────────────────────────────────────────────────────────┘
+
+(Untouched but referenced)
+
+  apps/builder/src/features/auth/api/customAdapter.ts            (unchanged)
+  apps/builder/src/features/auth/helpers/verifyCognitoToken.ts   (unchanged)
+  apps/builder/src/features/workspace/api/listWorkspaces.ts      (unchanged)
+```
+
+## Components
+
+### New file: `apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.ts`
+
+```ts
+import { PrismaClient, User } from '@typebot.io/prisma'
+import { trackEvents } from '@typebot.io/telemetry/trackEvents'
+
+type CreateCloudChatEmbeddedUserInput = {
+  p: PrismaClient
+  email: string
+  name?: string | null
+  emailVerified?: Date | null
+  image?: string | null
+}
+
+export const createCloudChatEmbeddedUser = async ({
+  p,
+  email,
+  name,
+  emailVerified,
+  image,
+}: CreateCloudChatEmbeddedUserInput): Promise<User> => {
+  const user = await p.user.create({
+    data: { email, name, emailVerified, image, onboardingCategories: [] },
+  })
+
+  await trackEvents([
+    {
+      name: 'User created',
+      userId: user.id,
+      data: { email, name: name?.split(' ')[0] },
+    },
+  ])
+
+  return user
+}
+```
+
+Responsibility: minimal `User` row + `'User created'` telemetry. No workspace,
+no API token, no invitation handling.
+
+### New file: `apps/builder/src/features/auth/helpers/isPrismaUniqueViolation.ts`
+
+```ts
+import { Prisma } from '@typebot.io/prisma'
+
+export const isPrismaUniqueViolation = (e: unknown): boolean =>
+  e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002'
+```
+
+### Modified file: `apps/builder/src/pages/api/auth/[...nextauth].ts`
+
+In the `cloudchat-embedded` provider's `authorize` callback, replace:
+
+```ts
+const user = await prisma.user.findUnique({ where: { email: payload.email } })
+if (!user) return null
+```
+
+with the JIT block (full code under "Final shape" below).
+
+### Untouched
+
+- `apps/builder/src/features/auth/api/customAdapter.ts`
+- `apps/builder/src/features/auth/helpers/verifyCognitoToken.ts`
+- `apps/builder/src/features/auth/helpers/getNewUserInvitations.ts`
+- `apps/builder/src/features/auth/helpers/convertInvitationsToCollaborations.ts`
+- `apps/builder/src/features/auth/helpers/joinWorkspaces.ts`
+- `apps/builder/src/features/workspace/helpers/parseWorkspaceDefaultPlan.ts`
+- All other NextAuth providers
+
+## Data flow
+
+### Happy path — first-time CloudChat user
+
+```
+Browser (CloudChat iframe)
+  │  GET /typebots/{id}/edit?embedded=true&jwt=...
+  ▼
+NextAuth → cloudchat-embedded.authorize
+  ├─ verifyCognitoToken(token) → payload                 (JWKS in prod)
+  ├─ payload.email validation                            (NEW)
+  ├─ prisma.user.findUnique({ email }) → null
+  ├─ createCloudChatEmbeddedUser({ p, email, name,
+  │                                emailVerified })
+  │   ├─ prisma.user.create({ email, name, emailVerified,
+  │   │                       image, onboardingCategories: [] })
+  │   └─ trackEvents([{ name: 'User created', ... }])
+  ├─ logger.info('JIT-provisioned cloudchat-embedded user',
+  │              { userId, email, hubRole, eddieWorkspacesCount })
+  └─ return DatabaseUserWithCognito (cloudChatAuthorization: true,
+                                     cognitoTokenExp)
+        │
+        ▼
+NextAuth jwt callback (existing) → session cookie emitted
+        │
+        ▼
+Browser → /typebots/{id}/edit
+  │
+  ├─ trpc workspace.listWorkspaces (existing)
+  │   └─ getCognitoAccessibleWorkspaceIds(user) → cognitoAccess
+  │   └─ findMany({ OR: [{ members: { some: { userId } } },
+  │                      { id: { in: cognitoAccess.ids } }] })
+  │   └─ returns workspaces from eddie_workspaces claim
+  │
+  └─ Editor loads
+```
+
+### Happy path — returning user
+
+`findUnique` hits, JIT block is skipped, return user as before.
+
+### Race — two concurrent tabs, fresh user
+
+```
+Tab A                                    Tab B
+  ├─ findUnique → null                     ├─ findUnique → null
+  ├─ createCloudChatEmbeddedUser           ├─ createCloudChatEmbeddedUser
+  │   user.create OK                       │   user.create blocks on PG
+  ├─ logger.info JIT-provisioned           │
+  └─ return user                           │   PG returns P2002
+                                           ├─ catch isPrismaUniqueViolation → true
+                                           ├─ findUnique → user (created by A)
+                                           ├─ logger.info race resolved
+                                           └─ return user
+```
+
+Both authenticate. Side effects (User row, telemetry) fire exactly once.
+
+### Refusal — JIT path internal error (rare)
+
+DB outage / `trackEvents` throws / non-P2002 Prisma error:
+
+```
+... cloudchat-embedded.authorize ...
+  ├─ findUnique → null
+  ├─ createCloudChatEmbeddedUser throws (not P2002)
+  ├─ catch interno → NÃO é P2002
+  ├─ logger.warn 'cloudchat-embedded JIT refused' { email, reason }
+  └─ return null
+        │
+        ▼
+NextAuth signIn → { ok: false }
+        │
+        ▼
+useEmbeddedAuth → setAuthError('Failed to load flow builder. Please reload the page.')
+```
+
+Note: if `trackEvents` throws after `user.create` succeeded, the user row already
+exists in the DB. The next attempt by the same email will hit the `findUnique` happy
+path. Mirrors the loose atomicity already present in `customAdapter.createUser`.
+
+### Refusal — invalid JWT (existing behavior)
+
+```
+... cloudchat-embedded.authorize ...
+  ├─ verifyCognitoToken throws
+  ├─ catch externo (existente): logger.error 'Error in cloudchat-embedded authorize'
+  └─ return null
+```
+
+### Refusal — payload missing email (NEW)
+
+```
+... cloudchat-embedded.authorize ...
+  ├─ verifyCognitoToken → payload (no email)
+  ├─ logger.warn 'cloudchat-embedded payload missing email'
+       { sub, cognitoUsername }
+  └─ return null
+```
+
+## Error handling
+
+| Scenario | Detection | Behavior | Log |
+|---|---|---|---|
+| Token missing/invalid/expired/wrong audience | `verifyCognitoToken` throws | catch externo (existing), `return null` | `error 'Error in cloudchat-embedded authorize'` |
+| Payload missing/empty `email` | explicit check after verify | `return null` | `warn 'cloudchat-embedded payload missing email'` |
+| `findUnique` failure (DB issue) | catch externo (existing) | `return null` | `error` (same outer) |
+| User exists | `findUnique` returns user | `return user` | (silent; existing NextAuth jwt log fires) |
+| User does not exist, create succeeds | findUnique null + create OK | `return user` | `info 'JIT-provisioned cloudchat-embedded user' { userId, email, hubRole, eddieWorkspacesCount }` |
+| Race — P2002 caught, refetch returns user | inner catch | `return user` | `info 'cloudchat-embedded JIT race resolved'` |
+| Race — P2002 caught, refetch returns null | inner catch (rare/strange) | `throw` (caught by outer, returns null) | `error` outer |
+| Other Prisma error during create | inner catch | `return null` | `warn 'cloudchat-embedded JIT refused' { email, reason }` |
+| `trackEvents` throws (after user.create OK) | inner catch (non-P2002) | `return null`; user already in DB | `warn 'cloudchat-embedded JIT refused (telemetry)'` |
+
+### Final shape of the modified `authorize` block
+
+```ts
+async authorize(credentials) {
+  try {
+    if (!credentials?.token) return null
+
+    const payload = await verifyCognitoToken({
+      cognitoAppClientId: env.CLOUDCHAT_COGNITO_APP_CLIENT_ID,
+      cognitoIssuerUrl: env.COGNITO_ISSUER_URL,
+      cognitoToken: credentials.token,
+    })
+
+    if (typeof payload.email !== 'string' || payload.email.length === 0) {
+      logger.warn('cloudchat-embedded payload missing email', {
+        sub: payload.sub,
+        cognitoUsername: payload['cognito:username'],
+      })
+      return null
+    }
+
+    let user = await prisma.user.findUnique({
+      where: { email: payload.email },
+    })
+
+    if (!user) {
+      try {
+        user = await createCloudChatEmbeddedUser({
+          p: prisma,
+          email: payload.email,
+          name: payload.name ?? null,
+          emailVerified:
+            payload.email_verified === true ? new Date() : null,
+        })
+        logger.info('JIT-provisioned cloudchat-embedded user', {
+          userId: user.id,
+          email: user.email,
+          hubRole: payload['custom:hub_role'],
+          eddieWorkspacesCount: (payload['custom:eddie_workspaces'] ?? '')
+            .split(',')
+            .filter(Boolean).length,
+        })
+      } catch (err) {
+        if (isPrismaUniqueViolation(err)) {
+          user = await prisma.user.findUnique({
+            where: { email: payload.email },
+          })
+          if (!user) throw err
+          logger.info('cloudchat-embedded JIT race resolved', {
+            email: payload.email,
+          })
+        } else {
+          logger.warn('cloudchat-embedded JIT refused', {
+            email: payload.email,
+            reason: err instanceof Error ? err.message : 'unknown',
+          })
+          return null
+        }
+      }
+    }
+
+    return {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      image: user.image,
+      emailVerified: user.emailVerified,
+      cognitoClaims: {
+        'custom:hub_role': payload['custom:hub_role'],
+        'custom:eddie_workspaces': payload['custom:eddie_workspaces'],
+      },
+      cloudChatAuthorization: true,
+      cognitoTokenExp: payload.exp,
+    }
+  } catch (error) {
+    logger.error('Error in cloudchat-embedded authorize', { error })
+    return null
+  }
+}
+```
+
+## Testing strategy
+
+### Unit — `createCloudChatEmbeddedUser.test.ts`
+
+Vitest. Mock Prisma `user.create` and `trackEvents` via `vi.fn()`. Cases:
+
+- creates `User` row with `email + name + emailVerified + image`
+- creates `User` row with `email` only when `name`/`emailVerified` absent
+- does not call any workspace, MemberInWorkspace, or apiToken create
+- fires single `'User created'` telemetry event with email + first-name
+- propagates `prisma.user.create` errors (does not swallow)
+- propagates `trackEvents` errors (does not swallow)
+
+### Unit — `cloudchat-embedded.authorize.test.ts`
+
+Vitest. Mocks: `verifyCognitoToken`, `prisma.user.findUnique`,
+`createCloudChatEmbeddedUser`, `logger`. Cases:
+
+- returns null when `credentials.token` is missing
+- returns null when `verifyCognitoToken` throws (logs error)
+- returns null + logs warn when payload has no email
+- returns existing user when `findUnique` hits
+- creates user via `createCloudChatEmbeddedUser` when `findUnique` misses;
+  logs info `'JIT-provisioned cloudchat-embedded user'` with `hubRole` and
+  `eddieWorkspacesCount`
+- on `P2002` race: refetches and returns user, logs info `'race resolved'`
+- on `P2002` race + refetch returns null: rethrows (caught by outer, returns null)
+- on non-`P2002` error: logs warn + returns null
+- returns full `DatabaseUserWithCognito` shape with `cloudChatAuthorization: true`
+- maps `payload.email_verified === true` to `emailVerified: Date`;
+  `false`/`undefined` to `emailVerified: null`
+- maps `eddie_workspaces: 'ws-a,ws-b'` to `eddieWorkspacesCount: 2`;
+  `''` to `0`
+
+### OAuth flow regression coverage
+
+`customAdapter.createUser` is unchanged. Existing coverage (if any) remains valid;
+no new tests required for that path.
+
+## Validation plan (local UAT)
+
+No staging environment exists. Local validation in three modes; production
+validation via observability.
+
+### Mode 1 — full iframe flow via CloudChat dev login
+
+CloudChat `dev_cognito_token` (in
+`cloudchat-saas/app/controllers/devise_overrides/sessions_controller.rb:442`)
+emits a fake JWT shaped:
+
+```
+header: { alg: 'none', typ: 'JWT' }
+payload: { email, sub: 'dev-user', custom:hub_role: 'ADMIN',
+           custom:eddie_workspaces: '*', custom:projects: 'claudia_project',
+           exp: <1h> }
+signature: '' (empty)
+```
+
+Eddie's `verifyCognitoToken` decodes payload directly under `NODE_ENV=development`
+(no JWKS). End-to-end iframe flow runs in fidelity for everything except claim
+shape (`email_verified`, `name` are absent in dev token).
+
+Steps:
+
+```
+1. composezao up:  docker compose up -d --build
+2. Reset typebot DB:  docker compose exec typebot-builder pnpm prisma migrate reset --force
+3. Create fresh CloudChat user (Rails console or super_admin UI):
+     User.create!(email: 'jit-uat-001@local.test',
+                  uid: 'jit-uat-001@local.test',
+                  password: 'devpass',
+                  confirmed_at: Time.now)
+4. Login at http://localhost:3000 as that user.
+5. Navigate Claudia menu → Tools → edit a tool.
+6. Confirm Eddie iframe loads (no 'Failed to load flow builder').
+7. SQL on typebot DB:
+     SELECT id, email, name, "emailVerified" FROM "User"
+     WHERE email = 'jit-uat-001@local.test';
+   Expected: 1 row, name = NULL, emailVerified = NULL (dev token limitation)
+8. SQL — confirm no workspace/token side effects:
+     SELECT * FROM "MemberInWorkspace" WHERE "userId" = <id from step 7>;  -- 0 rows
+     SELECT * FROM "ApiToken" WHERE "ownerId" = <id from step 7>;          -- 0 rows
+9. Logs:  docker compose logs typebot-builder | grep JIT
+   Expected: one 'JIT-provisioned cloudchat-embedded user' with userId, email,
+   hubRole=ADMIN, eddieWorkspacesCount=1 ('*'.split(',').filter(Boolean) = ['*']).
+10. Open second tab as same user → no duplicate row, no extra 'JIT-provisioned'.
+```
+
+### Mode 2 — hand-crafted JWT (covers fields the dev token does not produce)
+
+```bash
+B64() { echo -n "$1" | base64 -w0 | tr '+/' '-_' | tr -d '='; }
+
+PAYLOAD='{"email":"jit-uat-002@local.test","email_verified":true,"name":"Maria Cliente","custom:hub_role":"CLIENT","custom:eddie_workspaces":"ws-real-1,ws-real-2","sub":"abc","exp":9999999999}'
+JWT="$(B64 '{"alg":"none","typ":"JWT"}').$(B64 "$PAYLOAD")."
+
+# 2a — direct auth callback
+curl -i 'http://localhost:3002/api/auth/callback/cloudchat-embedded' \
+  -H 'Content-Type: application/json' \
+  -d "{\"token\":\"$JWT\",\"redirect\":false,\"json\":true}"
+
+# 2b — embedded URL (covers SSR + auth + iframe)
+xdg-open "http://localhost:3002/typebots?embedded=true&jwt=$JWT"
+```
+
+Confirm `emailVerified IS NOT NULL` and `name = 'Maria Cliente'` on the User row.
+Confirm log line shows `hubRole: CLIENT` and `eddieWorkspacesCount: 2`.
+
+### Mode 3 — race
+
+```bash
+JWT="$(craft-jwt 'race-test@local.test')"
+for i in 1 2; do
+  curl -X POST 'http://localhost:3002/api/auth/callback/cloudchat-embedded' \
+    -H 'Content-Type: application/json' \
+    -d "{\"token\":\"$JWT\"}" &
+done
+wait
+```
+
+Confirm exactly one row in `User`, exactly one `'JIT-provisioned'` log line, and
+exactly one `'cloudchat-embedded JIT race resolved'` log line.
+
+### Fidelity gap (cannot validate locally)
+
+| Area | Gap | Mitigation |
+|---|---|---|
+| JWT signature/issuer/audience verification | Local skips JWKS via `NODE_ENV=development` bypass | Out of scope (PR does not modify `verifyCognitoToken`); covered in prod by existing live code path |
+| Real Cognito user pool variance | Dev tokens always have `hub_role=ADMIN`, `eddie_workspaces=*` | Mode 2 covers the variant claim shapes |
+
+## Rollout & observability
+
+### Deploy day
+
+Saved Datadog query:
+
+```
+service:typebot-builder ("JIT-provisioned" OR "JIT refused" OR "race resolved" OR "payload missing email")
+```
+
+Watch for the first 30 minutes after rollout. First successful real-user
+`JIT-provisioned` log confirms the prod JWKS path works end-to-end.
+
+### Spot check
+
+```sql
+-- typebot prod, post-deploy
+SELECT count(*)
+FROM "User"
+WHERE created_at > '<deploy timestamp>';
+```
+
+Compare against count of `'JIT-provisioned cloudchat-embedded user'` log lines —
+they should be approximately equal (allowing for OAuth-path users in the gap).
+
+### Ongoing alerts
+
+- Spike in `'cloudchat-embedded JIT refused'` → investigate (DB issue or claim shape change).
+- Sustained ratio of `JIT-provisioned` to total `cloudchat-embedded` auth attempts
+  > expected onboarding rate → indicates `findUnique` may be missing existing rows
+  (data skew or migration regression).
+
+### Rollback
+
+The PR is purely additive on the embedded path. Reverting restores the
+`return null` behavior. Already-provisioned `User` rows stay in the DB and remain
+reachable via the same flow on the next deploy. No data migration needed.
+
+## Open questions / future work
+
+- The "Failed to load flow builder. Please reload the page." UI message stays the
+  same in every refusal scenario. A future PR could distinguish refusal-by-policy
+  vs invalid-token vs internal-error in the UI to improve user feedback. Out of scope here.
+- `customAdapter.createUser` and `createCloudChatEmbeddedUser` share a small amount
+  of duplication (~8 lines around `user.create` and the `'User created'` telemetry
+  event). A future PR could unify if and when a third caller appears. Until then,
+  the duplication is preferred over coupling the two paths.
+- No rate-limit on the embedded auth path. If JIT provisioning shows abuse signals
+  in prod, revisit with the Upstash `Ratelimit` infra already imported in
+  `[...nextauth].ts`.

--- a/docs/superpowers/specs/2026-05-06-cloudchat-embedded-jit-provisioning-design.md
+++ b/docs/superpowers/specs/2026-05-06-cloudchat-embedded-jit-provisioning-design.md
@@ -239,9 +239,13 @@ NextAuth signIn → { ok: false }
 useEmbeddedAuth → setAuthError('Failed to load flow builder. Please reload the page.')
 ```
 
-Note: if `trackEvents` throws after `user.create` succeeded, the user row already
-exists in the DB. The next attempt by the same email will hit the `findUnique` happy
-path. Mirrors the loose atomicity already present in `customAdapter.createUser`.
+Note: telemetry calls are best-effort inside `createCloudChatEmbeddedUser` —
+the helper wraps `trackEvents` in a try/catch. A telemetry outage logs
+`warn 'cloudchat-embedded telemetry failed (user provisioned)'` and the helper
+still returns the freshly-created user, so the auth path completes successfully.
+This deviates intentionally from `customAdapter.createUser`, which propagates
+telemetry errors. The JIT path is on the critical-auth hot path; we do not want
+a Datadog/StatsD hiccup to look like an authentication failure to the user.
 
 ### Refusal — invalid JWT (existing behavior)
 
@@ -274,7 +278,7 @@ path. Mirrors the loose atomicity already present in `customAdapter.createUser`.
 | Race — P2002 caught, refetch returns user | inner catch | `return user` | `info 'cloudchat-embedded JIT race resolved'` |
 | Race — P2002 caught, refetch returns null | inner catch (rare/strange) | `throw` (caught by outer, returns null) | `error` outer |
 | Other Prisma error during create | inner catch | `return null` | `warn 'cloudchat-embedded JIT refused' { email, reason }` |
-| `trackEvents` throws (after user.create OK) | inner catch (non-P2002) | `return null`; user already in DB | `warn 'cloudchat-embedded JIT refused (telemetry)'` |
+| `trackEvents` throws (after user.create OK) | inner catch in `createCloudChatEmbeddedUser` | swallowed; user returned; auth proceeds | `warn 'cloudchat-embedded telemetry failed (user provisioned)' { userId, email, error }` |
 
 ### Final shape of the modified `authorize` block
 
@@ -514,7 +518,10 @@ they should be approximately equal (allowing for OAuth-path users in the gap).
 
 ### Ongoing alerts
 
-- Spike in `'cloudchat-embedded JIT refused'` → investigate (DB issue or claim shape change).
+- Spike in `'cloudchat-embedded JIT refused'` → investigate. Possible causes (oncall triage order):
+  1. DB issue — `prisma.user.create` failing for a non-`P2002` reason (connection pool, constraint other than unique-email).
+  2. Claim shape change — Cognito payload missing fields the code path expects after passing the email guard.
+- Spike in `'cloudchat-embedded telemetry failed (user provisioned)'` → telemetry/Datadog outage. Auth still works; no user-facing impact, but observability is degraded. Out of band of the auth path.
 - Sustained ratio of `JIT-provisioned` to total `cloudchat-embedded` auth attempts
   > expected onboarding rate → indicates `findUnique` may be missing existing rows
   (data skew or migration regression).


### PR DESCRIPTION
## Resumo

Provisiona o `User` row do typebot **just-in-time** quando um JWT Cognito válido chega pelo provider `cloudchat-embedded` do NextAuth. Resolve o erro **\"Failed to load flow builder. Please reload the page.\"** que aparece quando um user CloudChat acessa Eddie embedded pela primeira vez.

**Root cause** (pré-fix): o `authorize` do `cloudchat-embedded` fazia `prisma.user.findUnique({ where: { email } })` e retornava `null` se o user não existia. Como `CredentialsProvider` por design do NextAuth não invoca o adapter (`customAdapter.createUser`), users novos ficavam stuck.

**Workaround atual em prod** (Mat): pedir pro user autenticar manualmente via `custom-oauth` Cognito provider primeiro, que aciona `customAdapter.createUser` e popula o User row. Esse PR elimina a etapa manual.

## O que muda

**Cirúrgico no caminho embedded — `customAdapter` e `verifyCognitoToken` ficam intactos.**

| Arquivo | Mudança |
|---|---|
| `apps/builder/src/features/auth/helpers/isPrismaUniqueViolation.ts` (novo) | Type guard para `Prisma.PrismaClientKnownRequestError` com `code: 'P2002'` |
| `apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.ts` (novo) | Helper minimal: cria User row + dispara telemetry `'User created'`. **Sem** workspace, **sem** apiToken, **sem** invitation processing |
| `apps/builder/src/features/auth/helpers/cloudchatEmbeddedAuthorize.ts` (novo) | Authorize callback extraído do inline em `[...nextauth].ts`. Lógica completa de JIT: validação de email, findUnique, create, P2002 race com refetch, logs estruturados |
| `apps/builder/src/pages/api/auth/[...nextauth].ts` | **+3/-47** linhas: provider passa a ser thin wrapper chamando o helper. Remove import de `verifyCognitoToken` (não usado mais nesse arquivo) |
| `*.test.ts` (3 novos) | 22 testes Vitest: 4 + 7 + 11. Cobre JIT happy/exists/race/refusal, email validation, field mapping, eddie_workspaces parsing |

**Pós-review (commit `578db80a`):** o `trackEvents` dentro do `createCloudChatEmbeddedUser` agora é wrapped em try/catch (telemetry é best-effort no caminho crítico de auth). Telemetry outage loga `warn 'cloudchat-embedded telemetry failed (user provisioned)'` em vez de surfacing como `JIT refused`. O teste original que validava propagação foi invertido pra validar o swallow. Spec doc + Datadog runbook atualizados.

## Decisões já bloqueadas no design

| | |
|---|---|
| Política de segurança | Qualquer JWT Cognito válido provisiona (paridade com OAuth flow). Barreira: `verifyCognitoToken` (issuer + audience + JWKS em prod). |
| `DISABLE_SIGNUP` | **NÃO** aplicado no JIT — flag é pra esconder botão de signup, não política de auth |
| Default workspace | **NÃO** criado — acesso vem do claim `custom:eddie_workspaces` (`listWorkspaces.getWorkspaceFilter` já tem `OR: [{ members: ... }, { id: { in: cognitoAccess.ids } }]`) |
| Default API token | **NÃO** criado — tokens são pra OAuth flow |
| Invitation processing | **NÃO** no JIT — convites typebot são conceito do produto standalone |
| Race condition | catch `P2002` + refetch (preserva atomicidade existente) |
| Observabilidade | Logs estruturados (5 níveis: error verify, warn missing-email, info JIT-provisioned, info race-resolved, warn JIT-refused) |

## Plan & spec docs

- [docs/superpowers/specs/2026-05-06-cloudchat-embedded-jit-provisioning-design.md](docs/superpowers/specs/2026-05-06-cloudchat-embedded-jit-provisioning-design.md) — design doc completo (decisões + rationale + dataflow + error matrix)
- [docs/superpowers/plans/2026-05-06-cloudchat-embedded-jit-provisioning.md](docs/superpowers/plans/2026-05-06-cloudchat-embedded-jit-provisioning.md) — plan de implementação task-a-task com TDD

## Como revisar

1. Diff é pequeno em código de produção (~150 LOC novas + 47 removidas em `[...nextauth].ts`)
2. Os 22 testes unit cobrem todos os branches da decisão (incluindo race + edge cases de claim parsing)
3. Para entender o porquê de cada decisão, ler o spec doc primeiro
4. Para entender o contrato exato de cada commit, ler o plan doc

## UAT local — antes de mergear

Como não temos staging, validação local + observabilidade pós-deploy. Roteiro completo no spec (\"Validation plan (local UAT)\") em 3 modos:

- **Modo 1**: CloudChat dev login + iframe Eddie real (testa caminho feliz E2E com `dev_cognito_token`)
- **Modo 2**: JWT craftado direto no callback (cobre `email_verified=true`, `name` setado, `hub_role: CLIENT`)
- **Modo 3**: 2 chamadas concorrentes (testa P2002 race com refetch resolved)

## Pós-deploy

Datadog query salva: `service:typebot-builder (\"JIT-provisioned\" OR \"JIT refused\" OR \"race resolved\" OR \"payload missing email\")`. Watch nos primeiros 30min do rollout pra confirmar que o JWKS real funciona com pessoas reais.

## Rollback

Branch é puramente aditivo no caminho embedded. Reverter restaura o `return null`. User rows já provisionados ficam no DB e funcionam no próximo deploy. Sem migração necessária.

## Follow-ups (intencionalmente fora de escopo)

- **`OAuthAccountNotLinked` no fluxo OAuth pós-JIT** (flagado pelo Cursor Bugbot, [#193 inline](https://github.com/cloudhumans/typebot.io/pull/193#discussion_r3196516818)) — user CloudChat-managed que JIT-provisionou via embed, se acessar Eddie standalone (`eddie.us-east-1.prd.cloudhumans.io` direto sem `?embedded=true`) e clicar "Cloud Hub Login", recebe erro porque NextAuth acha o User row mas sem `Account` linkado pro `custom-oauth` provider. Fix sugerido em PR separada: setar `allowDangerousEmailAccountLinking: true` no `custom-oauth` provider config — NextAuth passa a auto-linkar `Account` a `User` existentes quando email bate (seguro aqui porque o email é validado upstream pelo Cognito mesma User Pool). Pré-existe ao PR atual, mas o JIT torna o caso muito mais provável de acontecer.
- **`isNewUser=true` em todo login `cloudchat-embedded`** — o `authorize` retorna um `Pick<DatabaseUserWithCognito, ...>` sem `createdAt`, então o `signIn` callback (linha ~311 de `[...nextauth].ts`) avalia sempre como new user e dispara o disposable-email blocklist fetch pro GitHub. Pré-existe a esse PR (mesma shape no inline original), mas como o JIT path agora é exercitado de fato por mais users, fica mais visível. Opções: (a) incluir `createdAt` no return; (b) early-return no `signIn` callback pra `cloudchat-embedded`. Vou abrir issue separada.
- **Vitest como devDependency explícita** no workspace — atualmente os `*.test.ts` rodam via `npx vitest@4.1.5` (download on-demand) e não via `pnpm test`. Mesma situação dos testes pré-existentes (`accessControl.test.ts`, `cognitoUtils.test.ts`, etc.). Issue separada pra adicionar vitest config + script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Este PR extrai a lógica de autenticação `cloudchat-embedded` para um helper dedicado (`cloudchatEmbeddedAuthorize`) e adiciona provisionamento JIT (*just-in-time*) de usuários: quando um JWT Cognito válido chega pelo provider embedded e o e-mail não existe no banco, o helper cria o registro `User` automaticamente, lidando com race conditions via P2002 com refetch atômico.

- **`cloudchatEmbeddedAuthorize.ts`**: extrai o callback `authorize` do inline em `[...nextauth].ts`, adiciona JIT provisioning com tratamento de race P2002 e logs estruturados em 5 níveis; inclui `createdAt` no retorno, corrigindo o comportamento de `isNewUser` no `signIn` callback para usuários de retorno.
- **`createCloudChatEmbeddedUser.ts`**: helper mínimo que cria o registro `User` sem workspace/apiToken, com telemetria best-effort envolta em try/catch para não bloquear o caminho crítico de auth.
- **`isPrismaUniqueViolation.ts`** + 3 arquivos de teste: type guard reutilizável para `P2002` e 22 testes Vitest cobrindo happy path, race condition, edge cases de claim parsing e comportamento de telemetria.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is surgical and additive: production auth behavior changes only for the `cloudchat-embedded` credentials provider, and the rollback path is a one-line revert with no migration needed.

The JIT provisioning logic is well-structured with correct P2002 race handling, telemetry isolated in best-effort try/catch, and `createdAt` forwarded so the `signIn` callback evaluates `isNewUser` correctly for returning users. The 22 unit tests cover all decision branches. Previously flagged issues (telemetry blocking auth, `isNewUser` always true) are both resolved in this commit. No blocking defects found in the changed code paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/builder/src/features/auth/helpers/cloudchatEmbeddedAuthorize.ts | Core JIT authorize helper: token verification, findUnique, create, P2002 race handling, and structured logging. Correctly includes `createdAt` in the return type, fixing the `isNewUser` evaluation in the `signIn` callback. |
| apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.ts | Minimal user creation helper with best-effort telemetry wrapped in try/catch. Correctly uses `?? undefined` for nullable fields to let Prisma use DB defaults. No side-effects (no workspace, no apiToken). |
| apps/builder/src/features/auth/helpers/isPrismaUniqueViolation.ts | Simple and correct type guard for Prisma P2002 unique constraint violations; well-tested. |
| apps/builder/src/pages/api/auth/[...nextauth].ts | Provider registration slimmed down significantly (-47 lines). The `cloudchat-embedded` provider is now a thin wrapper calling `cloudchatEmbeddedAuthorize`. `isNewUser` evaluation now works correctly for returning users since `createdAt` is included in the returned shape. |
| apps/builder/src/features/auth/helpers/cloudchatEmbeddedAuthorize.test.ts | 11 tests covering all decision branches: missing token, bad JWT, missing email, existing user, JIT happy path, P2002 race resolved, P2002+null refetch, non-P2002 error, full shape assertion, createdAt forwarding, email_verified mapping, and eddie_workspaces count parsing. |
| apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.test.ts | 7 tests covering user creation with various field combinations, no-side-effects assertion, telemetry payload (first-name split), telemetry swallow on failure with warn log, and prisma error propagation. |
| apps/builder/src/features/auth/helpers/isPrismaUniqueViolation.test.ts | 4 tests covering true case (P2002), false case (non-P2002 code), plain Error, and non-Error values. Complete. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Embedded iframe login]) --> B[cloudchatEmbeddedAuthorize]
    B --> C{credentials.token present?}
    C -- No --> Z1([return null])
    C -- Yes --> D[verifyCognitoToken]
    D -- invalid --> Z2([return null, log error])
    D -- valid payload --> E{email in payload?}
    E -- No --> Z3([return null, log warn])
    E -- Yes --> F[DB findUnique by email]
    F -- found --> G([return AuthorizedUser])
    F -- not found --> H[createCloudChatEmbeddedUser]
    H --> I[p.user.create]
    I -- success --> J[trackEvents best-effort]
    J --> K([return AuthorizedUser, log JIT-provisioned])
    I -- P2002 race --> L[DB findUnique refetch]
    L -- found --> M([return AuthorizedUser, log race resolved])
    L -- null --> Z4([rethrow, null, log error])
    I -- other error --> Z5([return null, log warn JIT refused])
```

<sub>Reviews (8): Last reviewed commit: ["fix(auth): forward createdAt so signIn i..."](https://github.com/cloudhumans/typebot.io/commit/a1c9c99cdae2e713af344e03db4e327d2d5630d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31029691)</sub>

<!-- /greptile_comment -->