### PR TITLE
🐛bug: short callbackUrl on embedded signIn to fit Kong proxy buffer

### DIFF
--- a/apps/builder/src/features/embedded-auth/embedded-auth.test.ts
+++ b/apps/builder/src/features/embedded-auth/embedded-auth.test.ts
@@ -1,0 +1,193 @@
+import { vi } from 'vitest'
+
+vi.mock('next-auth/react', () => ({
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}))
+
+vi.mock('@/lib/trpc', () => ({
+  trpcVanilla: {
+    verifyEmbeddedToken: {
+      mutate: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { signIn, signOut } from 'next-auth/react'
+import { trpcVanilla } from '@/lib/trpc'
+import logger from '@/helpers/logger'
+import {
+  buildEmbeddedCallbackUrl,
+  handleEmbeddedAuthentication,
+} from './embedded-auth'
+
+const signInMock = signIn as unknown as ReturnType<typeof vi.fn>
+const signOutMock = signOut as unknown as ReturnType<typeof vi.fn>
+const verifyEmbeddedTokenMock = trpcVanilla.verifyEmbeddedToken
+  .mutate as unknown as ReturnType<typeof vi.fn>
+const loggerErrorMock = logger.error as unknown as ReturnType<typeof vi.fn>
+
+const SHORT_CALLBACK = 'https://eddie.test/typebots'
+
+describe('buildEmbeddedCallbackUrl', () => {
+  it('returns origin + pathname without the search/hash that carry the JWT', () => {
+    const url = buildEmbeddedCallbackUrl({
+      origin: 'https://eddie.test',
+      pathname: '/typebots/abc-123/edit',
+    })
+    expect(url).toBe('https://eddie.test/typebots/abc-123/edit')
+    expect(url).not.toContain('jwt')
+  })
+
+  it('handles root pathname', () => {
+    const url = buildEmbeddedCallbackUrl({
+      origin: 'https://eddie.test',
+      pathname: '/',
+    })
+    expect(url).toBe('https://eddie.test/')
+  })
+
+  it('stays under 256 bytes for typical hosts and paths', () => {
+    const url = buildEmbeddedCallbackUrl({
+      origin: 'https://eddie.us-east-1.prd.cloudhumans.io',
+      pathname: '/typebots/cmkjzi2631gkwd25qv1h9egow/edit',
+    })
+    // Keeps response Set-Cookie well under Kong's default 4 KB proxy_buffer_size.
+    expect(url.length).toBeLessThan(256)
+  })
+})
+
+describe('handleEmbeddedAuthentication', () => {
+  beforeEach(() => {
+    signInMock.mockReset()
+    signOutMock.mockReset()
+    verifyEmbeddedTokenMock.mockReset()
+    loggerErrorMock.mockReset()
+  })
+
+  it('passes a JWT-free callbackUrl to signIn', async () => {
+    signInMock.mockResolvedValue({ ok: true })
+
+    const result = await handleEmbeddedAuthentication({
+      session: null,
+      token: 'cognito.jwt.value',
+      callbackUrl: SHORT_CALLBACK,
+    })
+
+    expect(result).toBe(true)
+    expect(signInMock).toHaveBeenCalledTimes(1)
+    const [provider, options] = signInMock.mock.calls[0]
+    expect(provider).toBe('cloudchat-embedded')
+    expect(options).toMatchObject({
+      token: 'cognito.jwt.value',
+      redirect: false,
+      callbackUrl: SHORT_CALLBACK,
+    })
+  })
+
+  it('regression guard: never forwards a callbackUrl carrying the JWT', async () => {
+    signInMock.mockResolvedValue({ ok: true })
+
+    await handleEmbeddedAuthentication({
+      session: null,
+      token: 'cognito.jwt.value',
+      callbackUrl: SHORT_CALLBACK,
+    })
+
+    const options = signInMock.mock.calls[0][1] as { callbackUrl: string }
+    expect(options.callbackUrl).not.toContain('jwt=')
+    expect(options.callbackUrl).not.toContain('?embedded=')
+  })
+
+  it('skips signIn when an existing cloudchat-authorized session matches the token email', async () => {
+    verifyEmbeddedTokenMock.mockResolvedValue({ email: 'user@cloudhumans.com' })
+
+    const result = await handleEmbeddedAuthentication({
+      session: {
+        user: {
+          email: 'user@cloudhumans.com',
+          cloudChatAuthorization: true,
+        },
+        expires: '2099-01-01',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      token: 'cognito.jwt.value',
+      callbackUrl: SHORT_CALLBACK,
+    })
+
+    expect(result).toBe(true)
+    expect(signInMock).not.toHaveBeenCalled()
+    expect(signOutMock).not.toHaveBeenCalled()
+  })
+
+  it('signs out and signs in when the session email does not match the token', async () => {
+    verifyEmbeddedTokenMock.mockResolvedValue({ email: 'new@cloudhumans.com' })
+    signOutMock.mockResolvedValue(undefined)
+    signInMock.mockResolvedValue({ ok: true })
+
+    const result = await handleEmbeddedAuthentication({
+      session: {
+        user: {
+          email: 'stale@cloudhumans.com',
+          cloudChatAuthorization: true,
+        },
+        expires: '2099-01-01',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      token: 'cognito.jwt.value',
+      callbackUrl: SHORT_CALLBACK,
+    })
+
+    expect(result).toBe(true)
+    expect(signOutMock).toHaveBeenCalledWith({ redirect: false })
+    expect(signInMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns false and logs when signIn reports failure', async () => {
+    signInMock.mockResolvedValue({ ok: false, error: 'CredentialsSignin' })
+
+    const result = await handleEmbeddedAuthentication({
+      session: null,
+      token: 'cognito.jwt.value',
+      callbackUrl: SHORT_CALLBACK,
+    })
+
+    expect(result).toBe(false)
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      'Embedded authentication failed',
+      expect.objectContaining({
+        result: expect.objectContaining({ ok: false }),
+      })
+    )
+  })
+
+  it('returns false and logs error details when signIn throws', async () => {
+    signInMock.mockRejectedValue(new TypeError('URL constructor: undefined'))
+
+    const result = await handleEmbeddedAuthentication({
+      session: null,
+      token: 'cognito.jwt.value',
+      callbackUrl: SHORT_CALLBACK,
+    })
+
+    expect(result).toBe(false)
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      'Error during embedded authentication',
+      expect.objectContaining({
+        error: expect.objectContaining({
+          name: 'TypeError',
+          message: 'URL constructor: undefined',
+        }),
+      })
+    )
+  })
+})

--- a/apps/builder/src/features/embedded-auth/embedded-auth.ts
+++ b/apps/builder/src/features/embedded-auth/embedded-auth.ts
@@ -3,12 +3,29 @@ import { Session } from 'next-auth'
 import { trpcVanilla } from '@/lib/trpc'
 import logger from '@/helpers/logger'
 
+// next-auth/react defaults `callbackUrl` to `window.location.href` when not
+// passed explicitly. For the cloudchat-embedded flow that URL carries the
+// ~2 KB Cognito JWT in its query string, which next-auth then persists in the
+// `__Secure-next-auth.callback-url` cookie. Combined with the session-token
+// cookie, response Set-Cookie headers exceed Kong's default
+// `proxy_buffer_size` (4 KB), and the gateway rejects the response with
+// "an invalid response was received from the upstream server" → 502.
+//
+// callbackUrl is only used for post-signin redirects; the embedded flow uses
+// `redirect: false` and ignores `result.url`, so passing a short origin+path
+// is functionally equivalent and keeps response headers small.
+export const buildEmbeddedCallbackUrl = (
+  location: Pick<Location, 'origin' | 'pathname'>
+): string => `${location.origin}${location.pathname}`
+
 export const handleEmbeddedAuthentication = async ({
   session,
   token,
+  callbackUrl,
 }: {
   token: string
   session: Session | null
+  callbackUrl: string
 }): Promise<boolean> => {
   try {
     if (session?.user) {
@@ -25,6 +42,7 @@ export const handleEmbeddedAuthentication = async ({
     const result = await signIn('cloudchat-embedded', {
       token,
       redirect: false,
+      callbackUrl,
     })
 
     if (!result?.ok) {

--- a/apps/builder/src/features/embedded-auth/index.ts
+++ b/apps/builder/src/features/embedded-auth/index.ts
@@ -1,3 +1,6 @@
 export { EmbeddedAuthWrapper } from './EmbeddedAuthWrapper'
-export { handleEmbeddedAuthentication } from './embedded-auth'
+export {
+  handleEmbeddedAuthentication,
+  buildEmbeddedCallbackUrl,
+} from './embedded-auth'
 export { getAllowedOrigin, getAllowedOrigins, isOriginAllowed } from './utils'

--- a/apps/builder/src/hooks/useEmbeddedAuth.ts
+++ b/apps/builder/src/hooks/useEmbeddedAuth.ts
@@ -1,4 +1,7 @@
-import { handleEmbeddedAuthentication } from '@/features/embedded-auth'
+import {
+  handleEmbeddedAuthentication,
+  buildEmbeddedCallbackUrl,
+} from '@/features/embedded-auth'
 import { useSession } from 'next-auth/react'
 import { useSearchParams } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
@@ -25,7 +28,11 @@ export const useEmbeddedAuth = () => {
     // only attempt auth once
     authAttempted.current = true
 
-    handleEmbeddedAuthentication({ session: sessionData, token: embeddedJwt })
+    handleEmbeddedAuthentication({
+      session: sessionData,
+      token: embeddedJwt,
+      callbackUrl: buildEmbeddedCallbackUrl(window.location),
+    })
       .then((success) => {
         if (!success)
           setAuthError('Failed to load flow builder. Please reload the page.')


### PR DESCRIPTION
## Sintoma

Usuários reportaram, no console do browser do iframe Typebot embebido pelo CloudChat:

```
POST https://eddie.us-east-1.prd.cloudhumans.io/api/auth/callback/cloudchat-embedded? [HTTP/2 502]
Error during embedded authentication
  error: TypeError: URL constructor: undefined is not a valid URL.
```

Reprodutível em **qualquer browser sem cookie de sessão prévio** (Firefox padrão e Chrome em janela anônima). O `signIn('cloudchat-embedded', ...)` falha; o iframe nunca autentica.

## Causa raiz

1. CloudChat monta a iframe em `https://eddie.../typebots?embedded=true&jwt=<2 KB Cognito JWT>` (EddieView.vue).
2. `useEmbeddedAuth` chama `signIn('cloudchat-embedded', { token, redirect: false })`.
3. `next-auth/react` usa `window.location.href` como `callbackUrl` default → o body do POST envia `callbackUrl=<URL-encoded URL com o JWT dentro>` (~2.3 KB).
4. O servidor seta `__Secure-next-auth.callback-url=<2.3 KB>; …; Partitioned`.
5. Junto com `__Secure-next-auth.session-token` (também com `Partitioned`, do #199) e `__Host-next-auth.csrf-token`, os `Set-Cookie` da resposta passam de **4 KB**.
6. Kong (nginx) tem `proxy_buffer_size` default de **4 KB** para headers de resposta do upstream. Estoura → o gateway descarta a resposta e devolve `502 Bad Gateway` com body `{"message":"An invalid response was received from the upstream server"}`.
7. `next-auth/react` recebe o 502, tenta `new URL(data.url)` (que é `undefined`), e o erro `URL constructor: undefined is not a valid URL` aparece no console — sintoma _downstream_ surfaceado pelo logging de #198/#201.

Reproduzido manualmente via curl:

| Body | callbackUrl | Resposta | upstream latency |
|---|---|---|---|
| JWT real + callbackUrl curto (`origin`) | `~50 B` | **200** | 15 ms |
| JWT real + callbackUrl com JWT dentro | `~2.3 KB` | **502 (Kong)** | 17 ms |
| JWT real + sem callbackUrl | `n/a` | **200** | 15 ms |

A única variável é o tamanho do `callbackUrl`.

## Fix

Passar `window.location.origin + window.location.pathname` como `callbackUrl` explícito ao chamar `signIn`. O `callbackUrl` no next-auth só é usado para redirecionamento pós-login — o fluxo embedded usa `redirect: false` e o caller (`embedded-auth.ts:30`) só lê `result.ok`, ignorando `result.url`. Mudar pra origin+path é semanticamente equivalente e mantém o cookie `__Secure-next-auth.callback-url` em ~80 B em vez de ~2.3 KB.

Helper `buildEmbeddedCallbackUrl` extraído pra ser testável sem JSDOM.

## Por que isso virou problema agora

PR #199 (CHIPS) adicionou `Partitioned` em **todos** os cookies do next-auth. Cada cookie passa a carregar ~12 bytes extras (`; Partitioned`). Em conjunto com a session-token que cresceu pra carregar `cognitoClaims['custom:eddie_workspaces']` com ~270 chars (usuários ADMIN com muitos workspaces), a soma de Set-Cookie cruzou o threshold do `proxy_buffer_size`.

PRs #198 / #201 (logging) não causaram o bug — apenas tornaram o sintoma visível no console.

## Defesa em profundidade (sugestão para infra, fora desse PR)

Bumpar `proxy_buffer_size` do upstream typebot-builder no Kong para 16 KB ou 32 KB. Evita repetir esse problema se outro cookie crescer no futuro.

## No breaking changes

- ✅ `cloudchatEmbeddedAuthorize` lê o JWT do **body** (`credentials.token`); `callbackUrl` não entra na autenticação.
- ✅ Demais providers (Google/email/custom-oauth) não tocam nesse caminho.
- ✅ Comportamento com `redirect: false` é idêntico — `result.url` continua não sendo lido pelo caller.
- ✅ Reload da iframe: CloudChat sempre seta `src` com `?jwt=...` fresh, então o token chega de novo na URL.
- ✅ Hipotético cenário com `redirect: true` (não usado hoje): usuário seria mandado pra origin/pathname em vez da URL com JWT — ambas são URLs válidas dentro do builder.

## Test plan

- [x] Cobertura unitária de `buildEmbeddedCallbackUrl` (origin+pathname, root pathname, tamanho < 256 B).
- [x] Cobertura unitária de `handleEmbeddedAuthentication` em 6 cenários (callbackUrl propagado, regressão guard "jamais carregar JWT", session válida pula signIn, session stale força signOut+signIn, signIn retornando `ok:false`, signIn throwing).
- [ ] UAT manual: abrir typebot a partir do CloudChat (eddie.us-east-1) com browser sem sessão prévia — deve autenticar sem 502.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Esta PR corrige o erro 502 no fluxo de autenticação embebida do CloudChat causado pelo `callbackUrl` padrão do next-auth (que incluía o JWT Cognito de ~2 KB na query string), fazendo os headers `Set-Cookie` da resposta ultrapassarem o `proxy_buffer_size` de 4 KB do Kong.

- Extrai o helper `buildEmbeddedCallbackUrl` que retorna apenas `origin + pathname`, eliminando a query string com o JWT e mantendo o cookie `__Secure-next-auth.callback-url` em ~80 B em vez de ~2.3 KB.
- Torna `callbackUrl` um parâmetro obrigatório de `handleEmbeddedAuthentication`, forçando todos os callers a fornecer explicitamente uma URL curta.
- Adiciona cobertura unitária abrangente: 3 casos para `buildEmbeddedCallbackUrl` e 6 cenários para `handleEmbeddedAuthentication`, incluindo guard de regressão que impede que o JWT seja propagado no `callbackUrl`.

<h3>Confidence Score: 5/5</h3>

PR seguro para merge. A mudança é cirúrgica e não altera nenhuma lógica de autenticação — apenas controla qual URL é persistida no cookie callbackUrl.

A correção resolve diretamente a causa raiz do 502. A lógica de autenticação em si não foi alterada: callbackUrl não é lida pelo caller e o fluxo usa redirect=false. Os testes cobrem todos os caminhos relevantes, incluindo um guard de regressão explícito que impede que o JWT seja reintroduzido no callbackUrl.

Nenhum arquivo requer atenção especial. Todos os arquivos alterados são pequenos, bem documentados e acompanhados de testes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/builder/src/features/embedded-auth/embedded-auth.ts | Adiciona buildEmbeddedCallbackUrl e torna callbackUrl obrigatório em handleEmbeddedAuthentication. Lógica correta, comentários explicativos adequados, sem problemas identificados. |
| apps/builder/src/hooks/useEmbeddedAuth.ts | Passa buildEmbeddedCallbackUrl(window.location) dentro do useEffect (client-only) — sem risco de SSR. Integração correta com o novo parâmetro obrigatório. |
| apps/builder/src/features/embedded-auth/embedded-auth.test.ts | Cobertura unitária completa: testa buildEmbeddedCallbackUrl, os 6 cenários de handleEmbeddedAuthentication e inclui guard de regressão específico para o bug corrigido. |
| apps/builder/src/features/embedded-auth/index.ts | Reexporta buildEmbeddedCallbackUrl para torná-lo testável fora do módulo. Mudança mínima e correta. |

</details>

<sub>Reviews (1): Last reviewed commit: ["🐛bug: short callbackUrl on embedded sig..."](https://github.com/cloudhumans/typebot.io/commit/989ef28d9e5cb99dec971bc9148f01e7b97b9b3d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32681904)</sub>

<!-- /greptile_comment -->