### PR TITLE
feat(mcp): inject x-eddie-workspace-id as prefilledVariable

### DIFF
--- a/apps/builder/src/pages/api/mcp.ts
+++ b/apps/builder/src/pages/api/mcp.ts
@@ -142,10 +142,21 @@ export default async function handler(
         }
 
         const { name, arguments: args } = params || {}
-        const eddieWorkspaceId = req.headers['x-eddie-workspace-id'] as
-          | string
-          | undefined
-        logger.info('MCP tools/call', { tenant, toolName: name, requestId: id })
+        // Header values can be `string | string[] | undefined` (e.g. when a
+        // misconfigured proxy sends the header twice). Normalize to a single
+        // string before propagating; an empty string also collapses to
+        // undefined so the prefilled variable is never set to "".
+        const rawEddieHeader = req.headers['x-eddie-workspace-id']
+        const eddieWorkspaceId =
+          (Array.isArray(rawEddieHeader)
+            ? rawEddieHeader[0]
+            : rawEddieHeader) || undefined
+        logger.info('MCP tools/call', {
+          tenant,
+          toolName: name,
+          eddieWorkspaceId,
+          requestId: id,
+        })
 
         const { tools } = await getWorkflowTools({ tenant })
         const tool = tools.find((t) => sanitizeToolName(t.name) === name)
@@ -167,8 +178,26 @@ export default async function handler(
           })
         }
 
+        // `args` originates from the JSON-RPC body, which is caller-controlled
+        // (LLM tool call arguments or direct MCP client). Workspace identity
+        // is an infra decision that must come from the header — strip the
+        // reserved `_eddie_workspace_id` so a caller cannot spoof it via the
+        // body. Also defends against prototype pollution via `__proto__` /
+        // `constructor` / `prototype` keys leaking into the prefilled
+        // variables map.
+        const RESERVED_PREFILLED_KEYS = new Set([
+          '_eddie_workspace_id',
+          '__proto__',
+          'constructor',
+          'prototype',
+        ])
+        const sanitizedArgs = Object.fromEntries(
+          Object.entries((args as Record<string, unknown>) ?? {}).filter(
+            ([key]) => !RESERVED_PREFILLED_KEYS.has(key)
+          )
+        )
         const prefilledVariables: Record<string, unknown> = {
-          ...(args as Record<string, unknown>),
+          ...sanitizedArgs,
           ...(eddieWorkspaceId
             ? { _eddie_workspace_id: eddieWorkspaceId }
             : {}),

--- a/apps/builder/src/pages/api/mcp.ts
+++ b/apps/builder/src/pages/api/mcp.ts
@@ -26,7 +26,7 @@ export default async function handler(
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS')
   res.setHeader(
     'Access-Control-Allow-Headers',
-    'Content-Type, x-tenant, tenant, mcp-session-id, Authorization, X-MCP-Access-Token, x-include-drafts'
+    'Content-Type, x-tenant, tenant, mcp-session-id, Authorization, X-MCP-Access-Token, x-include-drafts, x-eddie-workspace-id'
   )
 
   if (req.method === 'OPTIONS') {
@@ -142,6 +142,9 @@ export default async function handler(
         }
 
         const { name, arguments: args } = params || {}
+        const eddieWorkspaceId = req.headers['x-eddie-workspace-id'] as
+          | string
+          | undefined
         logger.info('MCP tools/call', { tenant, toolName: name, requestId: id })
 
         const { tools } = await getWorkflowTools({ tenant })
@@ -164,10 +167,17 @@ export default async function handler(
           })
         }
 
+        const prefilledVariables: Record<string, unknown> = {
+          ...(args as Record<string, unknown>),
+          ...(eddieWorkspaceId
+            ? { _eddie_workspace_id: eddieWorkspaceId }
+            : {}),
+        }
+
         const startTime = Date.now()
         const result = await executeWorkflow({
           publicId: tool.publicName,
-          prefilledVariables: args as Record<string, unknown>,
+          prefilledVariables,
         })
         const durationMs = Date.now() - startTime
 


### PR DESCRIPTION
## Why

Part of the cross-repo rollout that replaces the implicit `project_name → workspaceId` name-match with an explicit `workspaceId` (cuid) end-to-end. The Eddie/Typebot workspace identifier flows now as a HTTP header all the way from `claudia-app` → `claudia` web-api → `claudia-agentic` → MCP proxy → this repo.

## What

`/api/mcp.ts` tools/call handler now:

- Reads the `x-eddie-workspace-id` request header.
- Injects its value as the reserved `_eddie_workspace_id` prefilledVariable on the call to `executeWorkflow(...)`.
- Adds `x-eddie-workspace-id` to the `Access-Control-Allow-Headers` CORS allowlist.

Backward-compatible: when the header is absent (existing deploys, OAP, claude.ai) the prefilledVariable is simply not added — existing flows continue to work unchanged.

## Companion runtime change (not in this PR)

To actually consume the cuid, the GAD `criador-de-tools`, `migrador-de-tools` and `criador-de-agentes` typebot flows need to be edited in the builder UI to read `{_eddie_workspace_id}` (with a `{project_name}` name-match fallback during the rollout window). That edit lives in Postgres data, not in this repo.

## Cross-repo PRs in this rollout (deploy order)

1. **typebot.io** ← this PR
2. claudia-agentic
3. claudia (Kotlin web-api)
4. cloudchat-saas
5. claudia-app

## Test plan

- [ ] `curl` with `-H 'x-eddie-workspace-id: <cuid>' -H 'x-tenant: <tenant>'` against `/api/mcp` `tools/call`; confirm the typebot-builder log shows the prefilledVariable arriving on `executeWorkflow`.
- [ ] CORS preflight (`OPTIONS /api/mcp` with `Access-Control-Request-Headers: x-eddie-workspace-id`) returns 200.
- [ ] Header absent → behaviour unchanged (no `_eddie_workspace_id` in prefilledVariables, existing flows still work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as claudia-agentic / MCP client
    participant MCP as /api/mcp.ts
    participant WF as executeWorkflow

    Client->>MCP: POST /api/mcp
    Note over Client,MCP: Headers: x-eddie-workspace-id: cuid, x-tenant: tenant
    MCP->>MCP: "Normalize header (string | string[] | undefined) → string | undefined"
    MCP->>MCP: Sanitize args (strip _eddie_workspace_id, __proto__, constructor, prototype)
    MCP->>MCP: "Build prefilledVariables { ...sanitizedArgs, _eddie_workspace_id: cuid }"
    MCP->>WF: "executeWorkflow({ publicId, prefilledVariables })"
    WF-->>MCP: result
    MCP-->>Client: "{ jsonrpc: 2.0, result: { content: [...] } }"
    Note over Client,MCP: Header absent → _eddie_workspace_id omitted, existing flows unchanged
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fbuilder%2Fsrc%2Fpages%2Fapi%2Fmcp.ts%3A188-193%0AO%20%60RESERVED_PREFILLED_KEYS%60%20%C3%A9%20recriado%20como%20um%20novo%20%60Set%60%20a%20cada%20requisi%C3%A7%C3%A3o%2C%20dentro%20do%20handler.%20Para%20um%20endpoint%20chamado%20com%20frequ%C3%AAncia%2C%20vale%20mov%C3%AA-lo%20para%20o%20escopo%20do%20m%C3%B3dulo%20como%20constante%2C%20evitando%20aloca%C3%A7%C3%B5es%20desnecess%C3%A1rias%20a%20cada%20invoca%C3%A7%C3%A3o.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20RESERVED_PREFILLED_KEYS%20is%20defined%20at%20module%20level%20%28see%20top%20of%20file%29%0A%60%60%60%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=206&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fbuilder%2Fsrc%2Fpages%2Fapi%2Fmcp.ts%3A188-193%0AO%20%60RESERVED_PREFILLED_KEYS%60%20%C3%A9%20recriado%20como%20um%20novo%20%60Set%60%20a%20cada%20requisi%C3%A7%C3%A3o%2C%20dentro%20do%20handler.%20Para%20um%20endpoint%20chamado%20com%20frequ%C3%AAncia%2C%20vale%20mov%C3%AA-lo%20para%20o%20escopo%20do%20m%C3%B3dulo%20como%20constante%2C%20evitando%20aloca%C3%A7%C3%B5es%20desnecess%C3%A1rias%20a%20cada%20invoca%C3%A7%C3%A3o.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%2F%2F%20RESERVED_PREFILLED_KEYS%20is%20defined%20at%20module%20level%20%28see%20top%20of%20file%29%0A%60%60%60%0A%0A&pr=206&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/builder/src/pages/api/mcp.ts:188-193
O `RESERVED_PREFILLED_KEYS` é recriado como um novo `Set` a cada requisição, dentro do handler. Para um endpoint chamado com frequência, vale movê-lo para o escopo do módulo como constante, evitando alocações desnecessárias a cada invocação.

```suggestion
        // RESERVED_PREFILLED_KEYS is defined at module level (see top of file)
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["security: harden MCP tools/call against ..."](https://github.com/cloudhumans/typebot.io/commit/7590a960db5a7236c60f0d4daade346d5c88d6e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33554154)</sub>

<!-- /greptile_comment -->