### PR TITLE
:bug: fixed getUserRoleInWorkspace not respecting cognito claims on s…

### DIFF
--- a/apps/builder/src/features/folders/api/createFolder.ts
+++ b/apps/builder/src/features/folders/api/createFolder.ts
@@ -38,7 +38,12 @@ export const createFolder = authenticatedProcedure
         where: { id: workspaceId },
         select: { id: true, members: true, plan: true },
       })
-      const userRole = getUserRoleInWorkspace(user.id, workspace?.members)
+      const userRole = getUserRoleInWorkspace(
+        user.id,
+        workspace?.members,
+        workspaceId,
+        user
+      )
       if (
         userRole === undefined ||
         userRole === WorkspaceRole.GUEST ||

--- a/apps/builder/src/features/folders/api/deleteFolder.ts
+++ b/apps/builder/src/features/folders/api/deleteFolder.ts
@@ -32,7 +32,12 @@ export const deleteFolder = authenticatedProcedure
       where: { id: workspaceId },
       select: { id: true, members: true, plan: true },
     })
-    const userRole = getUserRoleInWorkspace(user.id, workspace?.members)
+    const userRole = getUserRoleInWorkspace(
+      user.id,
+      workspace?.members,
+      workspaceId,
+      user
+    )
     if (
       userRole === undefined ||
       userRole === WorkspaceRole.GUEST ||

--- a/apps/builder/src/features/folders/api/updateFolder.ts
+++ b/apps/builder/src/features/folders/api/updateFolder.ts
@@ -39,7 +39,12 @@ export const updateFolder = authenticatedProcedure
         where: { id: workspaceId },
         select: { id: true, members: true, plan: true },
       })
-      const userRole = getUserRoleInWorkspace(user.id, workspace?.members)
+      const userRole = getUserRoleInWorkspace(
+        user.id,
+        workspace?.members,
+        workspaceId,
+        user
+      )
       if (
         userRole === undefined ||
         userRole === WorkspaceRole.GUEST ||


### PR DESCRIPTION
…ome endpoints

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Este PR corrige três endpoints de pastas (`createFolder`, `deleteFolder`, `updateFolder`) que não estavam passando `workspaceId` e `user` para `getUserRoleInWorkspace`, fazendo com que as claims do Cognito fossem ignoradas e a autorização caísse sempre no fallback de banco de dados.

- **`createFolder.ts` e `updateFolder.ts`**: alteração correta e consistente com os demais endpoints já corrigidos (`getFolder`, `listFolders`, `createTypebot`, etc.).
- **`deleteFolder.ts`**: recebe o mesmo ajuste, porém a query de exclusão usa apenas `folderId` sem filtrar por `workspaceId`, o que permite que um usuário com acesso a um workspace exclua pastas de outro workspace caso conheça o ID — comportamento pré-existente que fica mais crítico com ADMINs Cognito tendo acesso global.

<h3>Confidence Score: 3/5</h3>

O ajuste nos três endpoints é simples e correto, mas `deleteFolder` realiza a exclusão sem restringir por `workspaceId`, expondo uma brecha de autorização cruzada entre workspaces.

A correção do Cognito está bem implementada e alinhada com o padrão adotado nos demais endpoints. O problema está em `deleteFolder`: a query de exclusão usa somente `folderId`, sem confirmar que a pasta pertence ao workspace autorizado. Um usuário legítimo em workspace A poderia excluir uma pasta de workspace B fornecendo um `folderId` válido de lá — e com ADMINs Cognito tendo acesso irrestrito a todos os workspaces, o raio de impacto aumenta.

apps/builder/src/features/folders/api/deleteFolder.ts — a query de exclusão precisa de um filtro `workspaceId` para garantir que a pasta pertença ao workspace autorizado.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/builder/src/features/folders/api/createFolder.ts | Adiciona `workspaceId` e `user` à chamada de `getUserRoleInWorkspace`, habilitando verificação via claims Cognito antes do fallback para o banco de dados. |
| apps/builder/src/features/folders/api/deleteFolder.ts | Adiciona suporte ao Cognito corretamente, mas expõe que a query de delete não filtra por `workspaceId`, permitindo que usuários autorizados deletem pastas de outros workspaces. |
| apps/builder/src/features/folders/api/updateFolder.ts | Adiciona `workspaceId` e `user` à chamada de `getUserRoleInWorkspace`, habilitando verificação via claims Cognito — alteração correta e consistente. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Endpoint as Folder Endpoint
    participant GRIW as getUserRoleInWorkspace
    participant Cognito as checkCognitoWorkspaceAccess
    participant DB as Prisma / Database

    Client->>Endpoint: request(workspaceId, folderId, user)
    Endpoint->>DB: workspace.findUnique(workspaceId)
    DB-->>Endpoint: workspace (members, plan)
    Endpoint->>GRIW: getUserRoleInWorkspace(userId, members, workspaceId, user)
    GRIW->>Cognito: checkCognitoWorkspaceAccess(user, workspaceId)
    alt Cognito claims válidas e acesso concedido
        Cognito-->>GRIW: hasAccess true + role
        GRIW-->>Endpoint: role via Cognito
    else Sem claims ou sem acesso Cognito
        Cognito-->>GRIW: hasAccess false
        GRIW->>DB: members.find(userId)
        DB-->>GRIW: member.role
        GRIW-->>Endpoint: role via DB
    end
    alt "role === GUEST ou undefined ou workspace ausente"
        Endpoint-->>Client: TRPCError NOT_FOUND
    else Autorizado
        Endpoint->>DB: dashboardFolder.create/delete/update
        DB-->>Endpoint: folder
        Endpoint-->>Client: folder
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/builder/src/features/folders/api/deleteFolder.ts`, line 51-55 ([link](https://github.com/cloudhumans/typebot.io/blob/6c637566fbe29ba6d9c1f7bb23ee4f89ac9c47f8/apps/builder/src/features/folders/api/deleteFolder.ts#L51-L55)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Ausência de filtro por `workspaceId` na exclusão**

   A query de deleção usa apenas `folderId` como critério, sem validar que a pasta pertence ao `workspaceId` informado na requisição. Um usuário com acesso legítimo ao workspace A pode passar um `folderId` de outro workspace (B) e excluí-la, pois o controle de acesso verifica apenas o `workspaceId` da requisição, não o workspace real da pasta. Com a adição do Cognito (onde ADMINs têm acesso a todos os workspaces), esse cenário se torna ainda mais amplo.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/builder/src/features/folders/api/deleteFolder.ts
   Line: 51-55

   Comment:
   **Ausência de filtro por `workspaceId` na exclusão**

   A query de deleção usa apenas `folderId` como critério, sem validar que a pasta pertence ao `workspaceId` informado na requisição. Um usuário com acesso legítimo ao workspace A pode passar um `folderId` de outro workspace (B) e excluí-la, pois o controle de acesso verifica apenas o `workspaceId` da requisição, não o workspace real da pasta. Com a adição do Cognito (onde ADMINs têm acesso a todos os workspaces), esse cenário se torna ainda mais amplo.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fbuilder%2Fsrc%2Ffeatures%2Ffolders%2Fapi%2FdeleteFolder.ts%0ALine%3A%2051-55%0A%0AComment%3A%0A**Aus%C3%AAncia%20de%20filtro%20por%20%60workspaceId%60%20na%20exclus%C3%A3o**%0A%0AA%20query%20de%20dele%C3%A7%C3%A3o%20usa%20apenas%20%60folderId%60%20como%20crit%C3%A9rio%2C%20sem%20validar%20que%20a%20pasta%20pertence%20ao%20%60workspaceId%60%20informado%20na%20requisi%C3%A7%C3%A3o.%20Um%20usu%C3%A1rio%20com%20acesso%20leg%C3%ADtimo%20ao%20workspace%20A%20pode%20passar%20um%20%60folderId%60%20de%20outro%20workspace%20%28B%29%20e%20exclu%C3%AD-la%2C%20pois%20o%20controle%20de%20acesso%20verifica%20apenas%20o%20%60workspaceId%60%20da%20requisi%C3%A7%C3%A3o%2C%20n%C3%A3o%20o%20workspace%20real%20da%20pasta.%20Com%20a%20adi%C3%A7%C3%A3o%20do%20Cognito%20%28onde%20ADMINs%20t%C3%AAm%20acesso%20a%20todos%20os%20workspaces%29%2C%20esse%20cen%C3%A1rio%20se%20torna%20ainda%20mais%20amplo.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20folder%20%3D%20await%20prisma.dashboardFolder.delete%28%7B%0A%20%20%20%20%20%20where%3A%20%7B%0A%20%20%20%20%20%20%20%20id%3A%20folderId%2C%0A%20%20%20%20%20%20%20%20workspaceId%2C%0A%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%7D%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudhumans%2Ftypebot.io&pr=196&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fbuilder%2Fsrc%2Ffeatures%2Ffolders%2Fapi%2FdeleteFolder.ts%0ALine%3A%2051-55%0A%0AComment%3A%0A**Aus%C3%AAncia%20de%20filtro%20por%20%60workspaceId%60%20na%20exclus%C3%A3o**%0A%0AA%20query%20de%20dele%C3%A7%C3%A3o%20usa%20apenas%20%60folderId%60%20como%20crit%C3%A9rio%2C%20sem%20validar%20que%20a%20pasta%20pertence%20ao%20%60workspaceId%60%20informado%20na%20requisi%C3%A7%C3%A3o.%20Um%20usu%C3%A1rio%20com%20acesso%20leg%C3%ADtimo%20ao%20workspace%20A%20pode%20passar%20um%20%60folderId%60%20de%20outro%20workspace%20%28B%29%20e%20exclu%C3%AD-la%2C%20pois%20o%20controle%20de%20acesso%20verifica%20apenas%20o%20%60workspaceId%60%20da%20requisi%C3%A7%C3%A3o%2C%20n%C3%A3o%20o%20workspace%20real%20da%20pasta.%20Com%20a%20adi%C3%A7%C3%A3o%20do%20Cognito%20%28onde%20ADMINs%20t%C3%AAm%20acesso%20a%20todos%20os%20workspaces%29%2C%20esse%20cen%C3%A1rio%20se%20torna%20ainda%20mais%20amplo.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20folder%20%3D%20await%20prisma.dashboardFolder.delete%28%7B%0A%20%20%20%20%20%20where%3A%20%7B%0A%20%20%20%20%20%20%20%20id%3A%20folderId%2C%0A%20%20%20%20%20%20%20%20workspaceId%2C%0A%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%7D%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=196&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Ffolders%2Fapi%2FdeleteFolder.ts%3A51-55%0A**Aus%C3%AAncia%20de%20filtro%20por%20%60workspaceId%60%20na%20exclus%C3%A3o**%0A%0AA%20query%20de%20dele%C3%A7%C3%A3o%20usa%20apenas%20%60folderId%60%20como%20crit%C3%A9rio%2C%20sem%20validar%20que%20a%20pasta%20pertence%20ao%20%60workspaceId%60%20informado%20na%20requisi%C3%A7%C3%A3o.%20Um%20usu%C3%A1rio%20com%20acesso%20leg%C3%ADtimo%20ao%20workspace%20A%20pode%20passar%20um%20%60folderId%60%20de%20outro%20workspace%20%28B%29%20e%20exclu%C3%AD-la%2C%20pois%20o%20controle%20de%20acesso%20verifica%20apenas%20o%20%60workspaceId%60%20da%20requisi%C3%A7%C3%A3o%2C%20n%C3%A3o%20o%20workspace%20real%20da%20pasta.%20Com%20a%20adi%C3%A7%C3%A3o%20do%20Cognito%20%28onde%20ADMINs%20t%C3%AAm%20acesso%20a%20todos%20os%20workspaces%29%2C%20esse%20cen%C3%A1rio%20se%20torna%20ainda%20mais%20amplo.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20folder%20%3D%20await%20prisma.dashboardFolder.delete%28%7B%0A%20%20%20%20%20%20where%3A%20%7B%0A%20%20%20%20%20%20%20%20id%3A%20folderId%2C%0A%20%20%20%20%20%20%20%20workspaceId%2C%0A%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%7D%29%0A%60%60%60%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=196&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Ffolders%2Fapi%2FdeleteFolder.ts%3A51-55%0A**Aus%C3%AAncia%20de%20filtro%20por%20%60workspaceId%60%20na%20exclus%C3%A3o**%0A%0AA%20query%20de%20dele%C3%A7%C3%A3o%20usa%20apenas%20%60folderId%60%20como%20crit%C3%A9rio%2C%20sem%20validar%20que%20a%20pasta%20pertence%20ao%20%60workspaceId%60%20informado%20na%20requisi%C3%A7%C3%A3o.%20Um%20usu%C3%A1rio%20com%20acesso%20leg%C3%ADtimo%20ao%20workspace%20A%20pode%20passar%20um%20%60folderId%60%20de%20outro%20workspace%20%28B%29%20e%20exclu%C3%AD-la%2C%20pois%20o%20controle%20de%20acesso%20verifica%20apenas%20o%20%60workspaceId%60%20da%20requisi%C3%A7%C3%A3o%2C%20n%C3%A3o%20o%20workspace%20real%20da%20pasta.%20Com%20a%20adi%C3%A7%C3%A3o%20do%20Cognito%20%28onde%20ADMINs%20t%C3%AAm%20acesso%20a%20todos%20os%20workspaces%29%2C%20esse%20cen%C3%A1rio%20se%20torna%20ainda%20mais%20amplo.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20folder%20%3D%20await%20prisma.dashboardFolder.delete%28%7B%0A%20%20%20%20%20%20where%3A%20%7B%0A%20%20%20%20%20%20%20%20id%3A%20folderId%2C%0A%20%20%20%20%20%20%20%20workspaceId%2C%0A%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%7D%29%0A%60%60%60%0A%0A&pr=196&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/builder/src/features/folders/api/deleteFolder.ts:51-55
**Ausência de filtro por `workspaceId` na exclusão**

A query de deleção usa apenas `folderId` como critério, sem validar que a pasta pertence ao `workspaceId` informado na requisição. Um usuário com acesso legítimo ao workspace A pode passar um `folderId` de outro workspace (B) e excluí-la, pois o controle de acesso verifica apenas o `workspaceId` da requisição, não o workspace real da pasta. Com a adição do Cognito (onde ADMINs têm acesso a todos os workspaces), esse cenário se torna ainda mais amplo.

```suggestion
    const folder = await prisma.dashboardFolder.delete({
      where: {
        id: folderId,
        workspaceId,
      },
    })
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: [":bug: fixed getUserRoleInWorkspace not r..."](https://github.com/cloudhumans/typebot.io/commit/6c637566fbe29ba6d9c1f7bb23ee4f89ac9c47f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31601272)</sub>

<!-- /greptile_comment -->