### PR TITLE
:loud_sound: Log script errors with context

### DIFF
--- a/packages/bot-engine/blocks/logic/script/executeScript.ts
+++ b/packages/bot-engine/blocks/logic/script/executeScript.ts
@@ -9,9 +9,11 @@ import { updateVariablesInSession } from '@typebot.io/variables/updateVariablesI
 
 export const executeScript = async (
   state: SessionState,
-  block: ScriptBlock
+  block: ScriptBlock,
+  sessionId?: string
 ): Promise<ExecuteLogicResponse> => {
-  const { variables } = state.typebotsQueue[0].typebot
+  const typebot = state.typebotsQueue[0].typebot
+  const { variables } = typebot
   if (!block.options?.content || state.whatsApp)
     return { outgoingEdgeId: block.outgoingEdgeId }
 
@@ -22,6 +24,16 @@ export const executeScript = async (
     const { newVariables, error } = await executeFunction({
       variables,
       body: block.options.content,
+      errorContext: {
+        typebotId: typebot.id,
+        typebotName: typebot.name,
+        sessionId,
+        workspaceId: typebot.workspaceId ?? undefined,
+        workspaceName: typebot.workspaceName ?? undefined,
+        blockId: block.id,
+        blockType: block.type,
+        source: 'script',
+      },
     })
 
     const updateVarResults = newVariables

--- a/packages/bot-engine/blocks/logic/script/executeScript.ts
+++ b/packages/bot-engine/blocks/logic/script/executeScript.ts
@@ -26,13 +26,9 @@ export const executeScript = async (
       body: block.options.content,
       errorContext: {
         typebotId: typebot.id,
-        typebotName: typebot.name,
         sessionId,
         workspaceId: typebot.workspaceId ?? undefined,
         workspaceName: typebot.workspaceName ?? undefined,
-        blockId: block.id,
-        blockType: block.type,
-        source: 'script',
       },
     })
 

--- a/packages/bot-engine/blocks/logic/script/executeScript.ts
+++ b/packages/bot-engine/blocks/logic/script/executeScript.ts
@@ -10,7 +10,8 @@ import { updateVariablesInSession } from '@typebot.io/variables/updateVariablesI
 export const executeScript = async (
   state: SessionState,
   block: ScriptBlock,
-  sessionId?: string
+  sessionId?: string,
+  group?: { id: string; title?: string }
 ): Promise<ExecuteLogicResponse> => {
   const typebot = state.typebotsQueue[0].typebot
   const { variables } = typebot
@@ -29,6 +30,8 @@ export const executeScript = async (
         sessionId,
         workspaceId: typebot.workspaceId ?? undefined,
         workspaceName: typebot.workspaceName ?? undefined,
+        groupId: group?.id,
+        groupName: group?.title,
       },
     })
 

--- a/packages/bot-engine/executeGroup.ts
+++ b/packages/bot-engine/executeGroup.ts
@@ -188,7 +188,7 @@ export const executeGroup = async (
 
     const executionResponse = (
       isLogicBlock(block)
-        ? await executeLogic(newSessionState)(block)
+        ? await executeLogic(newSessionState, sessionId)(block)
         : isIntegrationBlock(block)
         ? await executeIntegration(newSessionState, sessionId)(block)
         : null

--- a/packages/bot-engine/executeGroup.ts
+++ b/packages/bot-engine/executeGroup.ts
@@ -188,7 +188,10 @@ export const executeGroup = async (
 
     const executionResponse = (
       isLogicBlock(block)
-        ? await executeLogic(newSessionState, sessionId)(block)
+        ? await executeLogic(newSessionState, sessionId, {
+            id: group.id,
+            title: group.title,
+          })(block)
         : isIntegrationBlock(block)
         ? await executeIntegration(newSessionState, sessionId)(block)
         : null

--- a/packages/bot-engine/executeLogic.ts
+++ b/packages/bot-engine/executeLogic.ts
@@ -14,7 +14,7 @@ import { executeDeclareVariables } from './blocks/logic/declareVariables/execute
 import { LogicBlockType } from '@typebot.io/schemas/features/blocks/logic/constants'
 
 export const executeLogic =
-  (state: SessionState) =>
+  (state: SessionState, sessionId?: string) =>
   async (block: LogicBlock): Promise<ExecuteLogicResponse> => {
     switch (block.type) {
       case LogicBlockType.SET_VARIABLE:
@@ -28,7 +28,7 @@ export const executeLogic =
       case LogicBlockType.REDIRECT:
         return executeRedirect(state, block)
       case LogicBlockType.SCRIPT:
-        return executeScript(state, block)
+        return executeScript(state, block, sessionId)
       case LogicBlockType.TYPEBOT_LINK:
         return executeTypebotLink(state, block)
       case LogicBlockType.WAIT:

--- a/packages/bot-engine/executeLogic.ts
+++ b/packages/bot-engine/executeLogic.ts
@@ -14,7 +14,11 @@ import { executeDeclareVariables } from './blocks/logic/declareVariables/execute
 import { LogicBlockType } from '@typebot.io/schemas/features/blocks/logic/constants'
 
 export const executeLogic =
-  (state: SessionState, sessionId?: string) =>
+  (
+    state: SessionState,
+    sessionId?: string,
+    group?: { id: string; title?: string }
+  ) =>
   async (block: LogicBlock): Promise<ExecuteLogicResponse> => {
     switch (block.type) {
       case LogicBlockType.SET_VARIABLE:
@@ -28,7 +32,7 @@ export const executeLogic =
       case LogicBlockType.REDIRECT:
         return executeRedirect(state, block)
       case LogicBlockType.SCRIPT:
-        return executeScript(state, block, sessionId)
+        return executeScript(state, block, sessionId, group)
       case LogicBlockType.TYPEBOT_LINK:
         return executeTypebotLink(state, block)
       case LogicBlockType.WAIT:

--- a/packages/variables/executeFunction.ts
+++ b/packages/variables/executeFunction.ts
@@ -16,6 +16,8 @@ export type ExecuteFunctionContext = {
   sessionId?: string
   workspaceId?: string
   workspaceName?: string
+  groupId?: string
+  groupName?: string
 }
 
 type Props = {

--- a/packages/variables/executeFunction.ts
+++ b/packages/variables/executeFunction.ts
@@ -10,18 +10,12 @@ import { parseTransferrableValue } from './codeRunners'
 import jwt from 'jsonwebtoken'
 
 const defaultTimeout = 10 * 1000
-const valuePreviewMaxChars = 200
-const bodyPreviewMaxChars = 600
 
 export type ExecuteFunctionContext = {
   typebotId?: string
-  typebotName?: string
   sessionId?: string
   workspaceId?: string
   workspaceName?: string
-  blockId?: string
-  blockType?: string
-  source?: string
 }
 
 type Props = {
@@ -29,23 +23,6 @@ type Props = {
   body: string
   args?: Record<string, unknown>
   errorContext?: ExecuteFunctionContext
-}
-
-const previewValue = (value: unknown): string => {
-  if (value === undefined) return 'undefined'
-  if (value === null) return 'null'
-  let str: string
-  if (typeof value === 'string') str = value
-  else {
-    try {
-      str = JSON.stringify(value) ?? String(value)
-    } catch {
-      str = String(value)
-    }
-  }
-  return str.length > valuePreviewMaxChars
-    ? `${str.slice(0, valuePreviewMaxChars)}…(+${str.length - valuePreviewMaxChars} chars)`
-    : str
 }
 
 export const executeFunction = async ({
@@ -140,17 +117,7 @@ export const executeFunction = async ({
         ? e
         : e instanceof Error
           ? e.message
-          : JSON.stringify(e)
-
-    const variablePreview = args.reduce<Record<string, string>>(
-      (acc, { id, value }) => {
-        const variable = variables.find((v) => v.id === id)
-        const name = variable?.name ?? id
-        acc[name] = previewValue(value)
-        return acc
-      },
-      {}
-    )
+          : (safeStringify(e) ?? String(e))
 
     logger.error('Error while executing script', {
       ...errorContext,
@@ -159,11 +126,6 @@ export const executeFunction = async ({
         message: error,
         stack: e instanceof Error ? e.stack : undefined,
       },
-      bodyPreview:
-        body.length > bodyPreviewMaxChars
-          ? `${body.slice(0, bodyPreviewMaxChars)}…(+${body.length - bodyPreviewMaxChars} chars)`
-          : body,
-      variables: variablePreview,
     })
 
     return {

--- a/packages/variables/executeFunction.ts
+++ b/packages/variables/executeFunction.ts
@@ -27,6 +27,9 @@ type Props = {
   errorContext?: ExecuteFunctionContext
 }
 
+const stripPaths = (s: string | undefined): string | undefined =>
+  s?.replace(/\/(home|app|usr|var|opt|tmp)\/[^\s)]+/g, '<path>')
+
 export const executeFunction = async ({
   variables,
   body,
@@ -98,7 +101,6 @@ export const executeFunction = async ({
       )
 
     const output = await run(parsedBody)
-    console.log('Output', output)
     return {
       output: safeStringify(output) ?? '',
       newVariables: Object.entries(updatedVariables)
@@ -121,12 +123,12 @@ export const executeFunction = async ({
           ? e.message
           : (safeStringify(e) ?? String(e))
 
-    logger.error('Error while executing script', {
+    logger.warn('Error while executing script', {
       ...errorContext,
       error: {
         name: e instanceof Error ? e.name : 'Unknown',
         message: error,
-        stack: e instanceof Error ? e.stack : undefined,
+        stack: stripPaths(e instanceof Error ? e.stack : undefined),
       },
     })
 

--- a/packages/variables/executeFunction.ts
+++ b/packages/variables/executeFunction.ts
@@ -2,6 +2,7 @@ import { parseVariables } from './parseVariables'
 import { extractVariablesFromText } from './extractVariablesFromText'
 import { parseGuessedValueType } from './parseGuessedValueType'
 import { isDefined } from '@typebot.io/lib'
+import logger from '@typebot.io/lib/logger'
 import { safeStringify } from '@typebot.io/lib/safeStringify'
 import { Variable } from './types'
 import ivm from 'isolated-vm'
@@ -9,17 +10,49 @@ import { parseTransferrableValue } from './codeRunners'
 import jwt from 'jsonwebtoken'
 
 const defaultTimeout = 10 * 1000
+const valuePreviewMaxChars = 200
+const bodyPreviewMaxChars = 600
+
+export type ExecuteFunctionContext = {
+  typebotId?: string
+  typebotName?: string
+  sessionId?: string
+  workspaceId?: string
+  workspaceName?: string
+  blockId?: string
+  blockType?: string
+  source?: string
+}
 
 type Props = {
   variables: Variable[]
   body: string
   args?: Record<string, unknown>
+  errorContext?: ExecuteFunctionContext
+}
+
+const previewValue = (value: unknown): string => {
+  if (value === undefined) return 'undefined'
+  if (value === null) return 'null'
+  let str: string
+  if (typeof value === 'string') str = value
+  else {
+    try {
+      str = JSON.stringify(value) ?? String(value)
+    } catch {
+      str = String(value)
+    }
+  }
+  return str.length > valuePreviewMaxChars
+    ? `${str.slice(0, valuePreviewMaxChars)}…(+${str.length - valuePreviewMaxChars} chars)`
+    : str
 }
 
 export const executeFunction = async ({
   variables,
   body,
   args: initialArgs,
+  errorContext,
 }: Props) => {
   const parsedBody = parseVariables(variables, {
     fieldToParse: 'id',
@@ -102,15 +135,36 @@ export const executeFunction = async ({
         .filter(isDefined),
     }
   } catch (e) {
-    console.log('Error while executing script')
-    console.error(e)
-
     const error =
       typeof e === 'string'
         ? e
         : e instanceof Error
           ? e.message
           : JSON.stringify(e)
+
+    const variablePreview = args.reduce<Record<string, string>>(
+      (acc, { id, value }) => {
+        const variable = variables.find((v) => v.id === id)
+        const name = variable?.name ?? id
+        acc[name] = previewValue(value)
+        return acc
+      },
+      {}
+    )
+
+    logger.error('Error while executing script', {
+      ...errorContext,
+      error: {
+        name: e instanceof Error ? e.name : 'Unknown',
+        message: error,
+        stack: e instanceof Error ? e.stack : undefined,
+      },
+      bodyPreview:
+        body.length > bodyPreviewMaxChars
+          ? `${body.slice(0, bodyPreviewMaxChars)}…(+${body.length - bodyPreviewMaxChars} chars)`
+          : body,
+      variables: variablePreview,
+    })
 
     return {
       error,


### PR DESCRIPTION
Card #6816 surfaced 1.8M `JSON.parse(undefined)` errors em `typebot-viewer` sem `typebotId`/`sessionId`/`workspaceId`, impossibilitando identificar o flow ofensor.

Substitui o `console.error` puro no catch de `executeFunction` por um `logger.warn` estruturado carregando `typebotId`, `sessionId`, `workspaceId`, `workspaceName`, `groupId`, `groupName` e o erro com `name`, `message` e `stack` (paths de filesystem strippados antes de logar).

Threada `sessionId` e o `group` por `executeGroup` → `executeLogic` → `executeScript` → `executeFunction` pra que o caminho de script tenha acesso ao contexto.

**Nível de log**: `warn` por escolha — erro de script é erro no código do **usuário** (typebot), não falha de plataforma. A engine fez o job: sandbox capturou, devolveu o erro pro flow. Volume (1.8M) inviabiliza rotear como `error` sem poluir dashboards de incidente.

**Limitação conhecida**: callers de `executeFunction` em `runChatCompletion.ts` e `askAssistant.tsx` (tool-calls do OpenAI) não passam `errorContext` por enquanto. Erros de tool-call continuam sem contexto — fora do escopo deste PR.

Volume de logs de erro inalterado; investigações futuras conseguem apontar o typebot ofensor em segundos.

Refs: cloudhumans/ClaudIA #6816