### PR TITLE
fix(auth): persist NextAuth cookies in CHIPS partitioned context

### DIFF
--- a/apps/builder/src/features/auth/helpers/cookiePartitioning.test.ts
+++ b/apps/builder/src/features/auth/helpers/cookiePartitioning.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  transformSetCookie,
+  patchSetCookieForPartitioned,
+} from './cookiePartitioning'
+
+describe('transformSetCookie', () => {
+  describe('non-NextAuth cookies', () => {
+    it('passes through unrelated cookies untouched', () => {
+      const cookie = 'session-id=abc123; Path=/; HttpOnly'
+      expect(transformSetCookie(cookie)).toBe(cookie)
+    })
+
+    it('does not match when the cookie value contains the NextAuth substring', () => {
+      const cookie =
+        'other=this-value-contains-next-auth.session-token-inside; Path=/'
+      expect(transformSetCookie(cookie)).toBe(cookie)
+    })
+
+    it('does not match when a different cookie name shares the suffix', () => {
+      const cookie = 'app.next-auth.session-token=xyz; Path=/'
+      expect(transformSetCookie(cookie)).toBe(cookie)
+    })
+  })
+
+  describe('NextAuth cookie matching', () => {
+    it('matches the dev (non-secure) session token name', () => {
+      const cookie = 'next-auth.session-token=jwt; Path=/; HttpOnly'
+      expect(transformSetCookie(cookie)).toBe(`${cookie}; Partitioned`)
+    })
+
+    it('matches the production `__Secure-` session token name', () => {
+      const cookie =
+        '__Secure-next-auth.session-token=jwt; Path=/; HttpOnly; Secure; SameSite=None'
+      expect(transformSetCookie(cookie)).toBe(`${cookie}; Partitioned`)
+    })
+
+    it('matches the production `__Host-` CSRF cookie name', () => {
+      const cookie =
+        '__Host-next-auth.csrf-token=token; Path=/; HttpOnly; Secure; SameSite=Lax'
+      expect(transformSetCookie(cookie)).toBe(`${cookie}; Partitioned`)
+    })
+
+    it('matches the callback-url cookie', () => {
+      const cookie =
+        '__Secure-next-auth.callback-url=https%3A%2F%2Fhost; Path=/'
+      expect(transformSetCookie(cookie)).toBe(`${cookie}; Partitioned`)
+    })
+
+    it('matches chunked session-token names (`.0`, `.1`)', () => {
+      const chunk0 = '__Secure-next-auth.session-token.0=part-a; Path=/'
+      const chunk1 = '__Secure-next-auth.session-token.1=part-b; Path=/'
+      expect(transformSetCookie(chunk0)).toBe(`${chunk0}; Partitioned`)
+      expect(transformSetCookie(chunk1)).toBe(`${chunk1}; Partitioned`)
+    })
+  })
+
+  describe('idempotency', () => {
+    it('leaves already-partitioned cookies untouched', () => {
+      const cookie = 'next-auth.session-token=jwt; Path=/; Partitioned'
+      expect(transformSetCookie(cookie)).toBe(cookie)
+    })
+
+    it('is case-insensitive when checking for the Partitioned attribute', () => {
+      const cookie = 'next-auth.session-token=jwt; Path=/; partitioned'
+      expect(transformSetCookie(cookie)).toBe(cookie)
+    })
+  })
+
+  describe('deletion cookies', () => {
+    it('emits both unpartitioned and partitioned variants when Max-Age=0', () => {
+      const cookie =
+        '__Secure-next-auth.session-token=; Max-Age=0; Path=/; HttpOnly'
+      expect(transformSetCookie(cookie)).toEqual([
+        cookie,
+        `${cookie}; Partitioned`,
+      ])
+    })
+
+    it('emits both variants when Expires is the epoch sentinel', () => {
+      const cookie =
+        '__Secure-next-auth.session-token=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/'
+      expect(transformSetCookie(cookie)).toEqual([
+        cookie,
+        `${cookie}; Partitioned`,
+      ])
+    })
+  })
+})
+
+describe('patchSetCookieForPartitioned', () => {
+  const buildResStub = () => {
+    const calls: Array<{ name: string; value: unknown }> = []
+    const res = {
+      setHeader: vi.fn((name: string, value: unknown) => {
+        calls.push({ name, value })
+      }),
+    }
+    return { res: res as never, calls }
+  }
+
+  it('rewrites a string Set-Cookie value', () => {
+    const { res, calls } = buildResStub()
+    patchSetCookieForPartitioned(res)
+    ;(res as { setHeader: (n: string, v: unknown) => void }).setHeader(
+      'Set-Cookie',
+      'next-auth.session-token=jwt; Path=/'
+    )
+    expect(calls[0].name).toBe('Set-Cookie')
+    expect(calls[0].value).toEqual([
+      'next-auth.session-token=jwt; Path=/; Partitioned',
+    ])
+  })
+
+  it('rewrites every entry of an array Set-Cookie value', () => {
+    const { res, calls } = buildResStub()
+    patchSetCookieForPartitioned(res)
+    ;(res as { setHeader: (n: string, v: unknown) => void }).setHeader(
+      'Set-Cookie',
+      ['__Secure-next-auth.session-token=jwt; Path=/', 'other=foo; Path=/']
+    )
+    expect(calls[0].value).toEqual([
+      '__Secure-next-auth.session-token=jwt; Path=/; Partitioned',
+      'other=foo; Path=/',
+    ])
+  })
+
+  it('expands a deletion cookie into a pair of headers', () => {
+    const { res, calls } = buildResStub()
+    patchSetCookieForPartitioned(res)
+    const deletion =
+      '__Secure-next-auth.session-token=; Max-Age=0; Path=/; HttpOnly'
+    ;(res as { setHeader: (n: string, v: unknown) => void }).setHeader(
+      'Set-Cookie',
+      deletion
+    )
+    expect(calls[0].value).toEqual([deletion, `${deletion}; Partitioned`])
+  })
+
+  it('passes through non Set-Cookie headers unchanged', () => {
+    const { res, calls } = buildResStub()
+    patchSetCookieForPartitioned(res)
+    ;(res as { setHeader: (n: string, v: unknown) => void }).setHeader(
+      'Content-Type',
+      'application/json'
+    )
+    expect(calls[0]).toEqual({
+      name: 'Content-Type',
+      value: 'application/json',
+    })
+  })
+})

--- a/apps/builder/src/features/auth/helpers/cookiePartitioning.ts
+++ b/apps/builder/src/features/auth/helpers/cookiePartitioning.ts
@@ -1,0 +1,78 @@
+import type { NextApiResponse } from 'next'
+import type { ServerResponse } from 'http'
+
+// CHIPS (Cookies Having Independent Partitioned State): append the `Partitioned`
+// attribute to NextAuth cookies so they survive Chrome's third-party cookie
+// phaseout when the builder is embedded inside CloudChat via iframe. Without
+// this, the CSRF cookie is dropped in the partitioned context, `getCsrfToken()`
+// on the client returns null, and `signIn('cloudchat-embedded', { redirect: false })`
+// crashes inside next-auth/react with `new URL(undefined)` → "Failed to construct
+// 'URL': Invalid URL".
+//
+// We patch `Set-Cookie` at the response layer because next-auth 4.22.1 depends
+// on `cookie@^0.5.0`, which predates `Partitioned` support (added in
+// cookie@0.7.0), so the `cookies` option in AuthOptions cannot emit the
+// attribute itself.
+//
+// Refs:
+//   - https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies
+//   - https://developers.google.com/privacy-sandbox/cookies/chips
+//   - https://datatracker.ietf.org/doc/draft-cutler-httpbis-partitioned-cookies/
+
+// Anchored matcher applied to the cookie *name* only (the substring before the
+// first `=`). Accepts the `__Secure-` / `__Host-` prefixes NextAuth uses in
+// production, and the `.0`, `.1`, ... chunk suffixes it appends when a JWT
+// session cookie exceeds the 4KB per-cookie limit.
+const NEXT_AUTH_COOKIE_NAME_RE =
+  /^(?:__Secure-|__Host-)?next-auth\.(?:session-token|callback-url|csrf-token)(?:\.\d+)?$/
+
+const extractCookieName = (cookie: string): string => {
+  const eqIdx = cookie.indexOf('=')
+  if (eqIdx === -1) return ''
+  return cookie.slice(0, eqIdx).trim()
+}
+
+const isNextAuthCookie = (cookie: string): boolean =>
+  NEXT_AUTH_COOKIE_NAME_RE.test(extractCookieName(cookie))
+
+const hasPartitionedAttribute = (cookie: string): boolean =>
+  /;\s*Partitioned/i.test(cookie)
+
+// NextAuth signs out by emitting a `Set-Cookie` with `Max-Age=0` (and an
+// `Expires` in the past). Partitioned and unpartitioned cookies live in
+// separate browser storage buckets, so a deletion header that carries
+// `Partitioned` only clears the partitioned bucket; any legacy unpartitioned
+// cookie issued before this feature shipped would persist. To migrate cleanly
+// we emit both variants on deletion so both buckets are cleared.
+const isDeletionCookie = (cookie: string): boolean =>
+  /;\s*Max-Age=0\b/i.test(cookie) ||
+  /;\s*Expires=Thu,\s*01\s+Jan\s+1970/i.test(cookie)
+
+const withPartitioned = (cookie: string): string => `${cookie}; Partitioned`
+
+export const transformSetCookie = (cookie: string): string | string[] => {
+  if (!isNextAuthCookie(cookie)) return cookie
+  if (hasPartitionedAttribute(cookie)) return cookie
+  if (isDeletionCookie(cookie)) return [cookie, withPartitioned(cookie)]
+  return withPartitioned(cookie)
+}
+
+export const patchSetCookieForPartitioned = (
+  res: NextApiResponse | ServerResponse
+) => {
+  const origSetHeader = res.setHeader.bind(res)
+  res.setHeader = ((
+    name: string,
+    value: number | string | readonly string[]
+  ) => {
+    if (name.toLowerCase() === 'set-cookie' && value !== undefined) {
+      const cookies = Array.isArray(value) ? value : [String(value)]
+      const patched = cookies.flatMap((c) => {
+        const result = transformSetCookie(c)
+        return Array.isArray(result) ? result : [result]
+      })
+      return origSetHeader(name, patched)
+    }
+    return origSetHeader(name, value as never)
+  }) as typeof res.setHeader
+}

--- a/apps/builder/src/features/auth/helpers/getAuthenticatedUser.ts
+++ b/apps/builder/src/features/auth/helpers/getAuthenticatedUser.ts
@@ -8,6 +8,7 @@ import { mockedUser } from '@typebot.io/lib/mockedUser'
 import { emailIsCloudhumans } from '@typebot.io/lib'
 import { DatabaseUserWithCognito } from '../types/cognito'
 import { verifyCognitoToken } from './verifyCognitoToken'
+import { patchSetCookieForPartitioned } from './cookiePartitioning'
 import logger from '@/helpers/logger'
 
 export const getAuthenticatedUser = async (
@@ -21,6 +22,7 @@ export const getAuthenticatedUser = async (
 
   if (bearerToken) return authenticateByToken(bearerToken)
 
+  if (!env.NEXT_PUBLIC_E2E_TEST) patchSetCookieForPartitioned(res)
   const session = env.NEXT_PUBLIC_E2E_TEST
     ? { user: mockedUser }
     : await getServerSession(req, res, getAuthOptions({}))

--- a/apps/builder/src/features/telemetry/helpers/trackAnalyticsPageView.ts
+++ b/apps/builder/src/features/telemetry/helpers/trackAnalyticsPageView.ts
@@ -1,4 +1,5 @@
 import { getAuthOptions } from '@/pages/api/auth/[...nextauth]'
+import { patchSetCookieForPartitioned } from '@/features/auth/helpers/cookiePartitioning'
 import prisma from '@typebot.io/lib/prisma'
 import { trackEvents } from '@typebot.io/telemetry/trackEvents'
 import { User } from '@typebot.io/schemas'
@@ -15,6 +16,7 @@ export const trackAnalyticsPageView = async (
     select: { workspaceId: true },
   })
   if (!typebot) return
+  patchSetCookieForPartitioned(context.res)
   const session = await getServerSession(
     context.req,
     context.res,

--- a/apps/builder/src/pages/api/auth/[...nextauth].ts
+++ b/apps/builder/src/pages/api/auth/[...nextauth].ts
@@ -343,6 +343,45 @@ export const getAuthOptions = ({
   },
 })
 
+// CHIPS (Cookies Having Independent Partitioned State): append the `Partitioned`
+// attribute to NextAuth cookies so they survive Chrome's third-party cookie
+// phaseout when the builder is embedded inside CloudChat via iframe. Without
+// this, the CSRF cookie is dropped in the partitioned context, `getCsrfToken()`
+// on the client returns null, and `signIn('cloudchat-embedded', { redirect: false })`
+// crashes inside next-auth/react with `new URL(undefined)` → "Failed to construct
+// 'URL': Invalid URL".
+//
+// We patch `Set-Cookie` at the response layer because next-auth 4.22.1 depends on
+// `cookie@^0.5.0`, which predates `Partitioned` support (added in cookie@0.7.0),
+// so the `cookies` option in AuthOptions cannot emit the attribute itself.
+//
+// Refs:
+//   - https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies
+//   - https://developers.google.com/privacy-sandbox/cookies/chips
+//   - https://datatracker.ietf.org/doc/draft-cutler-httpbis-partitioned-cookies/
+const NEXT_AUTH_COOKIE_RE = /next-auth\.(session-token|callback-url|csrf-token)/
+
+const addPartitionedAttribute = (cookie: string): string =>
+  NEXT_AUTH_COOKIE_RE.test(cookie) && !/;\s*Partitioned/i.test(cookie)
+    ? `${cookie}; Partitioned`
+    : cookie
+
+const patchSetCookieForPartitioned = (res: NextApiResponse) => {
+  const origSetHeader = res.setHeader.bind(res)
+  res.setHeader = ((
+    name: string,
+    value: number | string | readonly string[]
+  ) => {
+    if (name.toLowerCase() === 'set-cookie' && value !== undefined) {
+      const patched = Array.isArray(value)
+        ? value.map(addPartitionedAttribute)
+        : addPartitionedAttribute(String(value))
+      return origSetHeader(name, patched)
+    }
+    return origSetHeader(name, value as never)
+  }) as typeof res.setHeader
+}
+
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const isMockingSession =
     req.method === 'GET' &&
@@ -365,6 +404,8 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       if (!success) restricted = 'rate-limited'
     }
   }
+
+  patchSetCookieForPartitioned(res)
 
   return await NextAuth(req, res, getAuthOptions({ restricted }))
 }

--- a/apps/builder/src/pages/api/auth/[...nextauth].ts
+++ b/apps/builder/src/pages/api/auth/[...nextauth].ts
@@ -17,6 +17,7 @@ import { getAtPath, isDefined, emailIsCloudhumans } from '@typebot.io/lib'
 import { mockedUser } from '@typebot.io/lib/mockedUser'
 import { getNewUserInvitations } from '@/features/auth/helpers/getNewUserInvitations'
 import { sendVerificationRequest } from '@/features/auth/helpers/sendVerificationRequest'
+import { patchSetCookieForPartitioned } from '@/features/auth/helpers/cookiePartitioning'
 import { Ratelimit } from '@upstash/ratelimit'
 import { Redis } from '@upstash/redis/nodejs'
 import ky from 'ky'
@@ -342,45 +343,6 @@ export const getAuthOptions = ({
     },
   },
 })
-
-// CHIPS (Cookies Having Independent Partitioned State): append the `Partitioned`
-// attribute to NextAuth cookies so they survive Chrome's third-party cookie
-// phaseout when the builder is embedded inside CloudChat via iframe. Without
-// this, the CSRF cookie is dropped in the partitioned context, `getCsrfToken()`
-// on the client returns null, and `signIn('cloudchat-embedded', { redirect: false })`
-// crashes inside next-auth/react with `new URL(undefined)` → "Failed to construct
-// 'URL': Invalid URL".
-//
-// We patch `Set-Cookie` at the response layer because next-auth 4.22.1 depends on
-// `cookie@^0.5.0`, which predates `Partitioned` support (added in cookie@0.7.0),
-// so the `cookies` option in AuthOptions cannot emit the attribute itself.
-//
-// Refs:
-//   - https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies
-//   - https://developers.google.com/privacy-sandbox/cookies/chips
-//   - https://datatracker.ietf.org/doc/draft-cutler-httpbis-partitioned-cookies/
-const NEXT_AUTH_COOKIE_RE = /next-auth\.(session-token|callback-url|csrf-token)/
-
-const addPartitionedAttribute = (cookie: string): string =>
-  NEXT_AUTH_COOKIE_RE.test(cookie) && !/;\s*Partitioned/i.test(cookie)
-    ? `${cookie}; Partitioned`
-    : cookie
-
-const patchSetCookieForPartitioned = (res: NextApiResponse) => {
-  const origSetHeader = res.setHeader.bind(res)
-  res.setHeader = ((
-    name: string,
-    value: number | string | readonly string[]
-  ) => {
-    if (name.toLowerCase() === 'set-cookie' && value !== undefined) {
-      const patched = Array.isArray(value)
-        ? value.map(addPartitionedAttribute)
-        : addPartitionedAttribute(String(value))
-      return origSetHeader(name, patched)
-    }
-    return origSetHeader(name, value as never)
-  }) as typeof res.setHeader
-}
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const isMockingSession =

--- a/apps/builder/src/pages/feedback.tsx
+++ b/apps/builder/src/pages/feedback.tsx
@@ -4,6 +4,7 @@ import { isNotDefined } from '@typebot.io/lib'
 import { sign } from 'jsonwebtoken'
 import { getServerSession } from 'next-auth'
 import { getAuthOptions } from './api/auth/[...nextauth]'
+import { patchSetCookieForPartitioned } from '@/features/auth/helpers/cookiePartitioning'
 import { env } from '@typebot.io/env'
 
 export default function Page() {
@@ -11,6 +12,7 @@ export default function Page() {
 }
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
+  patchSetCookieForPartitioned(context.res)
   const session = await getServerSession(
     context.req,
     context.res,

--- a/apps/builder/src/pages/feedback/[feedbackId].ts
+++ b/apps/builder/src/pages/feedback/[feedbackId].ts
@@ -3,6 +3,7 @@ import { User } from '@typebot.io/prisma'
 import { isNotDefined } from '@typebot.io/lib'
 import { sign } from 'jsonwebtoken'
 import { getAuthOptions } from '../api/auth/[...nextauth]'
+import { patchSetCookieForPartitioned } from '@/features/auth/helpers/cookiePartitioning'
 import { GetServerSidePropsContext } from 'next'
 import { env } from '@typebot.io/env'
 
@@ -11,6 +12,7 @@ export default function Page() {
 }
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
+  patchSetCookieForPartitioned(context.res)
   const session = await getServerSession(
     context.req,
     context.res,

--- a/apps/builder/src/pages/index.tsx
+++ b/apps/builder/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import { GetServerSidePropsContext } from 'next'
 import { getServerSession } from 'next-auth'
 import { getAuthOptions } from './api/auth/[...nextauth]'
+import { patchSetCookieForPartitioned } from '@/features/auth/helpers/cookiePartitioning'
 
 export default function Page() {
   return null
@@ -9,6 +10,7 @@ export default function Page() {
 export const getServerSideProps = async (
   context: GetServerSidePropsContext
 ) => {
+  patchSetCookieForPartitioned(context.res)
   const session = await getServerSession(
     context.req,
     context.res,


### PR DESCRIPTION
Hoje, quando o builder do Typebot é embedado dentro do CloudChat via `<iframe>`, o fluxo `signIn('cloudchat-embedded', { redirect: false })` quebra com:

```
TypeError: Failed to construct 'URL': Invalid URL
```

A causa raiz é que o Chrome (e demais browsers em phaseout de cookies de terceiros) só preserva cookies de iframes cross-site quando eles têm o atributo `Partitioned` (CHIPS). Sem ele, o cookie `next-auth.csrf-token` é descartado no contexto particionado, `getCsrfToken()` no client retorna `null`, e o `next-auth/react` cai num `new URL(undefined)` interno.

Esta PR adiciona um patch no `Set-Cookie` da rota `/api/auth/[...nextauth]` que injeta `; Partitioned` nos cookies do NextAuth (`session-token`, `callback-url`, `csrf-token`) quando ainda não estiver presente.

**Por quê o patch no header e não no `cookies` do AuthOptions**: `next-auth@4.22.1` depende de `cookie@^0.5.0`, que é anterior ao suporte ao atributo `Partitioned` (adicionado em `cookie@0.7.0`). A configuração `cookies` do `AuthOptions` portanto não consegue emitir o atributo. Atuar no `res.setHeader('Set-Cookie', ...)` contorna isso sem subir a dependência do `next-auth` (mudança de maior superfície).

**Escopo**: troca local em `apps/builder/src/pages/api/auth/[...nextauth].ts`. Apenas três cookies casam com o regex (`next-auth\.(session-token|callback-url|csrf-token)`); demais cookies passam intactos. Nenhuma mudança de contrato, schema ou rota.

**Limitação conhecida**: navegadores que não implementam CHIPS ignoram o atributo `Partitioned` (e seguem aplicando a política antiga de cookies de terceiros). Mantém compatibilidade total — não há regressão para usuários não-embedded.

**Rollback**: reverter o commit volta ao comportamento anterior. Sem migração, sem flag.

**Refs**:
- [MDN — Partitioned cookies (CHIPS)](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies)
- [Privacy Sandbox — CHIPS](https://developers.google.com/privacy-sandbox/cookies/chips)
- [IETF draft — Partitioned cookies](https://datatracker.ietf.org/doc/draft-cutler-httpbis-partitioned-cookies/)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Esta PR implementa suporte a CHIPS (Cookies Having Independent Partitioned State) para os cookies do NextAuth, resolvendo a falha `TypeError: Failed to construct 'URL': Invalid URL` que ocorria quando o builder era incorporado via iframe no CloudChat sob o bloqueio de cookies de terceiros do Chrome.

- Novo módulo `cookiePartitioning.ts` que monkey-patcha `res.setHeader` para injetar o atributo `Partitioned` nos cookies `session-token`, `callback-url` e `csrf-token` do NextAuth — incluindo variantes `__Secure-`/`__Host-` e chunks `.0`/`.1`. Cookies de deleção recebem dupla emissão (com e sem `Partitioned`) para limpar ambos os buckets de armazenamento.
- O patch é aplicado nos pontos de entrada SSR/API relevantes sempre antes de `getServerSession` / `NextAuth()`, garantindo que qualquer `Set-Cookie` emitido pelas chamadas subsequentes passe pelo interceptador.

<h3>Confidence Score: 5/5</h3>

A mudança é bem escrita, com escopo contido e testes abrangentes; pode ser mergeada com segurança.

O patch é estritamente aditivo: cookies que não pertencem ao NextAuth passam intocados, cookies já com Partitioned são ignorados, e o comportamento em ambientes não-embedded não muda. A lógica de transformação é idempotente e coberta por testes unitários.

Nenhum arquivo requer atenção especial; cookiePartitioning.ts é o coração da mudança e está bem testado.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/builder/src/features/auth/helpers/cookiePartitioning.ts | Novo módulo CHIPS: extrai nome do cookie antes de aplicar regex, trata cookies de deleção com dual-emit, sem guard de idempotência no monkey-patch de setHeader. |
| apps/builder/src/features/auth/helpers/cookiePartitioning.test.ts | Suite de testes abrangente cobrindo prefixos __Secure-/__Host-, cookies chunked, idempotência e dual-emit de deleção. |
| apps/builder/src/pages/api/auth/[...nextauth].ts | Adiciona patchSetCookieForPartitioned imediatamente antes de NextAuth(); posicionamento correto, após lógica de rate-limit e antes de emissão de cookies. |
| apps/builder/src/features/auth/helpers/getAuthenticatedUser.ts | Aplica o patch antes de getServerSession, guardado com !NEXT_PUBLIC_E2E_TEST para não interferir em testes E2E. |
| apps/builder/src/features/telemetry/helpers/trackAnalyticsPageView.ts | Patch adicionado antes de getServerSession; mudança correta e sem novos problemas introduzidos. |
| apps/builder/src/pages/index.tsx | Aplica patch no getServerSideProps antes de getServerSession; mudança trivial e correta. |
| apps/builder/src/pages/feedback.tsx | Mesma adição de patchSetCookieForPartitioned antes de getServerSession; sem issues. |
| apps/builder/src/pages/feedback/[feedbackId].ts | Mesma adição de patchSetCookieForPartitioned antes de getServerSession; sem issues. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser as Browser iframe
    participant Handler as Next.js Handler
    participant Patch as cookiePartitioning
    participant NA as NextAuth

    Browser->>Handler: POST /api/auth/signin
    Handler->>Patch: patchSetCookieForPartitioned(res)
    Note over Patch: Monkey-patcha res.setHeader
    Handler->>NA: NextAuth(req, res, options)
    NA-->>Patch: setHeader(Set-Cookie, cookies)
    Patch->>Patch: transformSetCookie() appenda Partitioned
    Patch-->>Handler: cookies com atributo Partitioned
    Handler-->>Browser: Set-Cookie com Partitioned
    Note over Browser: Cookie salvo em bucket particionado
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fauth%2Fhelpers%2FcookiePartitioning.ts%3A60-63%0A**Sem%20guard%20de%20idempot%C3%AAncia%20no%20monkey-patch%20de%20%60setHeader%60**%0A%0A%60patchSetCookieForPartitioned%60%20n%C3%A3o%20verifica%20se%20o%20%60res%60%20j%C3%A1%20foi%20patcheado.%20Se%20chamada%20duas%20vezes%20sobre%20o%20mesmo%20objeto%20%60res%60%20%E2%80%94%20por%20exemplo%2C%20caso%20um%20novo%20%60getServerSideProps%60%20chame%20tanto%20a%20fun%C3%A7%C3%A3o%20diretamente%20quanto%20um%20helper%20que%20tamb%C3%A9m%20a%20chame%20%E2%80%94%2C%20o%20%60setHeader%60%20ser%C3%A1%20encapsulado%20duas%20vezes.%20Como%20%60transformSetCookie%60%20%C3%A9%20idempotente%20%28detecta%20o%20atributo%20%60Partitioned%60%20existente%29%2C%20o%20resultado%20funcional%20n%C3%A3o%20muda%2C%20mas%20a%20cadeia%20de%20closures%20cresce%20desnecessariamente%20a%20cada%20chamada.%20Um%20s%C3%ADmbolo%20sentinela%20no%20objeto%20%60res%60%20previne%20isso%20de%20forma%20simples.%0A%0A%60%60%60suggestion%0Aconst%20PATCHED_SYMBOL%20%3D%20Symbol%28'chipsPatched'%29%0A%0Aexport%20const%20patchSetCookieForPartitioned%20%3D%20%28%0A%20%20res%3A%20NextApiResponse%20%7C%20ServerResponse%0A%29%20%3D%3E%20%7B%0A%20%20if%20%28%28res%20as%20unknown%20as%20Record%3Csymbol%2C%20boolean%3E%29%5BPATCHED_SYMBOL%5D%29%20return%0A%20%20%3B%28res%20as%20unknown%20as%20Record%3Csymbol%2C%20boolean%3E%29%5BPATCHED_SYMBOL%5D%20%3D%20true%0A%20%20const%20origSetHeader%20%3D%20res.setHeader.bind%28res%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fauth%2Fhelpers%2FcookiePartitioning.ts%3A47-49%0A**%60isDeletionCookie%60%20detecta%20apenas%20dois%20padr%C3%B5es%20de%20expira%C3%A7%C3%A3o**%0A%0AO%20regex%20%60%2F%3B%5Cs*Expires%3DThu%2C%5Cs*01%5Cs%2BJan%5Cs%2B1970%2Fi%60%20s%C3%B3%20casa%20o%20dia%201%20de%20janeiro%20de%201970%20com%20o%20dia%20da%20semana%20literal%20%22Thu%22.%20Na%20pr%C3%A1tica%20o%20%60next-auth%404.x%60%20usa%20consistentemente%20%60Max-Age%3D0%60%2C%20ent%C3%A3o%20o%20segundo%20branch%20raramente%20%C3%A9%20ativado%20%E2%80%94%20mas%20seria%20mais%20robusto%20documentar%20a%20restri%C3%A7%C3%A3o%20ao%20comportamento%20espec%C3%ADfico%20do%20next-auth%204.x%20ou%20tornar%20a%20detec%C3%A7%C3%A3o%20mais%20gen%C3%A9rica.%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=199&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fauth%2Fhelpers%2FcookiePartitioning.ts%3A60-63%0A**Sem%20guard%20de%20idempot%C3%AAncia%20no%20monkey-patch%20de%20%60setHeader%60**%0A%0A%60patchSetCookieForPartitioned%60%20n%C3%A3o%20verifica%20se%20o%20%60res%60%20j%C3%A1%20foi%20patcheado.%20Se%20chamada%20duas%20vezes%20sobre%20o%20mesmo%20objeto%20%60res%60%20%E2%80%94%20por%20exemplo%2C%20caso%20um%20novo%20%60getServerSideProps%60%20chame%20tanto%20a%20fun%C3%A7%C3%A3o%20diretamente%20quanto%20um%20helper%20que%20tamb%C3%A9m%20a%20chame%20%E2%80%94%2C%20o%20%60setHeader%60%20ser%C3%A1%20encapsulado%20duas%20vezes.%20Como%20%60transformSetCookie%60%20%C3%A9%20idempotente%20%28detecta%20o%20atributo%20%60Partitioned%60%20existente%29%2C%20o%20resultado%20funcional%20n%C3%A3o%20muda%2C%20mas%20a%20cadeia%20de%20closures%20cresce%20desnecessariamente%20a%20cada%20chamada.%20Um%20s%C3%ADmbolo%20sentinela%20no%20objeto%20%60res%60%20previne%20isso%20de%20forma%20simples.%0A%0A%60%60%60suggestion%0Aconst%20PATCHED_SYMBOL%20%3D%20Symbol%28'chipsPatched'%29%0A%0Aexport%20const%20patchSetCookieForPartitioned%20%3D%20%28%0A%20%20res%3A%20NextApiResponse%20%7C%20ServerResponse%0A%29%20%3D%3E%20%7B%0A%20%20if%20%28%28res%20as%20unknown%20as%20Record%3Csymbol%2C%20boolean%3E%29%5BPATCHED_SYMBOL%5D%29%20return%0A%20%20%3B%28res%20as%20unknown%20as%20Record%3Csymbol%2C%20boolean%3E%29%5BPATCHED_SYMBOL%5D%20%3D%20true%0A%20%20const%20origSetHeader%20%3D%20res.setHeader.bind%28res%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fauth%2Fhelpers%2FcookiePartitioning.ts%3A47-49%0A**%60isDeletionCookie%60%20detecta%20apenas%20dois%20padr%C3%B5es%20de%20expira%C3%A7%C3%A3o**%0A%0AO%20regex%20%60%2F%3B%5Cs*Expires%3DThu%2C%5Cs*01%5Cs%2BJan%5Cs%2B1970%2Fi%60%20s%C3%B3%20casa%20o%20dia%201%20de%20janeiro%20de%201970%20com%20o%20dia%20da%20semana%20literal%20%22Thu%22.%20Na%20pr%C3%A1tica%20o%20%60next-auth%404.x%60%20usa%20consistentemente%20%60Max-Age%3D0%60%2C%20ent%C3%A3o%20o%20segundo%20branch%20raramente%20%C3%A9%20ativado%20%E2%80%94%20mas%20seria%20mais%20robusto%20documentar%20a%20restri%C3%A7%C3%A3o%20ao%20comportamento%20espec%C3%ADfico%20do%20next-auth%204.x%20ou%20tornar%20a%20detec%C3%A7%C3%A3o%20mais%20gen%C3%A9rica.%0A%0A&pr=199&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/builder/src/features/auth/helpers/cookiePartitioning.ts:60-63
**Sem guard de idempotência no monkey-patch de `setHeader`**

`patchSetCookieForPartitioned` não verifica se o `res` já foi patcheado. Se chamada duas vezes sobre o mesmo objeto `res` — por exemplo, caso um novo `getServerSideProps` chame tanto a função diretamente quanto um helper que também a chame —, o `setHeader` será encapsulado duas vezes. Como `transformSetCookie` é idempotente (detecta o atributo `Partitioned` existente), o resultado funcional não muda, mas a cadeia de closures cresce desnecessariamente a cada chamada. Um símbolo sentinela no objeto `res` previne isso de forma simples.

```suggestion
const PATCHED_SYMBOL = Symbol('chipsPatched')

export const patchSetCookieForPartitioned = (
  res: NextApiResponse | ServerResponse
) => {
  if ((res as unknown as Record<symbol, boolean>)[PATCHED_SYMBOL]) return
  ;(res as unknown as Record<symbol, boolean>)[PATCHED_SYMBOL] = true
  const origSetHeader = res.setHeader.bind(res)
```

### Issue 2 of 2
apps/builder/src/features/auth/helpers/cookiePartitioning.ts:47-49
**`isDeletionCookie` detecta apenas dois padrões de expiração**

O regex `/;\s*Expires=Thu,\s*01\s+Jan\s+1970/i` só casa o dia 1 de janeiro de 1970 com o dia da semana literal "Thu". Na prática o `next-auth@4.x` usa consistentemente `Max-Age=0`, então o segundo branch raramente é ativado — mas seria mais robusto documentar a restrição ao comportamento específico do next-auth 4.x ou tornar a detecção mais genérica.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(auth): apply CHIPS cookie patch on e..."](https://github.com/cloudhumans/typebot.io/commit/b6dc44bdf7962fb5f9fd87704b28df47dccbba04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32642438)</sub>

<!-- /greptile_comment -->