### PR TITLE
🩹enhancement: log credentialsId+typebot context on missing creds

### DIFF
--- a/apps/viewer/src/app/api/integrations/openai/streamer/route.ts
+++ b/apps/viewer/src/app/api/integrations/openai/streamer/route.ts
@@ -138,7 +138,6 @@ export async function POST(req: Request) {
       logger.error('Could not find credentials in database', {
         credentialsId: block.options.credentialsId,
         typebotId: typebot?.typebotId,
-        publicTypebotId: typebot?.id,
         workspaceId: typebot?.workspaceId,
         workspaceName: typebot?.workspaceName,
         sessionId,

--- a/apps/viewer/src/app/api/integrations/openai/streamer/route.ts
+++ b/apps/viewer/src/app/api/integrations/openai/streamer/route.ts
@@ -88,7 +88,8 @@ export async function POST(req: Request) {
       const stream = await getChatCompletionStream(conn)(
         state,
         block.options as ChatCompletionOpenAIOptions,
-        messages
+        messages,
+        { sessionId, blockId: block.id }
       )
       if (!stream)
         return NextResponse.json(
@@ -138,8 +139,8 @@ export async function POST(req: Request) {
         blockType: block.type,
       })
       return NextResponse.json(
-        { message: 'No credentialsId configured on block' },
-        { status: 400, headers: responseHeaders }
+        { message: 'Block configuration error' },
+        { status: 422, headers: responseHeaders }
       )
     }
     const credentials = (
@@ -159,8 +160,8 @@ export async function POST(req: Request) {
         blockType: block.type,
       })
       return NextResponse.json(
-        { message: 'Could not find credentials in database' },
-        { status: 400, headers: responseHeaders }
+        { message: 'Block configuration error' },
+        { status: 422, headers: responseHeaders }
       )
     }
     const decryptedCredentials = await decryptV2(

--- a/apps/viewer/src/app/api/integrations/openai/streamer/route.ts
+++ b/apps/viewer/src/app/api/integrations/openai/streamer/route.ts
@@ -127,7 +127,21 @@ export async function POST(req: Request) {
     )
 
   try {
-    if (!block.options.credentialsId) return
+    if (!block.options.credentialsId) {
+      const typebot = state.typebotsQueue[0]?.typebot
+      logger.warn('No credentialsId configured on block', {
+        typebotId: typebot?.typebotId,
+        workspaceId: typebot?.workspaceId,
+        workspaceName: typebot?.workspaceName,
+        sessionId,
+        blockId: block.id,
+        blockType: block.type,
+      })
+      return NextResponse.json(
+        { message: 'No credentialsId configured on block' },
+        { status: 400, headers: responseHeaders }
+      )
+    }
     const credentials = (
       await conn.execute('select data, iv from Credentials where id=?', [
         block.options.credentialsId,

--- a/apps/viewer/src/app/api/integrations/openai/streamer/route.ts
+++ b/apps/viewer/src/app/api/integrations/openai/streamer/route.ts
@@ -137,14 +137,18 @@ export async function POST(req: Request) {
       const typebot = state.typebotsQueue[0]?.typebot
       logger.error('Could not find credentials in database', {
         credentialsId: block.options.credentialsId,
-        typebotId: typebot?.id,
+        typebotId: typebot?.typebotId,
+        publicTypebotId: typebot?.id,
         workspaceId: typebot?.workspaceId,
         workspaceName: typebot?.workspaceName,
         sessionId,
         blockId: block.id,
         blockType: block.type,
       })
-      return
+      return NextResponse.json(
+        { message: 'Could not find credentials in database' },
+        { status: 400, headers: responseHeaders }
+      )
     }
     const decryptedCredentials = await decryptV2(
       credentials.data,

--- a/apps/viewer/src/app/api/integrations/openai/streamer/route.ts
+++ b/apps/viewer/src/app/api/integrations/openai/streamer/route.ts
@@ -134,7 +134,16 @@ export async function POST(req: Request) {
       ])
     ).rows.at(0) as { data: string; iv: string } | undefined
     if (!credentials) {
-      logger.error('Could not find credentials in database')
+      const typebot = state.typebotsQueue[0]?.typebot
+      logger.error('Could not find credentials in database', {
+        credentialsId: block.options.credentialsId,
+        typebotId: typebot?.id,
+        workspaceId: typebot?.workspaceId,
+        workspaceName: typebot?.workspaceName,
+        sessionId,
+        blockId: block.id,
+        blockType: block.type,
+      })
       return
     }
     const decryptedCredentials = await decryptV2(

--- a/packages/bot-engine/apiHandlers/getMessageStream.ts
+++ b/packages/bot-engine/apiHandlers/getMessageStream.ts
@@ -57,7 +57,8 @@ export const getMessageStream = async ({
       const stream = await getOpenAIChatCompletionStream(
         session.state,
         block.options as ChatCompletionOpenAIOptions,
-        messages
+        messages,
+        { sessionId, blockId: block.id }
       )
       if (!stream)
         return {

--- a/packages/bot-engine/apiHandlers/legacy/getOpenAIChatCompletionStream.ts
+++ b/packages/bot-engine/apiHandlers/legacy/getOpenAIChatCompletionStream.ts
@@ -20,7 +20,14 @@ export const getOpenAIChatCompletionStream = async (
   if (!options.credentialsId) return
   const credentials = await getCredentials(options.credentialsId)
   if (!credentials) {
-    logger.error('Could not find credentials in database')
+    const typebot = state.typebotsQueue[0]?.typebot
+    logger.error('Could not find credentials in database', {
+      credentialsId: options.credentialsId,
+      typebotId: typebot?.id,
+      workspaceId: typebot?.workspaceId,
+      workspaceName: typebot?.workspaceName,
+      blockType: 'OpenAI (legacy, apiHandler stream)',
+    })
     return
   }
   const { apiKey } = (await decryptV2(

--- a/packages/bot-engine/apiHandlers/legacy/getOpenAIChatCompletionStream.ts
+++ b/packages/bot-engine/apiHandlers/legacy/getOpenAIChatCompletionStream.ts
@@ -15,9 +15,21 @@ import logger from '@typebot.io/lib/logger'
 export const getOpenAIChatCompletionStream = async (
   state: SessionState,
   options: ChatCompletionOpenAIOptions,
-  messages: OpenAI.Chat.ChatCompletionMessageParam[]
+  messages: OpenAI.Chat.ChatCompletionMessageParam[],
+  ctx?: { sessionId?: string; blockId?: string }
 ) => {
-  if (!options.credentialsId) return
+  if (!options.credentialsId) {
+    const typebot = state.typebotsQueue[0]?.typebot
+    logger.warn('No credentialsId configured on block', {
+      typebotId: typebot?.typebotId,
+      workspaceId: typebot?.workspaceId,
+      workspaceName: typebot?.workspaceName,
+      sessionId: ctx?.sessionId,
+      blockId: ctx?.blockId,
+      blockType: 'legacy.openai.api_handler_stream',
+    })
+    return
+  }
   const credentials = await getCredentials(options.credentialsId)
   if (!credentials) {
     const typebot = state.typebotsQueue[0]?.typebot
@@ -26,7 +38,9 @@ export const getOpenAIChatCompletionStream = async (
       typebotId: typebot?.typebotId,
       workspaceId: typebot?.workspaceId,
       workspaceName: typebot?.workspaceName,
-      blockType: 'OpenAI (legacy, apiHandler stream)',
+      sessionId: ctx?.sessionId,
+      blockId: ctx?.blockId,
+      blockType: 'legacy.openai.api_handler_stream',
     })
     return
   }

--- a/packages/bot-engine/apiHandlers/legacy/getOpenAIChatCompletionStream.ts
+++ b/packages/bot-engine/apiHandlers/legacy/getOpenAIChatCompletionStream.ts
@@ -23,7 +23,8 @@ export const getOpenAIChatCompletionStream = async (
     const typebot = state.typebotsQueue[0]?.typebot
     logger.error('Could not find credentials in database', {
       credentialsId: options.credentialsId,
-      typebotId: typebot?.id,
+      typebotId: typebot?.typebotId,
+      publicTypebotId: typebot?.id,
       workspaceId: typebot?.workspaceId,
       workspaceName: typebot?.workspaceName,
       blockType: 'OpenAI (legacy, apiHandler stream)',

--- a/packages/bot-engine/apiHandlers/legacy/getOpenAIChatCompletionStream.ts
+++ b/packages/bot-engine/apiHandlers/legacy/getOpenAIChatCompletionStream.ts
@@ -24,7 +24,6 @@ export const getOpenAIChatCompletionStream = async (
     logger.error('Could not find credentials in database', {
       credentialsId: options.credentialsId,
       typebotId: typebot?.typebotId,
-      publicTypebotId: typebot?.id,
       workspaceId: typebot?.workspaceId,
       workspaceName: typebot?.workspaceName,
       blockType: 'OpenAI (legacy, apiHandler stream)',

--- a/packages/bot-engine/blocks/integrations/legacy/openai/audio/createSpeechOpenAI.ts
+++ b/packages/bot-engine/blocks/integrations/legacy/openai/audio/createSpeechOpenAI.ts
@@ -13,6 +13,7 @@ import { uploadFileToBucket } from '@typebot.io/lib/s3/uploadFileToBucket'
 import { updateVariablesInSession } from '@typebot.io/variables/updateVariablesInSession'
 import { createId } from '@paralleldrive/cuid2'
 import { parseVariables } from '@typebot.io/variables/parseVariables'
+import logger from '@typebot.io/lib/logger'
 
 export const createSpeechOpenAI = async (
   state: SessionState,
@@ -55,7 +56,14 @@ export const createSpeechOpenAI = async (
     },
   })
   if (!credentials) {
-    console.error('Could not find credentials in database')
+    const typebot = newSessionState.typebotsQueue[0]?.typebot
+    logger.error('Could not find credentials in database', {
+      credentialsId: options.credentialsId,
+      typebotId: typebot?.id,
+      workspaceId: typebot?.workspaceId,
+      workspaceName: typebot?.workspaceName,
+      blockType: 'OpenAI Speech (legacy)',
+    })
     return { outgoingEdgeId, logs: [noCredentialsError] }
   }
   const { apiKey } = (await decrypt(

--- a/packages/bot-engine/blocks/integrations/legacy/openai/audio/createSpeechOpenAI.ts
+++ b/packages/bot-engine/blocks/integrations/legacy/openai/audio/createSpeechOpenAI.ts
@@ -59,7 +59,8 @@ export const createSpeechOpenAI = async (
     const typebot = newSessionState.typebotsQueue[0]?.typebot
     logger.error('Could not find credentials in database', {
       credentialsId: options.credentialsId,
-      typebotId: typebot?.id,
+      typebotId: typebot?.typebotId,
+      publicTypebotId: typebot?.id,
       workspaceId: typebot?.workspaceId,
       workspaceName: typebot?.workspaceName,
       blockType: 'OpenAI Speech (legacy)',

--- a/packages/bot-engine/blocks/integrations/legacy/openai/audio/createSpeechOpenAI.ts
+++ b/packages/bot-engine/blocks/integrations/legacy/openai/audio/createSpeechOpenAI.ts
@@ -60,7 +60,6 @@ export const createSpeechOpenAI = async (
     logger.error('Could not find credentials in database', {
       credentialsId: options.credentialsId,
       typebotId: typebot?.typebotId,
-      publicTypebotId: typebot?.id,
       workspaceId: typebot?.workspaceId,
       workspaceName: typebot?.workspaceName,
       blockType: 'OpenAI Speech (legacy)',

--- a/packages/bot-engine/blocks/integrations/legacy/openai/audio/createSpeechOpenAI.ts
+++ b/packages/bot-engine/blocks/integrations/legacy/openai/audio/createSpeechOpenAI.ts
@@ -20,9 +20,13 @@ export const createSpeechOpenAI = async (
   {
     outgoingEdgeId,
     options,
+    blockId,
+    sessionId,
   }: {
     outgoingEdgeId?: string
     options: CreateSpeechOpenAIOptions
+    blockId?: string
+    sessionId?: string
   }
 ): Promise<ExecuteIntegrationResponse> => {
   let newSessionState = state
@@ -45,6 +49,15 @@ export const createSpeechOpenAI = async (
   }
 
   if (!options.credentialsId) {
+    const typebot = newSessionState.typebotsQueue[0]?.typebot
+    logger.warn('No credentialsId configured on block', {
+      typebotId: typebot?.typebotId,
+      workspaceId: typebot?.workspaceId,
+      workspaceName: typebot?.workspaceName,
+      sessionId,
+      blockId,
+      blockType: 'legacy.openai.speech',
+    })
     return {
       outgoingEdgeId,
       logs: [noCredentialsError],
@@ -62,7 +75,9 @@ export const createSpeechOpenAI = async (
       typebotId: typebot?.typebotId,
       workspaceId: typebot?.workspaceId,
       workspaceName: typebot?.workspaceName,
-      blockType: 'OpenAI Speech (legacy)',
+      sessionId,
+      blockId,
+      blockType: 'legacy.openai.speech',
     })
     return { outgoingEdgeId, logs: [noCredentialsError] }
   }

--- a/packages/bot-engine/blocks/integrations/legacy/openai/createChatCompletionOpenAI.ts
+++ b/packages/bot-engine/blocks/integrations/legacy/openai/createChatCompletionOpenAI.ts
@@ -30,10 +30,12 @@ export const createChatCompletionOpenAI = async (
     outgoingEdgeId,
     options,
     blockId,
+    sessionId,
   }: {
     outgoingEdgeId?: string
     options: ChatCompletionOpenAIOptions
     blockId: string
+    sessionId?: string
   }
 ): Promise<ExecuteIntegrationResponse> => {
   let newSessionState = state
@@ -43,6 +45,15 @@ export const createChatCompletionOpenAI = async (
   }
 
   if (!options.credentialsId) {
+    const typebot = newSessionState.typebotsQueue[0]?.typebot
+    logger.warn('No credentialsId configured on block', {
+      typebotId: typebot?.typebotId,
+      workspaceId: typebot?.workspaceId,
+      workspaceName: typebot?.workspaceName,
+      sessionId,
+      blockId,
+      blockType: 'legacy.openai.chat_completion',
+    })
     return {
       outgoingEdgeId,
       logs: [noCredentialsError],
@@ -60,8 +71,9 @@ export const createChatCompletionOpenAI = async (
       typebotId: typebot?.typebotId,
       workspaceId: typebot?.workspaceId,
       workspaceName: typebot?.workspaceName,
+      sessionId,
       blockId,
-      blockType: 'OpenAI (legacy)',
+      blockType: 'legacy.openai.chat_completion',
     })
     return { outgoingEdgeId, logs: [noCredentialsError] }
   }

--- a/packages/bot-engine/blocks/integrations/legacy/openai/createChatCompletionOpenAI.ts
+++ b/packages/bot-engine/blocks/integrations/legacy/openai/createChatCompletionOpenAI.ts
@@ -54,7 +54,15 @@ export const createChatCompletionOpenAI = async (
     },
   })
   if (!credentials) {
-    logger.error('Could not find credentials in database')
+    const typebot = newSessionState.typebotsQueue[0]?.typebot
+    logger.error('Could not find credentials in database', {
+      credentialsId: options.credentialsId,
+      typebotId: typebot?.id,
+      workspaceId: typebot?.workspaceId,
+      workspaceName: typebot?.workspaceName,
+      blockId,
+      blockType: 'OpenAI (legacy)',
+    })
     return { outgoingEdgeId, logs: [noCredentialsError] }
   }
   const { apiKey } = (await decrypt(

--- a/packages/bot-engine/blocks/integrations/legacy/openai/createChatCompletionOpenAI.ts
+++ b/packages/bot-engine/blocks/integrations/legacy/openai/createChatCompletionOpenAI.ts
@@ -58,7 +58,6 @@ export const createChatCompletionOpenAI = async (
     logger.error('Could not find credentials in database', {
       credentialsId: options.credentialsId,
       typebotId: typebot?.typebotId,
-      publicTypebotId: typebot?.id,
       workspaceId: typebot?.workspaceId,
       workspaceName: typebot?.workspaceName,
       blockId,

--- a/packages/bot-engine/blocks/integrations/legacy/openai/createChatCompletionOpenAI.ts
+++ b/packages/bot-engine/blocks/integrations/legacy/openai/createChatCompletionOpenAI.ts
@@ -57,7 +57,8 @@ export const createChatCompletionOpenAI = async (
     const typebot = newSessionState.typebotsQueue[0]?.typebot
     logger.error('Could not find credentials in database', {
       credentialsId: options.credentialsId,
-      typebotId: typebot?.id,
+      typebotId: typebot?.typebotId,
+      publicTypebotId: typebot?.id,
       workspaceId: typebot?.workspaceId,
       workspaceName: typebot?.workspaceName,
       blockId,

--- a/packages/bot-engine/blocks/integrations/legacy/openai/executeOpenAIBlock.ts
+++ b/packages/bot-engine/blocks/integrations/legacy/openai/executeOpenAIBlock.ts
@@ -6,7 +6,8 @@ import { createSpeechOpenAI } from './audio/createSpeechOpenAI'
 
 export const executeOpenAIBlock = async (
   state: SessionState,
-  block: OpenAIBlock
+  block: OpenAIBlock,
+  sessionId?: string
 ): Promise<ExecuteIntegrationResponse> => {
   switch (block.options?.task) {
     case 'Create chat completion':
@@ -14,11 +15,14 @@ export const executeOpenAIBlock = async (
         options: block.options,
         outgoingEdgeId: block.outgoingEdgeId,
         blockId: block.id,
+        sessionId,
       })
     case 'Create speech':
       return createSpeechOpenAI(state, {
         options: block.options,
         outgoingEdgeId: block.outgoingEdgeId,
+        blockId: block.id,
+        sessionId,
       })
     case 'Create image':
     case undefined:

--- a/packages/bot-engine/blocks/integrations/legacy/openai/getChatCompletionStream.ts
+++ b/packages/bot-engine/blocks/integrations/legacy/openai/getChatCompletionStream.ts
@@ -10,6 +10,7 @@ import { OpenAIStream } from 'ai'
 import { parseVariableNumber } from '@typebot.io/variables/parseVariableNumber'
 import { ClientOptions, OpenAI } from 'openai'
 import { defaultOpenAIOptions } from '@typebot.io/schemas/features/blocks/integrations/openai/constants'
+import logger from '@typebot.io/lib/logger'
 
 export const getChatCompletionStream =
   (conn: Connection) =>
@@ -25,7 +26,14 @@ export const getChatCompletionStream =
       ])
     ).rows.at(0) as { data: string; iv: string } | undefined
     if (!credentials) {
-      console.error('Could not find credentials in database')
+      const typebot = state.typebotsQueue[0]?.typebot
+      logger.error('Could not find credentials in database', {
+        credentialsId: options.credentialsId,
+        typebotId: typebot?.id,
+        workspaceId: typebot?.workspaceId,
+        workspaceName: typebot?.workspaceName,
+        blockType: 'OpenAI (legacy, planetscale stream)',
+      })
       return
     }
     const { apiKey } = (await decryptV2(

--- a/packages/bot-engine/blocks/integrations/legacy/openai/getChatCompletionStream.ts
+++ b/packages/bot-engine/blocks/integrations/legacy/openai/getChatCompletionStream.ts
@@ -17,9 +17,21 @@ export const getChatCompletionStream =
   async (
     state: SessionState,
     options: ChatCompletionOpenAIOptions,
-    messages: OpenAI.Chat.ChatCompletionMessageParam[]
+    messages: OpenAI.Chat.ChatCompletionMessageParam[],
+    ctx?: { sessionId?: string; blockId?: string }
   ) => {
-    if (!options.credentialsId) return
+    if (!options.credentialsId) {
+      const typebot = state.typebotsQueue[0]?.typebot
+      logger.warn('No credentialsId configured on block', {
+        typebotId: typebot?.typebotId,
+        workspaceId: typebot?.workspaceId,
+        workspaceName: typebot?.workspaceName,
+        sessionId: ctx?.sessionId,
+        blockId: ctx?.blockId,
+        blockType: 'legacy.openai.chat_stream',
+      })
+      return
+    }
     const credentials = (
       await conn.execute('select data, iv from Credentials where id=?', [
         options.credentialsId,
@@ -32,7 +44,9 @@ export const getChatCompletionStream =
         typebotId: typebot?.typebotId,
         workspaceId: typebot?.workspaceId,
         workspaceName: typebot?.workspaceName,
-        blockType: 'OpenAI (legacy, planetscale stream)',
+        sessionId: ctx?.sessionId,
+        blockId: ctx?.blockId,
+        blockType: 'legacy.openai.chat_stream',
       })
       return
     }

--- a/packages/bot-engine/blocks/integrations/legacy/openai/getChatCompletionStream.ts
+++ b/packages/bot-engine/blocks/integrations/legacy/openai/getChatCompletionStream.ts
@@ -29,7 +29,8 @@ export const getChatCompletionStream =
       const typebot = state.typebotsQueue[0]?.typebot
       logger.error('Could not find credentials in database', {
         credentialsId: options.credentialsId,
-        typebotId: typebot?.id,
+        typebotId: typebot?.typebotId,
+        publicTypebotId: typebot?.id,
         workspaceId: typebot?.workspaceId,
         workspaceName: typebot?.workspaceName,
         blockType: 'OpenAI (legacy, planetscale stream)',

--- a/packages/bot-engine/blocks/integrations/legacy/openai/getChatCompletionStream.ts
+++ b/packages/bot-engine/blocks/integrations/legacy/openai/getChatCompletionStream.ts
@@ -30,7 +30,6 @@ export const getChatCompletionStream =
       logger.error('Could not find credentials in database', {
         credentialsId: options.credentialsId,
         typebotId: typebot?.typebotId,
-        publicTypebotId: typebot?.id,
         workspaceId: typebot?.workspaceId,
         workspaceName: typebot?.workspaceName,
         blockType: 'OpenAI (legacy, planetscale stream)',

--- a/packages/bot-engine/executeIntegration.ts
+++ b/packages/bot-engine/executeIntegration.ts
@@ -47,7 +47,7 @@ export const executeIntegration =
         }
       case IntegrationBlockType.OPEN_AI:
         return {
-          ...(await executeOpenAIBlock(state, block)),
+          ...(await executeOpenAIBlock(state, block, sessionId)),
           startTimeShouldBeUpdated: true,
         }
       case IntegrationBlockType.PIXEL:

--- a/packages/bot-engine/forge/executeForgedBlock.ts
+++ b/packages/bot-engine/forge/executeForgedBlock.ts
@@ -53,7 +53,8 @@ export const executeForgedBlock = async (
       const typebot = state.typebotsQueue[0]?.typebot
       logger.error('Could not find credentials in database', {
         credentialsId: block.options.credentialsId,
-        typebotId: typebot?.id,
+        typebotId: typebot?.typebotId,
+        publicTypebotId: typebot?.id,
         workspaceId: typebot?.workspaceId,
         workspaceName: typebot?.workspaceName,
         sessionId,

--- a/packages/bot-engine/forge/executeForgedBlock.ts
+++ b/packages/bot-engine/forge/executeForgedBlock.ts
@@ -50,7 +50,16 @@ export const executeForgedBlock = async (
     }
     credentials = await getCredentials(block.options.credentialsId)
     if (!credentials) {
-      logger.error('Could not find credentials in database')
+      const typebot = state.typebotsQueue[0]?.typebot
+      logger.error('Could not find credentials in database', {
+        credentialsId: block.options.credentialsId,
+        typebotId: typebot?.id,
+        workspaceId: typebot?.workspaceId,
+        workspaceName: typebot?.workspaceName,
+        sessionId,
+        blockId: block.id,
+        blockType: block.type,
+      })
       return {
         outgoingEdgeId: block.outgoingEdgeId,
         logs: [noCredentialsError],

--- a/packages/bot-engine/forge/executeForgedBlock.ts
+++ b/packages/bot-engine/forge/executeForgedBlock.ts
@@ -43,6 +43,15 @@ export const executeForgedBlock = async (
   let credentials: { data: string; iv: string } | null = null
   if (blockDef.auth) {
     if (!block.options.credentialsId) {
+      const typebot = state.typebotsQueue[0]?.typebot
+      logger.warn('No credentialsId configured on block', {
+        typebotId: typebot?.typebotId,
+        workspaceId: typebot?.workspaceId,
+        workspaceName: typebot?.workspaceName,
+        sessionId,
+        blockId: block.id,
+        blockType: `forge.${block.type}`,
+      })
       return {
         outgoingEdgeId: block.outgoingEdgeId,
         logs: [noCredentialsError],
@@ -58,7 +67,7 @@ export const executeForgedBlock = async (
         workspaceName: typebot?.workspaceName,
         sessionId,
         blockId: block.id,
-        blockType: block.type,
+        blockType: `forge.${block.type}`,
       })
       return {
         outgoingEdgeId: block.outgoingEdgeId,

--- a/packages/bot-engine/forge/executeForgedBlock.ts
+++ b/packages/bot-engine/forge/executeForgedBlock.ts
@@ -54,7 +54,6 @@ export const executeForgedBlock = async (
       logger.error('Could not find credentials in database', {
         credentialsId: block.options.credentialsId,
         typebotId: typebot?.typebotId,
-        publicTypebotId: typebot?.id,
         workspaceId: typebot?.workspaceId,
         workspaceName: typebot?.workspaceName,
         sessionId,


### PR DESCRIPTION
Card #6793 (originalmente sobre timeouts em `typebot-instance2`) já tinha o problema raiz resolvido — zero `ReadTimeoutException` desde 2026-05-01. Mas a investigação revelou um spike novo hoje (2026-05-21): **2.000+ erros `Could not find credentials in database`** em ~6h sem nenhum atributo (`credentialsId`, `typebotId`, `workspaceId`), impossibilitando identificar o cliente afetado ou a credencial órfã.

Substitui os 6 sites de lookup de credencial (1 forge + 5 paths legacy OpenAI) que faziam `logger.error('Could not find credentials in database')` ou `console.error(...)` cru por logs estruturados carregando `credentialsId`, `typebotId`, `workspaceId`, `workspaceName`, e quando disponível `sessionId`/`blockId`/`blockType`.

Sites:
- `packages/bot-engine/forge/executeForgedBlock.ts`
- `packages/bot-engine/blocks/integrations/legacy/openai/createChatCompletionOpenAI.ts`
- `packages/bot-engine/blocks/integrations/legacy/openai/getChatCompletionStream.ts`
- `packages/bot-engine/blocks/integrations/legacy/openai/audio/createSpeechOpenAI.ts`
- `packages/bot-engine/apiHandlers/legacy/getOpenAIChatCompletionStream.ts`
- `apps/viewer/src/app/api/integrations/openai/streamer/route.ts`

Mesma receita do #194 — volume de erros inalterado, mas investigações futuras conseguem apontar o `credentialsId` órfão e o workspace afetado em segundos.

Refs: cloudhumans/ClaudIA #6793

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Route as route.ts (legado)
    participant Engine as executeIntegration
    participant Block as executeOpenAIBlock / executeForgedBlock
    participant DB as Credentials DB

    Client->>Route: POST /api/integrations/openai/streamer
    Route->>DB: SELECT credentialsId
    alt !credentialsId
        Route-->>Client: 422 + logger.warn(typebotId, workspaceId, sessionId...)
    else credentialsId existe
        DB-->>Route: credentials row
        alt !credentials
            Route-->>Client: 422 + logger.error(credentialsId, typebotId, workspaceId...)
        else credentials encontrada
            Route-->>Client: StreamingTextResponse
        end
    end

    Client->>Engine: executeIntegration(state, block, sessionId)
    Engine->>Block: executeOpenAIBlock(state, block, sessionId)
    Block->>DB: getCredentials(credentialsId)
    alt !credentialsId
        Block-->>Engine: logs + logger.warn(typebotId, sessionId, blockId...)
    else !credentials
        Block-->>Engine: logs + logger.error(credentialsId, typebotId, sessionId...)
    else OK
        Block-->>Engine: ExecuteIntegrationResponse
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/viewer/src/app/api/integrations/openai/streamer/route.ts`, line 130 ([link](https://github.com/cloudhumans/typebot.io/blob/8663beb46bd7627f3409359488a972ad7f07d6b0/apps/viewer/src/app/api/integrations/openai/streamer/route.ts#L130)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`return` sem resposta quando `credentialsId` está ausente**

   Na linha imediatamente anterior ao bloco alterado, o `if (!block.options.credentialsId) return` ainda faz um retorno sem resposta HTTP. Com a mudança neste PR, o bloco `!credentials` agora retorna um 400 adequado, mas o caso `!credentialsId` continua silencioso — o cliente recebe uma resposta vazia ou o Next.js gera um erro de runtime. Considere retornar também um 400 nesse caminho.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/viewer/src/app/api/integrations/openai/streamer/route.ts
   Line: 130

   Comment:
   **`return` sem resposta quando `credentialsId` está ausente**

   Na linha imediatamente anterior ao bloco alterado, o `if (!block.options.credentialsId) return` ainda faz um retorno sem resposta HTTP. Com a mudança neste PR, o bloco `!credentials` agora retorna um 400 adequado, mas o caso `!credentialsId` continua silencioso — o cliente recebe uma resposta vazia ou o Next.js gera um erro de runtime. Considere retornar também um 400 nesse caminho.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fviewer%2Fsrc%2Fapp%2Fapi%2Fintegrations%2Fopenai%2Fstreamer%2Froute.ts%0ALine%3A%20130%0A%0AComment%3A%0A**%60return%60%20sem%20resposta%20quando%20%60credentialsId%60%20est%C3%A1%20ausente**%0A%0ANa%20linha%20imediatamente%20anterior%20ao%20bloco%20alterado%2C%20o%20%60if%20%28!block.options.credentialsId%29%20return%60%20ainda%20faz%20um%20retorno%20sem%20resposta%20HTTP.%20Com%20a%20mudan%C3%A7a%20neste%20PR%2C%20o%20bloco%20%60!credentials%60%20agora%20retorna%20um%20400%20adequado%2C%20mas%20o%20caso%20%60!credentialsId%60%20continua%20silencioso%20%E2%80%94%20o%20cliente%20recebe%20uma%20resposta%20vazia%20ou%20o%20Next.js%20gera%20um%20erro%20de%20runtime.%20Considere%20retornar%20tamb%C3%A9m%20um%20400%20nesse%20caminho.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20%28!block.options.credentialsId%29%0A%20%20%20%20%20%20return%20NextResponse.json%28%0A%20%20%20%20%20%20%20%20%7B%20message%3A%20'Missing%20credentialsId'%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%20status%3A%20400%2C%20headers%3A%20responseHeaders%20%7D%0A%20%20%20%20%20%20%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudhumans%2Ftypebot.io&pr=204&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fviewer%2Fsrc%2Fapp%2Fapi%2Fintegrations%2Fopenai%2Fstreamer%2Froute.ts%0ALine%3A%20130%0A%0AComment%3A%0A**%60return%60%20sem%20resposta%20quando%20%60credentialsId%60%20est%C3%A1%20ausente**%0A%0ANa%20linha%20imediatamente%20anterior%20ao%20bloco%20alterado%2C%20o%20%60if%20%28!block.options.credentialsId%29%20return%60%20ainda%20faz%20um%20retorno%20sem%20resposta%20HTTP.%20Com%20a%20mudan%C3%A7a%20neste%20PR%2C%20o%20bloco%20%60!credentials%60%20agora%20retorna%20um%20400%20adequado%2C%20mas%20o%20caso%20%60!credentialsId%60%20continua%20silencioso%20%E2%80%94%20o%20cliente%20recebe%20uma%20resposta%20vazia%20ou%20o%20Next.js%20gera%20um%20erro%20de%20runtime.%20Considere%20retornar%20tamb%C3%A9m%20um%20400%20nesse%20caminho.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20%28!block.options.credentialsId%29%0A%20%20%20%20%20%20return%20NextResponse.json%28%0A%20%20%20%20%20%20%20%20%7B%20message%3A%20'Missing%20credentialsId'%20%7D%2C%0A%20%20%20%20%20%20%20%20%7B%20status%3A%20400%2C%20headers%3A%20responseHeaders%20%7D%0A%20%20%20%20%20%20%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=204&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["🩹enhancement: address Gustavo deep revi..."](https://github.com/cloudhumans/typebot.io/commit/db38538bacffd9c487c042e38ecc0b73242444d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33314817)</sub>

<!-- /greptile_comment -->