### PR TITLE
feat(listTypebots): support search and filter query params

### DIFF
--- a/apps/builder/next.config.mjs
+++ b/apps/builder/next.config.mjs
@@ -66,7 +66,7 @@ const nextConfig = {
         headers: [
           {
             key: 'Access-Control-Allow-Methods',
-            value: 'GET, POST, PUT, DELETE, OPTIONS',
+            value: 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
           },
           {
             key: 'Access-Control-Allow-Headers',

--- a/apps/builder/src/features/typebot/api/listTypebots.ts
+++ b/apps/builder/src/features/typebot/api/listTypebots.ts
@@ -26,13 +26,17 @@ export const listTypebots = authenticatedProcedure
         ),
       folderId: z.string().optional(),
       search: z.string().optional(),
-      filters: z
-        .object({
-          status: z.array(z.enum(['ativo', 'inativo'])).optional(),
-          createdAtFrom: z.string().datetime().optional(),
-          createdAtTo: z.string().datetime().optional(),
-        })
+      status: z
+        .preprocess(
+          (val) =>
+            typeof val === 'string'
+              ? val.split(',').filter(Boolean)
+              : val,
+          z.array(z.enum(['ativo', 'inativo']))
+        )
         .optional(),
+      createdAtFrom: z.string().datetime().optional(),
+      createdAtTo: z.string().datetime().optional(),
     })
   )
   .output(
@@ -51,7 +55,14 @@ export const listTypebots = authenticatedProcedure
   )
   .query(
     async ({
-      input: { workspaceId, folderId, search, filters },
+      input: {
+        workspaceId,
+        folderId,
+        search,
+        status,
+        createdAtFrom,
+        createdAtTo,
+      },
       ctx: { user },
     }) => {
       const workspace = await prisma.workspace.findUnique({
@@ -81,7 +92,7 @@ export const listTypebots = authenticatedProcedure
       }
 
       const statusConditions: { publishedTypebotId: null | { not: null } }[] = (
-        filters?.status ?? []
+        status ?? []
       ).map((s) =>
         s === 'ativo'
           ? { publishedTypebotId: { not: null } }
@@ -89,14 +100,10 @@ export const listTypebots = authenticatedProcedure
       )
 
       const createdAtFilter =
-        filters?.createdAtFrom || filters?.createdAtTo
+        createdAtFrom || createdAtTo
           ? {
-              ...(filters.createdAtFrom
-                ? { gte: new Date(filters.createdAtFrom) }
-                : {}),
-              ...(filters.createdAtTo
-                ? { lte: new Date(filters.createdAtTo) }
-                : {}),
+              ...(createdAtFrom ? { gte: new Date(createdAtFrom) } : {}),
+              ...(createdAtTo ? { lte: new Date(createdAtTo) } : {}),
             }
           : undefined
 

--- a/apps/builder/src/features/typebot/api/listTypebots.ts
+++ b/apps/builder/src/features/typebot/api/listTypebots.ts
@@ -1,8 +1,8 @@
 import prisma from '@typebot.io/lib/prisma'
 import { authenticatedProcedure } from '@/helpers/server/trpc'
 import { TRPCError } from '@trpc/server'
-import { WorkspaceRole } from '@typebot.io/prisma'
-import { PublicTypebot, Typebot, typebotV5Schema } from '@typebot.io/schemas'
+import { Prisma, WorkspaceRole } from '@typebot.io/prisma'
+import { typebotV5Schema } from '@typebot.io/schemas'
 import { omit } from '@typebot.io/lib'
 import { z } from 'zod'
 import { getUserRoleInWorkspace } from '@/features/workspace/helpers/getUserRoleInWorkspace'
@@ -29,10 +29,8 @@ export const listTypebots = authenticatedProcedure
       status: z
         .preprocess(
           (val) =>
-            typeof val === 'string'
-              ? val.split(',').filter(Boolean)
-              : val,
-          z.array(z.enum(['ativo', 'inativo']))
+            typeof val === 'string' ? val.split(',').filter(Boolean) : val,
+          z.array(z.enum(['active', 'inactive']))
         )
         .optional(),
       createdAtFrom: z.string().datetime().optional(),
@@ -91,12 +89,11 @@ export const listTypebots = authenticatedProcedure
         })
       }
 
-      const statusConditions: { publishedTypebotId: null | { not: null } }[] = (
-        status ?? []
-      ).map((s) =>
-        s === 'ativo'
-          ? { publishedTypebotId: { not: null } }
-          : { publishedTypebotId: null }
+      const statusConditions: Prisma.TypebotWhereInput[] = (status ?? []).map(
+        (s) =>
+          s === 'active'
+            ? { publishedTypebot: { isNot: null } }
+            : { publishedTypebot: null }
       )
 
       const createdAtFilter =
@@ -107,7 +104,7 @@ export const listTypebots = authenticatedProcedure
             }
           : undefined
 
-      const typebots = (await prisma.typebot.findMany({
+      const typebots = await prisma.typebot.findMany({
         where: {
           isArchived: { not: true },
           folderId:
@@ -135,9 +132,7 @@ export const listTypebots = authenticatedProcedure
           icon: true,
           createdAt: true,
         },
-      })) as (Pick<Typebot, 'name' | 'id' | 'icon' | 'createdAt'> & {
-        publishedTypebot: Pick<PublicTypebot, 'id'>
-      })[]
+      })
 
       if (!typebots)
         throw new TRPCError({

--- a/apps/builder/src/features/typebot/api/listTypebots.ts
+++ b/apps/builder/src/features/typebot/api/listTypebots.ts
@@ -96,13 +96,24 @@ export const listTypebots = authenticatedProcedure
             : { publishedTypebot: null }
       )
 
+      const fromDate = createdAtFrom ? new Date(createdAtFrom) : undefined
+      const toDate = createdAtTo ? new Date(createdAtTo) : undefined
+
+      if (fromDate && toDate && fromDate > toDate)
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'createdAtFrom must be before or equal to createdAtTo',
+        })
+
       const createdAtFilter =
-        createdAtFrom || createdAtTo
+        fromDate || toDate
           ? {
-              ...(createdAtFrom ? { gte: new Date(createdAtFrom) } : {}),
-              ...(createdAtTo ? { lte: new Date(createdAtTo) } : {}),
+              ...(fromDate ? { gte: fromDate } : {}),
+              ...(toDate ? { lte: toDate } : {}),
             }
           : undefined
+
+      const trimmedSearch = search?.trim()
 
       const typebots = await prisma.typebot.findMany({
         where: {
@@ -118,8 +129,10 @@ export const listTypebots = authenticatedProcedure
             userRole === WorkspaceRole.GUEST
               ? { some: { userId: user.id } }
               : undefined,
-          ...(search
-            ? { name: { contains: search, mode: 'insensitive' as const } }
+          ...(trimmedSearch
+            ? {
+                name: { contains: trimmedSearch, mode: 'insensitive' as const },
+              }
             : {}),
           ...(statusConditions.length > 0 ? { OR: statusConditions } : {}),
           ...(createdAtFilter ? { createdAt: createdAtFilter } : {}),
@@ -133,12 +146,6 @@ export const listTypebots = authenticatedProcedure
           createdAt: true,
         },
       })
-
-      if (!typebots)
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'No typebots found',
-        })
 
       return {
         typebots: typebots.map((typebot) => ({

--- a/apps/builder/src/features/typebot/api/listTypebots.ts
+++ b/apps/builder/src/features/typebot/api/listTypebots.ts
@@ -25,6 +25,14 @@ export const listTypebots = authenticatedProcedure
           '[Where to find my workspace ID?](../how-to#how-to-find-my-workspaceid)'
         ),
       folderId: z.string().optional(),
+      search: z.string().optional(),
+      filters: z
+        .object({
+          status: z.array(z.enum(['ativo', 'inativo'])).optional(),
+          createdAtFrom: z.string().datetime().optional(),
+          createdAtTo: z.string().datetime().optional(),
+        })
+        .optional(),
     })
   )
   .output(
@@ -35,65 +43,106 @@ export const listTypebots = authenticatedProcedure
             name: true,
             icon: true,
             id: true,
+            createdAt: true,
           })
           .merge(z.object({ publishedTypebotId: z.string().optional() }))
       ),
     })
   )
-  .query(async ({ input: { workspaceId, folderId }, ctx: { user } }) => {
-    const workspace = await prisma.workspace.findUnique({
-      where: { id: workspaceId },
-      select: { id: true, name: true, members: true },
-    })
+  .query(
+    async ({
+      input: { workspaceId, folderId, search, filters },
+      ctx: { user },
+    }) => {
+      const workspace = await prisma.workspace.findUnique({
+        where: { id: workspaceId },
+        select: { id: true, name: true, members: true },
+      })
 
-    if (!workspace) {
-      throw new TRPCError({ code: 'NOT_FOUND', message: 'Workspace not found' })
-    }
+      if (!workspace) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Workspace not found',
+        })
+      }
 
-    const userRole = getUserRoleInWorkspace(
-      user.id,
-      workspace.members,
-      workspaceId,
-      user
-    )
-
-    if (!userRole) {
-      throw new TRPCError({ code: 'NOT_FOUND', message: 'Workspace not found' })
-    }
-
-    const typebots = (await prisma.typebot.findMany({
-      where: {
-        isArchived: { not: true },
-        folderId:
-          userRole === WorkspaceRole.GUEST
-            ? undefined
-            : folderId === 'root'
-            ? null
-            : folderId,
+      const userRole = getUserRoleInWorkspace(
+        user.id,
+        workspace.members,
         workspaceId,
-        collaborators:
-          userRole === WorkspaceRole.GUEST
-            ? { some: { userId: user.id } }
-            : undefined,
-      },
-      orderBy: { createdAt: 'desc' },
-      select: {
-        name: true,
-        publishedTypebot: { select: { id: true } },
-        id: true,
-        icon: true,
-      },
-    })) as (Pick<Typebot, 'name' | 'id' | 'icon'> & {
-      publishedTypebot: Pick<PublicTypebot, 'id'>
-    })[]
+        user
+      )
 
-    if (!typebots)
-      throw new TRPCError({ code: 'NOT_FOUND', message: 'No typebots found' })
+      if (!userRole) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Workspace not found',
+        })
+      }
 
-    return {
-      typebots: typebots.map((typebot) => ({
-        publishedTypebotId: typebot.publishedTypebot?.id,
-        ...omit(typebot, 'publishedTypebot'),
-      })),
+      const statusConditions: { publishedTypebotId: null | { not: null } }[] = (
+        filters?.status ?? []
+      ).map((s) =>
+        s === 'ativo'
+          ? { publishedTypebotId: { not: null } }
+          : { publishedTypebotId: null }
+      )
+
+      const createdAtFilter =
+        filters?.createdAtFrom || filters?.createdAtTo
+          ? {
+              ...(filters.createdAtFrom
+                ? { gte: new Date(filters.createdAtFrom) }
+                : {}),
+              ...(filters.createdAtTo
+                ? { lte: new Date(filters.createdAtTo) }
+                : {}),
+            }
+          : undefined
+
+      const typebots = (await prisma.typebot.findMany({
+        where: {
+          isArchived: { not: true },
+          folderId:
+            userRole === WorkspaceRole.GUEST
+              ? undefined
+              : folderId === 'root'
+              ? null
+              : folderId,
+          workspaceId,
+          collaborators:
+            userRole === WorkspaceRole.GUEST
+              ? { some: { userId: user.id } }
+              : undefined,
+          ...(search
+            ? { name: { contains: search, mode: 'insensitive' as const } }
+            : {}),
+          ...(statusConditions.length > 0 ? { OR: statusConditions } : {}),
+          ...(createdAtFilter ? { createdAt: createdAtFilter } : {}),
+        },
+        orderBy: { createdAt: 'desc' },
+        select: {
+          name: true,
+          publishedTypebot: { select: { id: true } },
+          id: true,
+          icon: true,
+          createdAt: true,
+        },
+      })) as (Pick<Typebot, 'name' | 'id' | 'icon' | 'createdAt'> & {
+        publishedTypebot: Pick<PublicTypebot, 'id'>
+      })[]
+
+      if (!typebots)
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'No typebots found',
+        })
+
+      return {
+        typebots: typebots.map((typebot) => ({
+          publishedTypebotId: typebot.publishedTypebot?.id,
+          ...omit(typebot, 'publishedTypebot'),
+        })),
+      }
     }
-  })
+  )

--- a/apps/builder/src/utils/cors.ts
+++ b/apps/builder/src/utils/cors.ts
@@ -56,7 +56,7 @@ export function corsMiddleware(request: NextRequest, response: NextResponse) {
   response.headers.set('Access-Control-Allow-Credentials', 'true')
   response.headers.set(
     'Access-Control-Allow-Methods',
-    'GET, POST, PUT, DELETE, OPTIONS'
+    'GET, POST, PUT, PATCH, DELETE, OPTIONS'
   )
   response.headers.set(
     'Access-Control-Allow-Headers',


### PR DESCRIPTION
Extends listTypebots input with optional search (name ILIKE), filters.status (ativo/inativo as multi-select), and filters.createdAtFrom/To. Used by the new claudia-app ControlledFlows dashboard, which queries Eddie via apiGateway for server-side filtering instead of filtering on the client.

Also exposes createdAt in the response so the dashboard can render the "Data de criação" column.

<!-- greptile_comment -->

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dashboard as claudia-app Dashboard
    participant Eddie as Eddie (apiGateway)
    participant API as GET /v1/typebots
    participant DB as PostgreSQL (Typebot)

    Dashboard->>Eddie: "GET /controlledFlows?search=X&status=active&createdAtFrom=..."
    Eddie->>API: "GET /v1/typebots?workspaceId=W&search=X&status=active&createdAtFrom=...&createdAtTo=..."
    API->>API: Valida input (Zod): trim(search), parse status CSV, parse dates
    API->>DB: workspace.findUnique(workspaceId)
    DB-->>API: workspace + members
    API->>API: Verifica papel do usuário (getUserRoleInWorkspace)
    API->>DB: "typebot.findMany(WHERE isArchived=false AND workspaceId=W AND name ILIKE %X% AND publishedTypebot isNot null AND createdAt BETWEEN from AND to)"
    DB-->>API: typebots[] com createdAt
    API-->>Eddie: "{ typebots: [{id, name, icon, createdAt, publishedTypebotId}] }"
    Eddie-->>Dashboard: lista filtrada para renderizar coluna Data de criação
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Ftypebot%2Fapi%2FlistTypebots.ts%3A116-118%0A**Busca%20por%20nome%20sem%20%C3%ADndice%20pode%20causar%20degrada%C3%A7%C3%A3o%20de%20performance**%0A%0AO%20filtro%20%60name%20ILIKE%60%20executa%20um%20escaneamento%20sequencial%20na%20coluna%20%60name%60%20do%20modelo%20%60Typebot%60%2C%20pois%20n%C3%A3o%20existe%20%C3%ADndice%20trigram%20%28GIN%2Fpg_trgm%29%20para%20suportar%20buscas%20%60CONTAINS%60%20%2B%20%60insensitive%60%20no%20PostgreSQL.%20Para%20workspaces%20com%20muitos%20typebots%2C%20isso%20pode%20resultar%20em%20queries%20lentas%20em%20produ%C3%A7%C3%A3o.%20Recomenda-se%20adicionar%20um%20%C3%ADndice%20trigram%20via%20migra%C3%A7%C3%A3o%20Prisma%20ou%2C%20como%20mitiga%C3%A7%C3%A3o%20imediata%2C%20limitar%20o%20campo%20%60name%60%20com%20um%20comprimento%20m%C3%ADnimo%20no%20input%20para%20evitar%20buscas%20trivialmente%20amplas.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20const%20trimmedSearch%20%3D%20search%3F.trim%28%29%0A%20%20%20%20%20%20if%20%28trimmedSearch%20!%3D%3D%20undefined%20%26%26%20trimmedSearch.length%20%3C%202%29%0A%20%20%20%20%20%20%20%20throw%20new%20TRPCError%28%7B%0A%20%20%20%20%20%20%20%20%20%20code%3A%20'BAD_REQUEST'%2C%0A%20%20%20%20%20%20%20%20%20%20message%3A%20'search%20must%20be%20at%20least%202%20characters'%2C%0A%20%20%20%20%20%20%20%20%7D%29%0A%0A%20%20%20%20%20%20const%20typebots%20%3D%20await%20prisma.typebot.findMany%28%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Ftypebot%2Fapi%2FlistTypebots.ts%3A29-35%0A**%60status%60%20via%20REST%20recebe%20array%20repetido%20sem%20tratamento%20adequado**%0A%0AO%20%60z.preprocess%60%20divide%20um%20valor%20string%20por%20v%C3%ADrgula%20%28ex%3A%20%60%3Fstatus%3Dactive%2Cinactive%60%29%2C%20mas%20quando%20um%20cliente%20HTTP%20envia%20par%C3%A2metros%20de%20query%20repetidos%20%28ex%3A%20%60%3Fstatus%3Dactive%26status%3Dinactive%60%29%2C%20alguns%20parsers%20entregam%20o%20valor%20j%C3%A1%20como%20array%20de%20strings.%20Nesse%20caso%2C%20%60typeof%20val%20%3D%3D%3D%20'string'%60%20seria%20%60false%60%20e%20o%20array%20passaria%20direto%20para%20%60z.array%28z.enum%28%5B...%5D%29%29%60%20sem%20problemas%20%E2%80%94%20por%C3%A9m%2C%20se%20o%20parser%20enviar%20um%20formato%20inesperado%2C%20a%20valida%C3%A7%C3%A3o%20falhar%C3%A1%20com%20uma%20mensagem%20de%20erro%20gen%C3%A9rica.%20Considere%20adicionar%20tratamento%20expl%C3%ADcito%20para%20arrays%20no%20preprocess%20para%20tornar%20o%20contrato%20mais%20robusto%20e%20o%20erro%20mais%20descritivo.%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=200&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Ftypebot%2Fapi%2FlistTypebots.ts%3A116-118%0A**Busca%20por%20nome%20sem%20%C3%ADndice%20pode%20causar%20degrada%C3%A7%C3%A3o%20de%20performance**%0A%0AO%20filtro%20%60name%20ILIKE%60%20executa%20um%20escaneamento%20sequencial%20na%20coluna%20%60name%60%20do%20modelo%20%60Typebot%60%2C%20pois%20n%C3%A3o%20existe%20%C3%ADndice%20trigram%20%28GIN%2Fpg_trgm%29%20para%20suportar%20buscas%20%60CONTAINS%60%20%2B%20%60insensitive%60%20no%20PostgreSQL.%20Para%20workspaces%20com%20muitos%20typebots%2C%20isso%20pode%20resultar%20em%20queries%20lentas%20em%20produ%C3%A7%C3%A3o.%20Recomenda-se%20adicionar%20um%20%C3%ADndice%20trigram%20via%20migra%C3%A7%C3%A3o%20Prisma%20ou%2C%20como%20mitiga%C3%A7%C3%A3o%20imediata%2C%20limitar%20o%20campo%20%60name%60%20com%20um%20comprimento%20m%C3%ADnimo%20no%20input%20para%20evitar%20buscas%20trivialmente%20amplas.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20const%20trimmedSearch%20%3D%20search%3F.trim%28%29%0A%20%20%20%20%20%20if%20%28trimmedSearch%20!%3D%3D%20undefined%20%26%26%20trimmedSearch.length%20%3C%202%29%0A%20%20%20%20%20%20%20%20throw%20new%20TRPCError%28%7B%0A%20%20%20%20%20%20%20%20%20%20code%3A%20'BAD_REQUEST'%2C%0A%20%20%20%20%20%20%20%20%20%20message%3A%20'search%20must%20be%20at%20least%202%20characters'%2C%0A%20%20%20%20%20%20%20%20%7D%29%0A%0A%20%20%20%20%20%20const%20typebots%20%3D%20await%20prisma.typebot.findMany%28%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Ftypebot%2Fapi%2FlistTypebots.ts%3A29-35%0A**%60status%60%20via%20REST%20recebe%20array%20repetido%20sem%20tratamento%20adequado**%0A%0AO%20%60z.preprocess%60%20divide%20um%20valor%20string%20por%20v%C3%ADrgula%20%28ex%3A%20%60%3Fstatus%3Dactive%2Cinactive%60%29%2C%20mas%20quando%20um%20cliente%20HTTP%20envia%20par%C3%A2metros%20de%20query%20repetidos%20%28ex%3A%20%60%3Fstatus%3Dactive%26status%3Dinactive%60%29%2C%20alguns%20parsers%20entregam%20o%20valor%20j%C3%A1%20como%20array%20de%20strings.%20Nesse%20caso%2C%20%60typeof%20val%20%3D%3D%3D%20'string'%60%20seria%20%60false%60%20e%20o%20array%20passaria%20direto%20para%20%60z.array%28z.enum%28%5B...%5D%29%29%60%20sem%20problemas%20%E2%80%94%20por%C3%A9m%2C%20se%20o%20parser%20enviar%20um%20formato%20inesperado%2C%20a%20valida%C3%A7%C3%A3o%20falhar%C3%A1%20com%20uma%20mensagem%20de%20erro%20gen%C3%A9rica.%20Considere%20adicionar%20tratamento%20expl%C3%ADcito%20para%20arrays%20no%20preprocess%20para%20tornar%20o%20contrato%20mais%20robusto%20e%20o%20erro%20mais%20descritivo.%0A%0A&pr=200&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/builder/src/features/typebot/api/listTypebots.ts:116-118
**Busca por nome sem índice pode causar degradação de performance**

O filtro `name ILIKE` executa um escaneamento sequencial na coluna `name` do modelo `Typebot`, pois não existe índice trigram (GIN/pg_trgm) para suportar buscas `CONTAINS` + `insensitive` no PostgreSQL. Para workspaces com muitos typebots, isso pode resultar em queries lentas em produção. Recomenda-se adicionar um índice trigram via migração Prisma ou, como mitigação imediata, limitar o campo `name` com um comprimento mínimo no input para evitar buscas trivialmente amplas.

```suggestion
      const trimmedSearch = search?.trim()
      if (trimmedSearch !== undefined && trimmedSearch.length < 2)
        throw new TRPCError({
          code: 'BAD_REQUEST',
          message: 'search must be at least 2 characters',
        })

      const typebots = await prisma.typebot.findMany({
```

### Issue 2 of 2
apps/builder/src/features/typebot/api/listTypebots.ts:29-35
**`status` via REST recebe array repetido sem tratamento adequado**

O `z.preprocess` divide um valor string por vírgula (ex: `?status=active,inactive`), mas quando um cliente HTTP envia parâmetros de query repetidos (ex: `?status=active&status=inactive`), alguns parsers entregam o valor já como array de strings. Nesse caso, `typeof val === 'string'` seria `false` e o array passaria direto para `z.array(z.enum([...]))` sem problemas — porém, se o parser enviar um formato inesperado, a validação falhará com uma mensagem de erro genérica. Considere adicionar tratamento explícito para arrays no preprocess para tornar o contrato mais robusto e o erro mais descritivo.

`````

</details>

<sub>Reviews (5): Last reviewed commit: [":construction: fix comments"](https://github.com/cloudhumans/typebot.io/commit/395f3a0034ef30e4d727d620e284dd833e3fc536) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32648097)</sub>

<!-- /greptile_comment -->