### PR TITLE
perf(auth): cache JWKS instance per Cognito issuer

### DIFF
--- a/apps/builder/src/features/auth/helpers/verifyCognitoToken.ts
+++ b/apps/builder/src/features/auth/helpers/verifyCognitoToken.ts
@@ -1,6 +1,23 @@
 import { createRemoteJWKSet, jwtVerify, JWTPayload } from 'jose'
 import { CognitoJWTPayload } from '../types/cognito'
 
+// Cache one JWKS instance per issuer for the lifetime of the process so that
+// jose's internal key cache survives across requests. Recreating per call
+// triggers a JWKS fetch on every auth callback, which compounds with CPU
+// throttling on the builder pods.
+const jwksByIssuer = new Map<string, ReturnType<typeof createRemoteJWKSet>>()
+
+const getJwks = (cognitoIssuerUrl: string) => {
+  let jwks = jwksByIssuer.get(cognitoIssuerUrl)
+  if (!jwks) {
+    jwks = createRemoteJWKSet(
+      new URL(`${cognitoIssuerUrl}/.well-known/jwks.json`)
+    )
+    jwksByIssuer.set(cognitoIssuerUrl, jwks)
+  }
+  return jwks
+}
+
 /**
  * In development, skip real JWKS verification and decode the JWT payload directly.
  * The token is expected to be a standard JWT (header.payload.signature) where the
@@ -37,14 +54,14 @@ export const verifyCognitoToken = async ({
     }
   }
 
-  const jwks = createRemoteJWKSet(
-    new URL(`${cognitoIssuerUrl}/.well-known/jwks.json`)
+  const { payload } = await jwtVerify<CognitoJWTPayload>(
+    cognitoToken,
+    getJwks(cognitoIssuerUrl),
+    {
+      issuer: cognitoIssuerUrl,
+      audience: cognitoAppClientId,
+    }
   )
-
-  const { payload } = await jwtVerify<CognitoJWTPayload>(cognitoToken, jwks, {
-    issuer: cognitoIssuerUrl,
-    audience: cognitoAppClientId,
-  })
 
   return payload
 }


### PR DESCRIPTION
`apps/builder/src/features/auth/helpers/verifyCognitoToken.ts` recriava o `JWKSet` a cada chamada de `verifyCognitoToken`, derrotando o cache interno do `jose` e disparando um fetch do endpoint `.well-known/jwks.json` em todo callback de auth. Sob throttling de CPU nos pods do builder, isso compunha latência percebida no login do modo embedded.

Mantém um `Map<issuer, JWKSet>` de vida-do-processo para reusar a instância através de requisições.

**Por quê**: `createRemoteJWKSet` retorna uma função com cache de chave + cooldown próprios. Criar uma nova a cada request joga esse cache fora e força o `jose` a refazer o `GET` do JWKS toda vez que o callback de NextAuth chama `verifyCognitoToken` — comportamento documentado em [`panva/jose` — Remote JSON Web Key Set](https://github.com/panva/jose/blob/main/docs/jwks/remote/functions/createRemoteJWKSet.md).

**Escopo**: troca puramente local em `verifyCognitoToken`. Nenhuma mudança de contrato, schema ou rota. `getJwks(issuer)` lazy-initializa a entrada do `Map` na primeira chamada por issuer e devolve a mesma instância depois disso.

**Limitação conhecida**: o `Map` é por processo. Em deploys multi-pod, cada pod paga o primeiro fetch uma vez — comportamento desejado, já que rotação de chaves do Cognito é coberta pelo cache interno do `jose`.

**Rollback**: reverter o commit volta ao comportamento anterior. Sem migração, sem flag.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Esta PR introduz um cache de nível de módulo (`Map<issuer, JWKSet>`) em `verifyCognitoToken.ts` para reutilizar a instância de `createRemoteJWKSet` do `jose` entre requisições, evitando que o cache interno de chaves da biblioteca seja descartado a cada chamada de callback de autenticação.

- **Cache lazy por issuer**: `getJwks(cognitoIssuerUrl)` inicializa a entrada no `Map` na primeira chamada e retorna a mesma instância nas chamadas seguintes, preservando o cooldown e o cache de chaves internos do `jose`.
- **Escopo cirúrgico**: apenas `verifyCognitoToken.ts` é alterado; nenhum contrato de API, schema ou rota é modificado.

<h3>Confidence Score: 5/5</h3>

A mudança é segura para merge — escopo limitado a um único helper de autenticação, sem alteração de contrato ou rota.

A otimização está correta: `createRemoteJWKSet` do `jose` é explicitamente projetado para ser reutilizado entre chamadas, e o cache lazy por issuer é implementado sem race condition (JS é single-threaded no event loop). O caminho de desenvolvimento permanece inalterado. Nenhum comportamento de segurança ou lógica de validação foi modificado.

Nenhum arquivo requer atenção especial.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/builder/src/features/auth/helpers/verifyCognitoToken.ts | Adiciona cache de instância RemoteJWKSet por issuer via Map de nível de módulo; lógica de lazy-init correta, sem race condition (JS single-threaded), alinhada com a recomendação oficial do jose. |

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(auth): cache JWKS instance per Cogn..."](https://github.com/cloudhumans/typebot.io/commit/c77a495b014dc226aa028c86a1f7466ef82d02f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32387753)</sub>

<!-- /greptile_comment -->