### PR TITLE
feat(typebot): add pagination support to listTypebots API and notify …

### DIFF
--- a/apps/builder/src/features/publish/components/PublishButton.tsx
+++ b/apps/builder/src/features/publish/components/PublishButton.tsx
@@ -95,6 +95,16 @@ export const PublishButton = ({
         invalidateTypebotHistory({
           typebotId: typebot?.id as string,
         })
+        // In embedded mode, notify the host so it can show feedback and navigate
+        if (query.embedded && typeof window !== 'undefined' && window.parent) {
+          window.parent.postMessage(
+            {
+              type: 'typebot:published',
+              typebotId: typebot?.id ?? (query.typebotId as string | undefined),
+            },
+            '*'
+          )
+        }
         // Only redirect if not in embedded mode
         if (!publishedTypebot && !pathname.endsWith('share') && !query.embedded)
           push(`/typebots/${query.typebotId}/share`)

--- a/apps/builder/src/features/typebot/api/listTypebots.ts
+++ b/apps/builder/src/features/typebot/api/listTypebots.ts
@@ -35,6 +35,8 @@ export const listTypebots = authenticatedProcedure
         .optional(),
       createdAtFrom: z.string().datetime().optional(),
       createdAtTo: z.string().datetime().optional(),
+      page: z.coerce.number().int().positive().optional(),
+      per_page: z.coerce.number().int().positive().max(500).optional(),
     })
   )
   .output(
@@ -46,9 +48,16 @@ export const listTypebots = authenticatedProcedure
             icon: true,
             id: true,
             createdAt: true,
+            updatedAt: true,
           })
           .merge(z.object({ publishedTypebotId: z.string().optional() }))
       ),
+      meta: z.object({
+        total_count: z.number().int().nonnegative(),
+        current_page: z.number().int().positive(),
+        per_page: z.number().int().positive(),
+        total_pages: z.number().int().nonnegative(),
+      }),
     })
   )
   .query(
@@ -60,6 +69,8 @@ export const listTypebots = authenticatedProcedure
         status,
         createdAtFrom,
         createdAtTo,
+        page,
+        per_page,
       },
       ctx: { user },
     }) => {
@@ -115,43 +126,61 @@ export const listTypebots = authenticatedProcedure
 
       const trimmedSearch = search?.trim()
 
-      const typebots = await prisma.typebot.findMany({
-        where: {
-          isArchived: { not: true },
-          folderId:
-            userRole === WorkspaceRole.GUEST
-              ? undefined
-              : folderId === 'root'
-              ? null
-              : folderId,
-          workspaceId,
-          collaborators:
-            userRole === WorkspaceRole.GUEST
-              ? { some: { userId: user.id } }
-              : undefined,
-          ...(trimmedSearch
-            ? {
-                name: { contains: trimmedSearch, mode: 'insensitive' as const },
-              }
-            : {}),
-          ...(statusConditions.length > 0 ? { OR: statusConditions } : {}),
-          ...(createdAtFilter ? { createdAt: createdAtFilter } : {}),
-        },
-        orderBy: { createdAt: 'desc' },
-        select: {
-          name: true,
-          publishedTypebot: { select: { id: true } },
-          id: true,
-          icon: true,
-          createdAt: true,
-        },
-      })
+      const where = {
+        isArchived: { not: true },
+        folderId:
+          userRole === WorkspaceRole.GUEST
+            ? undefined
+            : folderId === 'root'
+            ? null
+            : folderId,
+        workspaceId,
+        collaborators:
+          userRole === WorkspaceRole.GUEST
+            ? { some: { userId: user.id } }
+            : undefined,
+        ...(trimmedSearch
+          ? {
+              name: { contains: trimmedSearch, mode: 'insensitive' as const },
+            }
+          : {}),
+        ...(statusConditions.length > 0 ? { OR: statusConditions } : {}),
+        ...(createdAtFilter ? { createdAt: createdAtFilter } : {}),
+      }
+
+      const currentPage = page ?? 1
+      const perPage = per_page ?? 25
+      const skip = (currentPage - 1) * perPage
+
+      const [totalCount, typebots] = await prisma.$transaction([
+        prisma.typebot.count({ where }),
+        prisma.typebot.findMany({
+          where,
+          orderBy: { createdAt: 'desc' },
+          skip,
+          take: perPage,
+          select: {
+            name: true,
+            publishedTypebot: { select: { id: true } },
+            id: true,
+            icon: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        }),
+      ])
 
       return {
         typebots: typebots.map((typebot) => ({
           publishedTypebotId: typebot.publishedTypebot?.id,
           ...omit(typebot, 'publishedTypebot'),
         })),
+        meta: {
+          total_count: totalCount,
+          current_page: currentPage,
+          per_page: perPage,
+          total_pages: totalCount === 0 ? 0 : Math.ceil(totalCount / perPage),
+        },
       }
     }
   )


### PR DESCRIPTION
…host on publish in embedded mode

<!-- greptile_comment -->

<details open><summary><h3>Security Review</h3></summary>

- **Origem irrestrita no `postMessage`** (`PublishButton.tsx`): A mensagem `typebot:published` contendo o `typebotId` é enviada com `targetOrigin: '*'`, o que permite que qualquer página pai, independentemente do domínio, receba o evento. Recomenda-se usar uma origem específica (ex: derivada de `document.referrer`) para limitar o escopo do destinatário.
</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Cliente (API)
    participant API as listTypebots /v1/typebots
    participant DB as Prisma / DB

    Client->>API: "GET /v1/typebots?workspaceId=X&page=2&per_page=10"
    API->>DB: "$transaction([count(where), findMany(where, skip=10, take=10)])"
    DB-->>API: [totalCount, typebots[]]
    API-->>Client: "{ typebots[], meta: { total_count, current_page, per_page, total_pages } }"

    Note over Client,API: Sem page/per_page -> page=1, per_page=25 (quebra clientes antigos)

    participant Host as Janela Host (iframe parent)
    participant Builder as Builder (modo embutido)

    Builder->>Builder: publishTypebotMutate()
    Builder-->>Host: "window.parent.postMessage({ type: typebot:published, typebotId }, *)"
    Note over Builder,Host: targetOrigin='*' envia para qualquer origem
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fpublish%2Fcomponents%2FPublishButton.tsx%3A100-106%0AEnviar%20%60postMessage%60%20com%20a%20origem%20%60'*'%60%20significa%20que%20qualquer%20janela%20pai%2C%20de%20qualquer%20dom%C3%ADnio%2C%20receber%C3%A1%20a%20mensagem%20com%20o%20%60typebotId%60.%20O%20correto%20%C3%A9%20especificar%20a%20origem%20esperada%20do%20host%20embutido%20para%20evitar%20que%20p%C3%A1ginas%20maliciosas%20interceptem%20o%20evento.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20window.parent.postMessage%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20type%3A%20'typebot%3Apublished'%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20typebotId%3A%20typebot%3F.id%20%3F%3F%20%28query.typebotId%20as%20string%20%7C%20undefined%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20document.referrer%20%3F%20new%20URL%28document.referrer%29.origin%20%3A%20'*'%0A%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Ftypebot%2Fapi%2FlistTypebots.ts%3A151-153%0A**Mudan%C3%A7a%20silenciosamente%20destrutiva%20no%20comportamento%20padr%C3%A3o**%0A%0AAntes%20desta%20PR%2C%20a%20API%20retornava%20**todos**%20os%20typebots%20de%20um%20workspace%20em%20uma%20%C3%BAnica%20chamada.%20Agora%2C%20sem%20passar%20%60page%60%20ou%20%60per_page%60%2C%20o%20padr%C3%A3o%20%C3%A9%20%60page%3D1%2C%20per_page%3D25%60%2C%20fazendo%20com%20que%20integra%C3%A7%C3%B5es%20existentes%20recebam%20apenas%20os%2025%20primeiros%20resultados%20sem%20qualquer%20indica%C3%A7%C3%A3o%20de%20que%20h%C3%A1%20dados%20faltando.%20Como%20este%20endpoint%20%C3%A9%20exposto%20publicamente%20em%20%60%2Fv1%2Ftypebots%60%2C%20clientes%20que%20j%C3%A1%20consomem%20a%20API%20ser%C3%A3o%20afetados%20silenciosamente.%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=205&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fpublish%2Fcomponents%2FPublishButton.tsx%3A100-106%0AEnviar%20%60postMessage%60%20com%20a%20origem%20%60'*'%60%20significa%20que%20qualquer%20janela%20pai%2C%20de%20qualquer%20dom%C3%ADnio%2C%20receber%C3%A1%20a%20mensagem%20com%20o%20%60typebotId%60.%20O%20correto%20%C3%A9%20especificar%20a%20origem%20esperada%20do%20host%20embutido%20para%20evitar%20que%20p%C3%A1ginas%20maliciosas%20interceptem%20o%20evento.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20window.parent.postMessage%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20type%3A%20'typebot%3Apublished'%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20typebotId%3A%20typebot%3F.id%20%3F%3F%20%28query.typebotId%20as%20string%20%7C%20undefined%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20document.referrer%20%3F%20new%20URL%28document.referrer%29.origin%20%3A%20'*'%0A%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Ftypebot%2Fapi%2FlistTypebots.ts%3A151-153%0A**Mudan%C3%A7a%20silenciosamente%20destrutiva%20no%20comportamento%20padr%C3%A3o**%0A%0AAntes%20desta%20PR%2C%20a%20API%20retornava%20**todos**%20os%20typebots%20de%20um%20workspace%20em%20uma%20%C3%BAnica%20chamada.%20Agora%2C%20sem%20passar%20%60page%60%20ou%20%60per_page%60%2C%20o%20padr%C3%A3o%20%C3%A9%20%60page%3D1%2C%20per_page%3D25%60%2C%20fazendo%20com%20que%20integra%C3%A7%C3%B5es%20existentes%20recebam%20apenas%20os%2025%20primeiros%20resultados%20sem%20qualquer%20indica%C3%A7%C3%A3o%20de%20que%20h%C3%A1%20dados%20faltando.%20Como%20este%20endpoint%20%C3%A9%20exposto%20publicamente%20em%20%60%2Fv1%2Ftypebots%60%2C%20clientes%20que%20j%C3%A1%20consomem%20a%20API%20ser%C3%A3o%20afetados%20silenciosamente.%0A%0A&pr=205&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/builder/src/features/publish/components/PublishButton.tsx:100-106
Enviar `postMessage` com a origem `'*'` significa que qualquer janela pai, de qualquer domínio, receberá a mensagem com o `typebotId`. O correto é especificar a origem esperada do host embutido para evitar que páginas maliciosas interceptem o evento.

```suggestion
          window.parent.postMessage(
            {
              type: 'typebot:published',
              typebotId: typebot?.id ?? (query.typebotId as string | undefined),
            },
            document.referrer ? new URL(document.referrer).origin : '*'
          )
```

### Issue 2 of 2
apps/builder/src/features/typebot/api/listTypebots.ts:151-153
**Mudança silenciosamente destrutiva no comportamento padrão**

Antes desta PR, a API retornava **todos** os typebots de um workspace em uma única chamada. Agora, sem passar `page` ou `per_page`, o padrão é `page=1, per_page=25`, fazendo com que integrações existentes recebam apenas os 25 primeiros resultados sem qualquer indicação de que há dados faltando. Como este endpoint é exposto publicamente em `/v1/typebots`, clientes que já consomem a API serão afetados silenciosamente.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(typebot): add pagination support to..."](https://github.com/cloudhumans/typebot.io/commit/242064c213b26a09f67de83cb9b771da3466731d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33499741)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->