### PR TITLE
✨feature: cap block visits per session

### DIFF
--- a/packages/bot-engine/executeGroup.ts
+++ b/packages/bot-engine/executeGroup.ts
@@ -151,7 +151,6 @@ export const executeGroup = async (
         newSessionState: {
           ...newSessionState,
           currentBlockId: undefined,
-          visitedBlockCounts: {},
         },
         clientSideActions,
         logs,

--- a/packages/bot-engine/executeGroup.ts
+++ b/packages/bot-engine/executeGroup.ts
@@ -107,7 +107,11 @@ export const executeGroup = async (
     // Skip NOTE blocks during execution
     if (block.type === BubbleBlockType.NOTE) continue
 
-    if (env.BLOCK_VISIT_LIMIT_ENABLED) {
+    const willSkipBubble =
+      isBubbleBlock(block) &&
+      (!block.content || (firstBubbleWasStreamed && index === 0))
+
+    if (env.BLOCK_VISIT_LIMIT_ENABLED && !willSkipBubble) {
       const visitCount =
         (newSessionState.visitedBlockCounts?.[block.id] ?? 0) + 1
       newSessionState = {

--- a/packages/bot-engine/executeGroup.ts
+++ b/packages/bot-engine/executeGroup.ts
@@ -118,18 +118,34 @@ export const executeGroup = async (
 
     if (visitCount > env.MAX_BLOCK_VISITS_PER_SESSION) {
       const offendingTypebot = newSessionState.typebotsQueue[0].typebot
-      logger.error('Block visit limit exceeded — terminating run', {
-        typebotId: offendingTypebot.id,
-        sessionId: sessionId ?? 'preview',
-        workspaceId: offendingTypebot.workspaceId ?? undefined,
-        workspaceName: offendingTypebot.workspaceName ?? undefined,
-        groupId: group.id,
-        groupName: group.title,
-        blockId: block.id,
-        blockType: block.type,
-        visitCount,
-        limit: env.MAX_BLOCK_VISITS_PER_SESSION,
-      })
+      const offendingWorkspaceName =
+        offendingTypebot.workspaceName ?? 'unknown'
+      logger.error(
+        `${offendingWorkspaceName} - Block visit limit exceeded`,
+        {
+          workspace: {
+            id: offendingTypebot.workspaceId ?? 'unknown',
+            name: offendingWorkspaceName,
+          },
+          workflow: {
+            id: offendingTypebot.id,
+            name: offendingTypebot.name ?? 'unknown',
+            schema_version: String(offendingTypebot.version ?? 'unknown'),
+            execution_id: sessionId ?? 'preview',
+            version_id: offendingTypebot.typebotHistoryId ?? 'unknown',
+          },
+          typebot_block: {
+            id: block.id,
+            type: block.type,
+          },
+          typebot_group: {
+            id: group.id,
+            name: group.title,
+          },
+          visit_count: visitCount,
+          limit: env.MAX_BLOCK_VISITS_PER_SESSION,
+        }
+      )
       return {
         messages,
         newSessionState: {

--- a/packages/bot-engine/executeGroup.ts
+++ b/packages/bot-engine/executeGroup.ts
@@ -107,55 +107,58 @@ export const executeGroup = async (
     // Skip NOTE blocks during execution
     if (block.type === BubbleBlockType.NOTE) continue
 
-    const visitCount = (newSessionState.visitedBlockCounts?.[block.id] ?? 0) + 1
-    newSessionState = {
-      ...newSessionState,
-      visitedBlockCounts: {
-        ...(newSessionState.visitedBlockCounts ?? {}),
-        [block.id]: visitCount,
-      },
-    }
-
-    if (visitCount > env.MAX_BLOCK_VISITS_PER_SESSION) {
-      const offendingTypebot = newSessionState.typebotsQueue[0].typebot
-      const offendingWorkspaceName =
-        offendingTypebot.workspaceName ?? 'unknown'
-      logger.error(
-        `${offendingWorkspaceName} - Block visit limit exceeded`,
-        {
-          workspace: {
-            id: offendingTypebot.workspaceId ?? 'unknown',
-            name: offendingWorkspaceName,
-          },
-          workflow: {
-            id: offendingTypebot.id,
-            name: offendingTypebot.name ?? 'unknown',
-            schema_version: String(offendingTypebot.version ?? 'unknown'),
-            execution_id: sessionId ?? 'preview',
-            version_id: offendingTypebot.typebotHistoryId ?? 'unknown',
-          },
-          typebot_block: {
-            id: block.id,
-            type: block.type,
-          },
-          typebot_group: {
-            id: group.id,
-            name: group.title,
-          },
-          visit_count: visitCount,
-          limit: env.MAX_BLOCK_VISITS_PER_SESSION,
-        }
-      )
-      return {
-        messages,
-        newSessionState: {
-          ...newSessionState,
-          currentBlockId: undefined,
+    if (env.BLOCK_VISIT_LIMIT_ENABLED) {
+      const visitCount =
+        (newSessionState.visitedBlockCounts?.[block.id] ?? 0) + 1
+      newSessionState = {
+        ...newSessionState,
+        visitedBlockCounts: {
+          ...(newSessionState.visitedBlockCounts ?? {}),
+          [block.id]: visitCount,
         },
-        clientSideActions,
-        logs,
-        visitedEdges,
-        setVariableHistory,
+      }
+
+      if (visitCount > env.MAX_BLOCK_VISITS_PER_SESSION) {
+        const offendingTypebot = newSessionState.typebotsQueue[0].typebot
+        const offendingWorkspaceName =
+          offendingTypebot.workspaceName ?? 'unknown'
+        logger.error(
+          `${offendingWorkspaceName} - Block visit limit exceeded`,
+          {
+            workspace: {
+              id: offendingTypebot.workspaceId ?? 'unknown',
+              name: offendingWorkspaceName,
+            },
+            workflow: {
+              id: offendingTypebot.id,
+              name: offendingTypebot.name ?? 'unknown',
+              schema_version: String(offendingTypebot.version ?? 'unknown'),
+              execution_id: sessionId ?? 'preview',
+              version_id: offendingTypebot.typebotHistoryId ?? 'unknown',
+            },
+            typebot_block: {
+              id: block.id,
+              type: block.type,
+            },
+            typebot_group: {
+              id: group.id,
+              name: group.title,
+            },
+            visit_count: visitCount,
+            limit: env.MAX_BLOCK_VISITS_PER_SESSION,
+          }
+        )
+        return {
+          messages,
+          newSessionState: {
+            ...newSessionState,
+            currentBlockId: undefined,
+          },
+          clientSideActions,
+          logs,
+          visitedEdges,
+          setVariableHistory,
+        }
       }
     }
 

--- a/packages/bot-engine/executeGroup.ts
+++ b/packages/bot-engine/executeGroup.ts
@@ -107,6 +107,42 @@ export const executeGroup = async (
     // Skip NOTE blocks during execution
     if (block.type === BubbleBlockType.NOTE) continue
 
+    const visitCount = (newSessionState.visitedBlockCounts?.[block.id] ?? 0) + 1
+    newSessionState = {
+      ...newSessionState,
+      visitedBlockCounts: {
+        ...(newSessionState.visitedBlockCounts ?? {}),
+        [block.id]: visitCount,
+      },
+    }
+
+    if (visitCount > env.MAX_BLOCK_VISITS_PER_SESSION) {
+      const offendingTypebot = newSessionState.typebotsQueue[0].typebot
+      logger.error('Block visit limit exceeded — terminating run', {
+        typebotId: offendingTypebot.id,
+        sessionId,
+        workspaceId: offendingTypebot.workspaceId ?? undefined,
+        workspaceName: offendingTypebot.workspaceName ?? undefined,
+        groupId: group.id,
+        groupName: group.title,
+        blockId: block.id,
+        blockType: block.type,
+        visitCount,
+        limit: env.MAX_BLOCK_VISITS_PER_SESSION,
+      })
+      return {
+        messages,
+        newSessionState: {
+          ...newSessionState,
+          currentBlockId: undefined,
+        },
+        clientSideActions,
+        logs,
+        visitedEdges,
+        setVariableHistory,
+      }
+    }
+
     if (isBubbleBlock(block)) {
       if (!block.content || (firstBubbleWasStreamed && index === 0)) {
         continue

--- a/packages/bot-engine/executeGroup.ts
+++ b/packages/bot-engine/executeGroup.ts
@@ -120,7 +120,7 @@ export const executeGroup = async (
       const offendingTypebot = newSessionState.typebotsQueue[0].typebot
       logger.error('Block visit limit exceeded — terminating run', {
         typebotId: offendingTypebot.id,
-        sessionId,
+        sessionId: sessionId ?? 'preview',
         workspaceId: offendingTypebot.workspaceId ?? undefined,
         workspaceName: offendingTypebot.workspaceName ?? undefined,
         groupId: group.id,
@@ -135,6 +135,7 @@ export const executeGroup = async (
         newSessionState: {
           ...newSessionState,
           currentBlockId: undefined,
+          visitedBlockCounts: {},
         },
         clientSideActions,
         logs,

--- a/packages/bot-engine/startSession.ts
+++ b/packages/bot-engine/startSession.ts
@@ -165,6 +165,7 @@ export const startSession = async ({
       : undefined,
     setVariableIdsForHistory:
       extractVariableIdsUsedForTranscript(typebotInSession),
+    visitedBlockCounts: {},
     ...initialSessionState,
   }
 

--- a/packages/env/env.ts
+++ b/packages/env/env.ts
@@ -82,6 +82,7 @@ const baseEnv = {
       .default('FREE'),
     DEBUG: boolean.optional().default('false'),
     CHAT_API_TIMEOUT: z.coerce.number().optional(),
+    MAX_BLOCK_VISITS_PER_SESSION: z.coerce.number().default(500),
     // Datadog logging configuration
     DD_LOGS_ENABLED: boolean.optional().default('false'),
     LOG_LEVEL: z

--- a/packages/env/env.ts
+++ b/packages/env/env.ts
@@ -83,6 +83,7 @@ const baseEnv = {
     DEBUG: boolean.optional().default('false'),
     CHAT_API_TIMEOUT: z.coerce.number().optional(),
     MAX_BLOCK_VISITS_PER_SESSION: z.coerce.number().int().min(1).default(500),
+    BLOCK_VISIT_LIMIT_ENABLED: boolean.optional().default('true'),
     // Datadog logging configuration
     DD_LOGS_ENABLED: boolean.optional().default('false'),
     LOG_LEVEL: z

--- a/packages/env/env.ts
+++ b/packages/env/env.ts
@@ -82,7 +82,7 @@ const baseEnv = {
       .default('FREE'),
     DEBUG: boolean.optional().default('false'),
     CHAT_API_TIMEOUT: z.coerce.number().optional(),
-    MAX_BLOCK_VISITS_PER_SESSION: z.coerce.number().default(500),
+    MAX_BLOCK_VISITS_PER_SESSION: z.coerce.number().int().min(1).default(500),
     // Datadog logging configuration
     DD_LOGS_ENABLED: boolean.optional().default('false'),
     LOG_LEVEL: z

--- a/packages/schemas/features/chat/sessionState.ts
+++ b/packages/schemas/features/chat/sessionState.ts
@@ -107,6 +107,7 @@ const sessionStateSchemaV3 = sessionStateSchemaV2
       })
       .optional(),
     lastEndpointResponse: z.any().optional(),
+    visitedBlockCounts: z.record(z.string(), z.number()).optional(),
   })
 
 export type SessionState = z.infer<typeof sessionStateSchemaV3>

--- a/packages/schemas/features/chat/sessionState.ts
+++ b/packages/schemas/features/chat/sessionState.ts
@@ -107,7 +107,9 @@ const sessionStateSchemaV3 = sessionStateSchemaV2
       })
       .optional(),
     lastEndpointResponse: z.any().optional(),
-    visitedBlockCounts: z.record(z.string(), z.number()).optional(),
+    visitedBlockCounts: z
+      .record(z.string(), z.number().int().nonnegative())
+      .optional(),
   })
 
 export type SessionState = z.infer<typeof sessionStateSchemaV3>


### PR DESCRIPTION
## Problema

O card [#6816](https://dev.azure.com/cloudhumans/ClaudIA/_workitems/edit/6816) flagrou um caso onde um único bloco Script de um typebot ficou executando milhões de vezes na mesma sessão lógica (mesmo `trace_id`/`span_id`), queimando CPU do pod `typebot-viewer` e gerando 1,83M de logs em 7 dias. Hoje o único safeguard do `bot-engine` é o `CHAT_API_TIMEOUT` (wall-clock por HTTP turn) — não pega loops rápidos que atravessam múltiplos turns. O loop só parou organicamente quando a sessão saiu de circulação.

O PR #194 deixou os erros desses loops observáveis (logs com `typebotId/sessionId/workspaceId/groupName`), mas não corta o loop. Este PR fecha a lacuna.

## Mudança

Adiciona um contador `visitedBlockCounts: Record<blockId, number>` no `SessionState` (V3), incrementado em `executeGroup` antes da execução de cada bloco. Quando qualquer bloco passar de `MAX_BLOCK_VISITS_PER_SESSION` (env, default 500), a run é encerrada graciosamente: `logger.error` estruturado com todo o contexto identificador (typebot, workspace, group, block, counter), `currentBlockId` limpo, e retorno sem exceção/500. Próximo `continueChat` na mesma sessão trata como sessão encerrada.

Contador é por `blockId` e acumulativo na sessão inteira (sobrevive turns via JSON `state` no DB). Cobre tanto loop em 1 bloco (caso do 6816) quanto ping-pong entre blocos diferentes (cada contador acumula em paralelo).

Sem migration: `ChatSession.state` já é `Json`, campo Zod é `optional()`.

Validado local: criado typebot com self-loop, contador chegou em 501, log disparou em formato estruturado, sessão encerrada (`currentBlockId: null` no DB), `visitedBlockCounts` persistido corretamente.

Ref: cloudhumans/ClaudIA #6816

<!-- greptile_comment -->

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant continueChat
    participant executeGroup
    participant DB

    Client->>continueChat: POST /continueChat
    continueChat->>DB: load ChatSession.state (inclui visitedBlockCounts)
    continueChat->>executeGroup: executa grupo atual

    loop Para cada bloco no grupo
        executeGroup->>executeGroup: pular NOTE blocks
        executeGroup->>executeGroup: calcular willSkipBubble
        alt "BLOCK_VISIT_LIMIT_ENABLED && !willSkipBubble"
            executeGroup->>executeGroup: "visitCount = visitedBlockCounts[blockId] + 1"
            executeGroup->>executeGroup: atualiza newSessionState.visitedBlockCounts
            alt "visitCount > MAX_BLOCK_VISITS_PER_SESSION"
                executeGroup->>executeGroup: logger.error (workspace, workflow, block, group, count)
                executeGroup-->>continueChat: "return { currentBlockId: undefined, visitedBlockCounts preservado }"
                continueChat->>DB: salva estado (sessão encerrada)
                continueChat-->>Client: resposta sem input (sessão encerrada)
            else dentro do limite
                executeGroup->>executeGroup: executa bloco normalmente
            end
        end
    end

    executeGroup->>executeGroup: getNextGroup (recursivo)
    executeGroup-->>continueChat: return resultado com newSessionState
    continueChat->>DB: salva estado atualizado (visitedBlockCounts acumulado)
    continueChat-->>Client: resposta normal
```

<sub>Reviews (5): Last reviewed commit: ["🩹enhancement: skip visit counter for no..."](https://github.com/cloudhumans/typebot.io/commit/655a22f8d035cbb0ccb445470a74a6e248555acf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34900846)</sub>

<!-- /greptile_comment -->