### PR TITLE
feat: log embedded auth failures

### DIFF
--- a/apps/builder/src/features/embedded-auth/embedded-auth.ts
+++ b/apps/builder/src/features/embedded-auth/embedded-auth.ts
@@ -1,6 +1,7 @@
 import { signIn, signOut } from 'next-auth/react'
 import { Session } from 'next-auth'
 import { trpcVanilla } from '@/lib/trpc'
+import logger from '@/helpers/logger'
 
 export const handleEmbeddedAuthentication = async ({
   session,
@@ -27,11 +28,15 @@ export const handleEmbeddedAuthentication = async ({
     })
 
     if (!result?.ok) {
+      logger.error('Embedded authentication failed', { result })
       return false
     }
 
     return true
   } catch (error) {
+    logger.error('Error during embedded authentication', {
+      error: error instanceof Error ? error.message : String(error),
+    })
     return false
   }
 }


### PR DESCRIPTION
Hoje, falhas no fluxo de autenticação embedded (Cloudchat → Builder) retornam `false` silenciosamente, sem nenhum rastro nos logs — o que dificulta diagnosticar por que um usuário não conseguiu logar.

Adiciona `logger.error` nos dois pontos de falha (`signIn` não-ok e exception no catch) para termos visibilidade no Datadog.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

A PR adiciona chamadas `logger.error` em dois pontos de falha do fluxo de autenticação embedded (`signIn` não-ok e bloco `catch`) para aumentar a observabilidade no Datadog. No entanto, como o módulo usa `next-auth/react` — uma API exclusivamente client-side — o logger sempre executa no browser e cai no branch de fallback (`console.error`), nunca acionando o Winston configurado para o Datadog.

- Dois `logger.error` adicionados: um quando `result?.ok` é falso e outro no `catch` genérico.
- O objetivo de visibilidade no Datadog não é atingido na implementação atual, pois o logger detecta contexto de browser (`typeof window !== 'undefined'`) e usa apenas `console.error`.

<h3>Confidence Score: 3/5</h3>

A mudança não quebra comportamento existente, mas também não entrega o que promete: os erros continuarão invisíveis no Datadog após o merge.

O objetivo principal da PR — visibilidade dos erros no Datadog — não é alcançado porque o código roda inteiramente no browser e o logger cai em modo console. Fazer o merge nesse estado dá falsa sensação de cobertura de observabilidade enquanto o problema original permanece sem solução.

apps/builder/src/features/embedded-auth/embedded-auth.ts — o logging precisa ser movido para um contexto server-side (ex: provider de credenciais do NextAuth ou uma tRPC procedure) para que os erros cheguem ao Datadog.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/builder/src/features/embedded-auth/embedded-auth.ts | Adiciona logger.error nos dois pontos de falha do fluxo embedded-auth, mas como o módulo usa next-auth/react (client-side), o logger cai no modo console do browser em vez do Winston/Datadog. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fembedded-auth%2Fembedded-auth.ts%3A31-39%0A**Logs%20n%C3%A3o%20chegar%C3%A3o%20ao%20Datadog%20%E2%80%94%20contexto%20%C3%A9%20client-side**%0A%0A%60handleEmbeddedAuthentication%60%20importa%20%60signIn%60%2F%60signOut%60%20de%20%60next-auth%2Freact%60%2C%20que%20%C3%A9%20uma%20API%20exclusivamente%20de%20browser.%20Portanto%2C%20esse%20m%C3%B3dulo%20%C3%A9%20sempre%20executado%20no%20cliente%2C%20onde%20%60typeof%20window%20!%3D%3D%20'undefined'%60.%20Nesse%20caso%2C%20%60packages%2Flib%2Flogger.ts%60%20cai%20no%20branch%20%60else%60%20e%20cria%20um%20logger%20falso%20que%20apenas%20delega%20para%20%60console.error%60%20%E2%80%94%20o%20Winston%2FDatadog%20nunca%20%C3%A9%20inicializado.%20Os%20erros%20ficam%20somente%20no%20console%20do%20navegador%2C%20n%C3%A3o%20no%20Datadog%2C%20contrariando%20o%20objetivo%20declarado%20da%20PR.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fembedded-auth%2Fembedded-auth.ts%3A38%0A**Stack%20trace%20perdida%20no%20catch**%0A%0AApenas%20%60error.message%60%20%C3%A9%20registrado%2C%20o%20que%20descarta%20o%20stack%20trace%20completo.%20Passar%20o%20objeto%20%60error%60%20diretamente%20%28junto%20com%20%60errors%28%7B%20stack%3A%20true%20%7D%29%60%20j%C3%A1%20configurado%20no%20Winston%29%20preserva%20a%20stack%20e%20melhora%20muito%20o%20diagn%C3%B3stico%20em%20produ%C3%A7%C3%A3o.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20error%3A%20error%20instanceof%20Error%20%3F%20error%20%3A%20String%28error%29%2C%0A%60%60%60%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=198&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fembedded-auth%2Fembedded-auth.ts%3A31-39%0A**Logs%20n%C3%A3o%20chegar%C3%A3o%20ao%20Datadog%20%E2%80%94%20contexto%20%C3%A9%20client-side**%0A%0A%60handleEmbeddedAuthentication%60%20importa%20%60signIn%60%2F%60signOut%60%20de%20%60next-auth%2Freact%60%2C%20que%20%C3%A9%20uma%20API%20exclusivamente%20de%20browser.%20Portanto%2C%20esse%20m%C3%B3dulo%20%C3%A9%20sempre%20executado%20no%20cliente%2C%20onde%20%60typeof%20window%20!%3D%3D%20'undefined'%60.%20Nesse%20caso%2C%20%60packages%2Flib%2Flogger.ts%60%20cai%20no%20branch%20%60else%60%20e%20cria%20um%20logger%20falso%20que%20apenas%20delega%20para%20%60console.error%60%20%E2%80%94%20o%20Winston%2FDatadog%20nunca%20%C3%A9%20inicializado.%20Os%20erros%20ficam%20somente%20no%20console%20do%20navegador%2C%20n%C3%A3o%20no%20Datadog%2C%20contrariando%20o%20objetivo%20declarado%20da%20PR.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fembedded-auth%2Fembedded-auth.ts%3A38%0A**Stack%20trace%20perdida%20no%20catch**%0A%0AApenas%20%60error.message%60%20%C3%A9%20registrado%2C%20o%20que%20descarta%20o%20stack%20trace%20completo.%20Passar%20o%20objeto%20%60error%60%20diretamente%20%28junto%20com%20%60errors%28%7B%20stack%3A%20true%20%7D%29%60%20j%C3%A1%20configurado%20no%20Winston%29%20preserva%20a%20stack%20e%20melhora%20muito%20o%20diagn%C3%B3stico%20em%20produ%C3%A7%C3%A3o.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20error%3A%20error%20instanceof%20Error%20%3F%20error%20%3A%20String%28error%29%2C%0A%60%60%60%0A%0A&pr=198&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/builder/src/features/embedded-auth/embedded-auth.ts:31-39
**Logs não chegarão ao Datadog — contexto é client-side**

`handleEmbeddedAuthentication` importa `signIn`/`signOut` de `next-auth/react`, que é uma API exclusivamente de browser. Portanto, esse módulo é sempre executado no cliente, onde `typeof window !== 'undefined'`. Nesse caso, `packages/lib/logger.ts` cai no branch `else` e cria um logger falso que apenas delega para `console.error` — o Winston/Datadog nunca é inicializado. Os erros ficam somente no console do navegador, não no Datadog, contrariando o objetivo declarado da PR.

### Issue 2 of 2
apps/builder/src/features/embedded-auth/embedded-auth.ts:38
**Stack trace perdida no catch**

Apenas `error.message` é registrado, o que descarta o stack trace completo. Passar o objeto `error` diretamente (junto com `errors({ stack: true })` já configurado no Winston) preserva a stack e melhora muito o diagnóstico em produção.

```suggestion
      error: error instanceof Error ? error : String(error),
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: [":loud\_sound: log embedded auth failures"](https://github.com/cloudhumans/typebot.io/commit/f46edf5510af4d500ec4ddbaea46b7cca79593b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32620932)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - Make all comments in Brazilian Portuguese (ptBR) ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->