### PR TITLE
🩹enhancement: log full error details on embedded auth failure

### DIFF
--- a/apps/builder/src/features/embedded-auth/embedded-auth.ts
+++ b/apps/builder/src/features/embedded-auth/embedded-auth.ts
@@ -35,7 +35,15 @@ export const handleEmbeddedAuthentication = async ({
     return true
   } catch (error) {
     logger.error('Error during embedded authentication', {
-      error: String(error),
+      error:
+        error instanceof Error
+          ? {
+              name: error.name,
+              message: error.message,
+              stack: error.stack,
+              cause: error.cause,
+            }
+          : String(error),
     })
     return false
   }

--- a/apps/builder/src/features/embedded-auth/embedded-auth.ts
+++ b/apps/builder/src/features/embedded-auth/embedded-auth.ts
@@ -35,7 +35,7 @@ export const handleEmbeddedAuthentication = async ({
     return true
   } catch (error) {
     logger.error('Error during embedded authentication', {
-      error: error instanceof Error ? error.message : String(error),
+      error: String(error),
     })
     return false
   }


### PR DESCRIPTION
Hoje o catch do `handleEmbeddedAuthentication` loga só `error.message` (ou `String(error)`), o que **descarta o stack trace** — exatamente a info mais útil pra debugar falha de auth embedded.

Extrai `name`, `message`, `stack` e `cause` de instâncias de `Error`. Pra throws não-`Error`, mantém `String(error)` como fallback.

Detalhe: `JSON.stringify(new Error('x'))` retorna `{}` porque as props de `Error` são non-enumerable — por isso winston não consegue serializar sozinho dentro de `{ error: err }`. Precisa abrir na mão.

Follow-up direto do #198.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

A mudança aprimora o log de erros em `handleEmbeddedAuthentication`, substituindo o log de apenas `error.message` por um objeto estruturado com `name`, `message`, `stack` e `cause` quando o erro for uma instância de `Error`.

- O log passa a capturar informações de diagnóstico mais completas (stack trace e causa raiz), facilitando a investigação de falhas em produção.
- A descrição do PR afirma incorretamente que a condicional seria removida em favor de `String(error)`, mas o código implementado mantém e expande a condicional — a descrição merece atualização para refletir a mudança real.

<h3>Confidence Score: 5/5</h3>

A mudança é segura para merge; altera apenas a estrutura do objeto logado no bloco catch, sem afetar o fluxo de autenticação ou os valores retornados.

A alteração é estritamente de observabilidade: enriquece o objeto de erro registrado sem modificar nenhuma lógica de negócio, fluxo de controle ou valor de retorno. O único ponto de atenção é a descrição do PR, que não corresponde ao que foi implementado, mas isso não representa risco de regressão.

Nenhum arquivo requer atenção especial.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/builder/src/features/embedded-auth/embedded-auth.ts | Enriquece o log de erro no bloco catch, passando de uma simples string (error.message) para um objeto estruturado com name, message, stack e cause quando o erro for instância de Error. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fembedded-auth%2Fembedded-auth.ts%3A36-48%0A**Descri%C3%A7%C3%A3o%20do%20PR%20n%C3%A3o%20corresponde%20%C3%A0%20mudan%C3%A7a%20real**%0A%0AA%20descri%C3%A7%C3%A3o%20afirma%20que%20o%20objetivo%20%C3%A9%20substituir%20%60error%20instanceof%20Error%20%3F%20error.message%20%3A%20String%28error%29%60%20por%20simplesmente%20%60String%28error%29%60%2C%20mas%20o%20c%C3%B3digo%20implementado%20faz%20o%20contr%C3%A1rio%3A%20mant%C3%A9m%20a%20verifica%C3%A7%C3%A3o%20%60instanceof%20Error%60%20e%20expande%20o%20objeto%20logado%20com%20%60name%60%2C%20%60message%60%2C%20%60stack%60%20e%20%60cause%60.%20Quem%20consultar%20o%20hist%C3%B3rico%20do%20git%20ter%C3%A1%20uma%20descri%C3%A7%C3%A3o%20enganosa%20do%20que%20foi%20alterado.%20Vale%20atualizar%20a%20descri%C3%A7%C3%A3o%20do%20PR%20para%20refletir%20que%20a%20mudan%C3%A7a%20enriquece%20o%20log%20de%20erros%20com%20informa%C3%A7%C3%B5es%20estruturadas%2C%20em%20vez%20de%20simplific%C3%A1-lo.%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=201&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fembedded-auth%2Fembedded-auth.ts%3A36-48%0A**Descri%C3%A7%C3%A3o%20do%20PR%20n%C3%A3o%20corresponde%20%C3%A0%20mudan%C3%A7a%20real**%0A%0AA%20descri%C3%A7%C3%A3o%20afirma%20que%20o%20objetivo%20%C3%A9%20substituir%20%60error%20instanceof%20Error%20%3F%20error.message%20%3A%20String%28error%29%60%20por%20simplesmente%20%60String%28error%29%60%2C%20mas%20o%20c%C3%B3digo%20implementado%20faz%20o%20contr%C3%A1rio%3A%20mant%C3%A9m%20a%20verifica%C3%A7%C3%A3o%20%60instanceof%20Error%60%20e%20expande%20o%20objeto%20logado%20com%20%60name%60%2C%20%60message%60%2C%20%60stack%60%20e%20%60cause%60.%20Quem%20consultar%20o%20hist%C3%B3rico%20do%20git%20ter%C3%A1%20uma%20descri%C3%A7%C3%A3o%20enganosa%20do%20que%20foi%20alterado.%20Vale%20atualizar%20a%20descri%C3%A7%C3%A3o%20do%20PR%20para%20refletir%20que%20a%20mudan%C3%A7a%20enriquece%20o%20log%20de%20erros%20com%20informa%C3%A7%C3%B5es%20estruturadas%2C%20em%20vez%20de%20simplific%C3%A1-lo.%0A%0A&pr=201&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/builder/src/features/embedded-auth/embedded-auth.ts:36-48
**Descrição do PR não corresponde à mudança real**

A descrição afirma que o objetivo é substituir `error instanceof Error ? error.message : String(error)` por simplesmente `String(error)`, mas o código implementado faz o contrário: mantém a verificação `instanceof Error` e expande o objeto logado com `name`, `message`, `stack` e `cause`. Quem consultar o histórico do git terá uma descrição enganosa do que foi alterado. Vale atualizar a descrição do PR para refletir que a mudança enriquece o log de erros com informações estruturadas, em vez de simplificá-lo.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["🩹enhancement: log full error details on..."](https://github.com/cloudhumans/typebot.io/commit/47e1f92120b5ffcde38d90b68c55b7a2a76d7afa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32663386)</sub>

<!-- /greptile_comment -->