### PR TITLE
feat(typebots): add isTool flag and include settings and toolDescript…

### DIFF
--- a/apps/builder/src/features/typebot/api/listTypebots.test.ts
+++ b/apps/builder/src/features/typebot/api/listTypebots.test.ts
@@ -1,0 +1,118 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { listTypebots } from './listTypebots'
+import { WorkspaceRole } from '@typebot.io/prisma'
+import { getUserRoleInWorkspace } from '@/features/workspace/helpers/getUserRoleInWorkspace'
+import prisma from '@typebot.io/lib/prisma'
+
+vi.mock('@typebot.io/lib/prisma', () => ({
+  default: {
+    workspace: {
+      findUnique: vi.fn(),
+    },
+    typebot: {
+      findMany: vi.fn(),
+    },
+  },
+}))
+vi.mock('@/features/workspace/helpers/getUserRoleInWorkspace', () => ({
+  getUserRoleInWorkspace: vi.fn(),
+}))
+
+describe('listTypebots', () => {
+  const mockUser = { id: 'user-1', email: 'test@test.com' }
+  const mockWorkspace = {
+    id: 'ws-1',
+    name: 'WS',
+    members: [{ userId: mockUser.id, role: WorkspaceRole.ADMIN }],
+  }
+
+  const toolTypebot = {
+    id: 'tool-1',
+    name: 'Get Order Status',
+    icon: null,
+    createdAt: new Date('2026-01-02T00:00:00Z'),
+    settings: { general: { type: 'TOOL' } },
+    publishedTypebot: null,
+  }
+  const normalTypebot = {
+    id: 'flow-1',
+    name: 'Flow',
+    icon: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    settings: { general: { type: 'default' } },
+    publishedTypebot: { id: 'pub-1' },
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(prisma.workspace.findUnique).mockResolvedValue(mockWorkspace as any)
+    vi.mocked(getUserRoleInWorkspace).mockReturnValue(WorkspaceRole.ADMIN)
+  })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const caller = () => listTypebots.createCaller({ user: mockUser } as any)
+
+  it('marks a TOOL-type typebot with isTool: true', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(prisma.typebot.findMany).mockResolvedValue([toolTypebot] as any)
+
+    const { typebots } = await caller()({ workspaceId: mockWorkspace.id })
+
+    expect(typebots).toHaveLength(1)
+    expect(typebots[0].isTool).toBe(true)
+  })
+
+  it('keeps non-TOOL workflows with isTool: false', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(prisma.typebot.findMany).mockResolvedValue([normalTypebot] as any)
+
+    const { typebots } = await caller()({ workspaceId: mockWorkspace.id })
+
+    expect(typebots).toHaveLength(1)
+    expect(typebots[0].isTool).toBe(false)
+    expect(typebots[0].publishedTypebotId).toBe('pub-1')
+  })
+
+  it('still flags TOOL typebots whose other settings fields are invalid', async () => {
+    vi.mocked(prisma.typebot.findMany).mockResolvedValue([
+      {
+        ...toolTypebot,
+        settings: { general: { type: 'TOOL' }, typingEmulation: 'nonsense' },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any)
+
+    const { typebots } = await caller()({ workspaceId: mockWorkspace.id })
+
+    expect(typebots[0].isTool).toBe(true)
+  })
+
+  it('excludes TOOL workflows when excludeTools is true', async () => {
+    vi.mocked(prisma.typebot.findMany).mockResolvedValue([
+      normalTypebot,
+      toolTypebot,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any)
+
+    const { typebots } = await caller()({
+      workspaceId: mockWorkspace.id,
+      excludeTools: true,
+    })
+
+    expect(typebots).toHaveLength(1)
+    expect(typebots[0].id).toBe('flow-1')
+  })
+
+  it('returns both flows and tools when excludeTools is not set', async () => {
+    vi.mocked(prisma.typebot.findMany).mockResolvedValue([
+      normalTypebot,
+      toolTypebot,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any)
+
+    const { typebots } = await caller()({ workspaceId: mockWorkspace.id })
+
+    expect(typebots).toHaveLength(2)
+  })
+})

--- a/apps/builder/src/features/typebot/api/listTypebots.ts
+++ b/apps/builder/src/features/typebot/api/listTypebots.ts
@@ -2,10 +2,17 @@ import prisma from '@typebot.io/lib/prisma'
 import { authenticatedProcedure } from '@/helpers/server/trpc'
 import { TRPCError } from '@trpc/server'
 import { Prisma, WorkspaceRole } from '@typebot.io/prisma'
-import { typebotV5Schema, settingsSchema } from '@typebot.io/schemas'
+import { typebotV5Schema } from '@typebot.io/schemas'
 import { omit } from '@typebot.io/lib'
 import { z } from 'zod'
 import { getUserRoleInWorkspace } from '@/features/workspace/helpers/getUserRoleInWorkspace'
+
+// Minimal, lenient schema: we only need `general.type` to decide if a typebot
+// is a tool. Validating the full settingsSchema would make an invalid sibling
+// field hide a legit TOOL (isTool: false), letting it leak past excludeTools.
+const toolSettingsSchema = z.object({
+  general: z.object({ type: z.string().nullish() }).nullish(),
+})
 
 export const listTypebots = authenticatedProcedure
   .meta({
@@ -158,26 +165,20 @@ export const listTypebots = authenticatedProcedure
           icon: true,
           createdAt: true,
           settings: true,
-          toolDescription: true,
         },
       })
 
       return {
         typebots: typebots
           .map((typebot) => {
-            const parsedSettings = settingsSchema.safeParse(typebot.settings)
+            const parsedSettings = toolSettingsSchema.safeParse(typebot.settings)
             const isTool =
               parsedSettings.success &&
               parsedSettings.data.general?.type === 'TOOL'
             return {
               publishedTypebotId: typebot.publishedTypebot?.id,
               isTool,
-              ...omit(
-                typebot,
-                'publishedTypebot',
-                'settings',
-                'toolDescription'
-              ),
+              ...omit(typebot, 'publishedTypebot', 'settings'),
             }
           })
           .filter((typebot) => !excludeTools || !typebot.isTool),

--- a/apps/builder/src/features/typebot/api/listTypebots.ts
+++ b/apps/builder/src/features/typebot/api/listTypebots.ts
@@ -2,7 +2,7 @@ import prisma from '@typebot.io/lib/prisma'
 import { authenticatedProcedure } from '@/helpers/server/trpc'
 import { TRPCError } from '@trpc/server'
 import { Prisma, WorkspaceRole } from '@typebot.io/prisma'
-import { typebotV5Schema } from '@typebot.io/schemas'
+import { typebotV5Schema, settingsSchema } from '@typebot.io/schemas'
 import { omit } from '@typebot.io/lib'
 import { z } from 'zod'
 import { getUserRoleInWorkspace } from '@/features/workspace/helpers/getUserRoleInWorkspace'
@@ -35,6 +35,13 @@ export const listTypebots = authenticatedProcedure
         .optional(),
       createdAtFrom: z.string().datetime().optional(),
       createdAtTo: z.string().datetime().optional(),
+      excludeTools: z
+        .preprocess(
+          (val) => (typeof val === 'string' ? val === 'true' : val),
+          z.boolean()
+        )
+        .optional()
+        .describe('When true, omit TOOL-type typebots from the response.'),
     })
   )
   .output(
@@ -65,6 +72,7 @@ export const listTypebots = authenticatedProcedure
         status,
         createdAtFrom,
         createdAtTo,
+        excludeTools,
       },
       ctx: { user },
     }) => {
@@ -155,17 +163,24 @@ export const listTypebots = authenticatedProcedure
       })
 
       return {
-        typebots: typebots.map((typebot) => {
-          const settings = typebot.settings as { general?: { type?: string } }
-          const isTool =
-            settings?.general?.type === 'TOOL' &&
-            Boolean(typebot.toolDescription)
-          return {
-            publishedTypebotId: typebot.publishedTypebot?.id,
-            isTool,
-            ...omit(typebot, 'publishedTypebot', 'settings', 'toolDescription'),
-          }
-        }),
+        typebots: typebots
+          .map((typebot) => {
+            const parsedSettings = settingsSchema.safeParse(typebot.settings)
+            const isTool =
+              parsedSettings.success &&
+              parsedSettings.data.general?.type === 'TOOL'
+            return {
+              publishedTypebotId: typebot.publishedTypebot?.id,
+              isTool,
+              ...omit(
+                typebot,
+                'publishedTypebot',
+                'settings',
+                'toolDescription'
+              ),
+            }
+          })
+          .filter((typebot) => !excludeTools || !typebot.isTool),
       }
     }
   )

--- a/apps/builder/src/features/typebot/api/listTypebots.ts
+++ b/apps/builder/src/features/typebot/api/listTypebots.ts
@@ -47,7 +47,12 @@ export const listTypebots = authenticatedProcedure
             id: true,
             createdAt: true,
           })
-          .merge(z.object({ publishedTypebotId: z.string().optional() }))
+          .merge(
+            z.object({
+              publishedTypebotId: z.string().optional(),
+              isTool: z.boolean(),
+            })
+          )
       ),
     })
   )
@@ -144,14 +149,23 @@ export const listTypebots = authenticatedProcedure
           id: true,
           icon: true,
           createdAt: true,
+          settings: true,
+          toolDescription: true,
         },
       })
 
       return {
-        typebots: typebots.map((typebot) => ({
-          publishedTypebotId: typebot.publishedTypebot?.id,
-          ...omit(typebot, 'publishedTypebot'),
-        })),
+        typebots: typebots.map((typebot) => {
+          const settings = typebot.settings as { general?: { type?: string } }
+          const isTool =
+            settings?.general?.type === 'TOOL' &&
+            Boolean(typebot.toolDescription)
+          return {
+            publishedTypebotId: typebot.publishedTypebot?.id,
+            isTool,
+            ...omit(typebot, 'publishedTypebot', 'settings', 'toolDescription'),
+          }
+        }),
       }
     }
   )


### PR DESCRIPTION
…ion in response¨

<!-- greptile_comment -->

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant listTypebots
    participant Prisma DB

    Client->>listTypebots: "GET /v1/typebots?workspaceId=X&excludeTools=true"
    listTypebots->>Prisma DB: findMany({ select: { ..., settings: true } })
    Prisma DB-->>listTypebots: typebots[] (including TOOL-type)
    loop Para cada typebot
        listTypebots->>listTypebots: toolSettingsSchema.safeParse(settings)
        listTypebots->>listTypebots: "isTool = success && general.type === 'TOOL'"
        listTypebots->>listTypebots: omit(typebot, 'publishedTypebot', 'settings')
    end
    listTypebots->>listTypebots: ".filter(!excludeTools || !isTool)"
    listTypebots-->>Client: "{ typebots: [{ isTool, publishedTypebotId, ... }] }"
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Ftypebot%2Fapi%2FlistTypebots.ts%3A184%0AA%20filtragem%20de%20TOOLs%20acontece%20em%20mem%C3%B3ria%2C%20ap%C3%B3s%20o%20banco%20j%C3%A1%20ter%20retornado%20todos%20os%20typebots%20%28incluindo%20os%20que%20ser%C3%A3o%20descartados%29.%20Para%20workspaces%20com%20muitos%20typebots%20do%20tipo%20TOOL%2C%20isso%20gera%20leitura%20desnecess%C3%A1ria%20de%20linhas%20no%20banco%20e%20transfer%C3%AAncia%20de%20dados.%20Quando%20%60excludeTools%60%20%C3%A9%20%60true%60%2C%20%C3%A9%20poss%C3%ADvel%20adicionar%20uma%20condi%C3%A7%C3%A3o%20diretamente%20no%20%60where%60%20do%20Prisma%20usando%20um%20subquery%20em%20%60settings%60%20%E2%80%94%20ou%20ao%20menos%20mover%20o%20%60.filter%28%29%60%20para%20o%20banco%20usando%20uma%20cl%C3%A1usula%20%60NOT%60%20no%20JSON.%20A%20abordagem%20in-memory%20%C3%A9%20funcional%2C%20mas%20pode%20ser%20custosa%20%C3%A0%20medida%20que%20o%20volume%20crescer.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20.filter%28%28typebot%29%20%3D%3E%20!excludeTools%20%7C%7C%20!typebot.isTool%29%2C%0A%20%20%20%20%20%20%20%20%2F%2F%20TODO%3A%20considerar%20mover%20o%20filtro%20excludeTools%20para%20o%20n%C3%ADvel%20do%20banco%0A%20%20%20%20%20%20%20%20%2F%2F%20%28ex.%3A%20cl%C3%A1usula%20NOT%20sobre%20settings-%3E%3E'general'-%3E%3E'type'%29%20para%20evitar%0A%20%20%20%20%20%20%20%20%2F%2F%20buscar%20typebots%20do%20tipo%20TOOL%20apenas%20para%20descart%C3%A1-los%20em%20mem%C3%B3ria.%0A%60%60%60%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=209&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Ftypebot%2Fapi%2FlistTypebots.ts%3A184%0AA%20filtragem%20de%20TOOLs%20acontece%20em%20mem%C3%B3ria%2C%20ap%C3%B3s%20o%20banco%20j%C3%A1%20ter%20retornado%20todos%20os%20typebots%20%28incluindo%20os%20que%20ser%C3%A3o%20descartados%29.%20Para%20workspaces%20com%20muitos%20typebots%20do%20tipo%20TOOL%2C%20isso%20gera%20leitura%20desnecess%C3%A1ria%20de%20linhas%20no%20banco%20e%20transfer%C3%AAncia%20de%20dados.%20Quando%20%60excludeTools%60%20%C3%A9%20%60true%60%2C%20%C3%A9%20poss%C3%ADvel%20adicionar%20uma%20condi%C3%A7%C3%A3o%20diretamente%20no%20%60where%60%20do%20Prisma%20usando%20um%20subquery%20em%20%60settings%60%20%E2%80%94%20ou%20ao%20menos%20mover%20o%20%60.filter%28%29%60%20para%20o%20banco%20usando%20uma%20cl%C3%A1usula%20%60NOT%60%20no%20JSON.%20A%20abordagem%20in-memory%20%C3%A9%20funcional%2C%20mas%20pode%20ser%20custosa%20%C3%A0%20medida%20que%20o%20volume%20crescer.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20.filter%28%28typebot%29%20%3D%3E%20!excludeTools%20%7C%7C%20!typebot.isTool%29%2C%0A%20%20%20%20%20%20%20%20%2F%2F%20TODO%3A%20considerar%20mover%20o%20filtro%20excludeTools%20para%20o%20n%C3%ADvel%20do%20banco%0A%20%20%20%20%20%20%20%20%2F%2F%20%28ex.%3A%20cl%C3%A1usula%20NOT%20sobre%20settings-%3E%3E'general'-%3E%3E'type'%29%20para%20evitar%0A%20%20%20%20%20%20%20%20%2F%2F%20buscar%20typebots%20do%20tipo%20TOOL%20apenas%20para%20descart%C3%A1-los%20em%20mem%C3%B3ria.%0A%60%60%60%0A%0A&pr=209&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/builder/src/features/typebot/api/listTypebots.ts:184
A filtragem de TOOLs acontece em memória, após o banco já ter retornado todos os typebots (incluindo os que serão descartados). Para workspaces com muitos typebots do tipo TOOL, isso gera leitura desnecessária de linhas no banco e transferência de dados. Quando `excludeTools` é `true`, é possível adicionar uma condição diretamente no `where` do Prisma usando um subquery em `settings` — ou ao menos mover o `.filter()` para o banco usando uma cláusula `NOT` no JSON. A abordagem in-memory é funcional, mas pode ser custosa à medida que o volume crescer.

```suggestion
          .filter((typebot) => !excludeTools || !typebot.isTool),
        // TODO: considerar mover o filtro excludeTools para o nível do banco
        // (ex.: cláusula NOT sobre settings->>'general'->>'type') para evitar
        // buscar typebots do tipo TOOL apenas para descartá-los em memória.
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(listTypebots): lenient tool detectio..."](https://github.com/cloudhumans/typebot.io/commit/afdf7dc5cd9e2e23107d74ec0cfc28fbce2290b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34952404)</sub>

<!-- /greptile_comment -->