### PR TITLE
🐛bug: provision embedded user on api auth path

### DIFF
--- a/apps/builder/src/features/auth/helpers/cloudchatEmbeddedAuthorize.ts
+++ b/apps/builder/src/features/auth/helpers/cloudchatEmbeddedAuthorize.ts
@@ -3,8 +3,7 @@ import { env } from '@typebot.io/env'
 import logger from '@/helpers/logger'
 import { verifyCognitoToken } from '@/features/auth/helpers/verifyCognitoToken'
 import { DatabaseUserWithCognito } from '@/features/auth/types/cognito'
-import { isPrismaUniqueViolation } from './isPrismaUniqueViolation'
-import { createCloudChatEmbeddedUser } from './createCloudChatEmbeddedUser'
+import { findOrCreateCloudChatEmbeddedUser } from './findOrCreateCloudChatEmbeddedUser'
 
 type Credentials = { token?: string } | undefined
 
@@ -34,52 +33,8 @@ export const cloudchatEmbeddedAuthorize = async (
       cognitoToken: credentials.token,
     })
 
-    if (typeof payload.email !== 'string' || payload.email.length === 0) {
-      logger.warn('cloudchat-embedded payload missing email', {
-        sub: payload.sub,
-        cognitoUsername: payload['cognito:username'],
-      })
-      return null
-    }
-
-    let user = await p.user.findUnique({
-      where: { email: payload.email },
-    })
-
-    if (!user) {
-      try {
-        user = await createCloudChatEmbeddedUser({
-          p,
-          email: payload.email,
-          name: payload.name ?? null,
-          emailVerified: payload.email_verified === true ? new Date() : null,
-        })
-        logger.info('JIT-provisioned cloudchat-embedded user', {
-          userId: user.id,
-          email: user.email,
-          hubRole: payload['custom:hub_role'],
-          eddieWorkspacesCount: (payload['custom:eddie_workspaces'] ?? '')
-            .split(',')
-            .filter(Boolean).length,
-        })
-      } catch (err) {
-        if (isPrismaUniqueViolation(err)) {
-          user = await p.user.findUnique({
-            where: { email: payload.email },
-          })
-          if (!user) throw err
-          logger.info('cloudchat-embedded JIT race resolved', {
-            email: payload.email,
-          })
-        } else {
-          logger.warn('cloudchat-embedded JIT refused', {
-            email: payload.email,
-            reason: err instanceof Error ? err.message : 'unknown',
-          })
-          return null
-        }
-      }
-    }
+    const user = await findOrCreateCloudChatEmbeddedUser(p, payload)
+    if (!user) return null
 
     return {
       id: user.id,

--- a/apps/builder/src/features/auth/helpers/findOrCreateCloudChatEmbeddedUser.test.ts
+++ b/apps/builder/src/features/auth/helpers/findOrCreateCloudChatEmbeddedUser.test.ts
@@ -1,0 +1,168 @@
+import { vi } from 'vitest'
+
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('./createCloudChatEmbeddedUser', () => ({
+  createCloudChatEmbeddedUser: vi.fn(),
+}))
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Prisma } from '@typebot.io/prisma'
+import logger from '@/helpers/logger'
+import { createCloudChatEmbeddedUser } from './createCloudChatEmbeddedUser'
+import { findOrCreateCloudChatEmbeddedUser } from './findOrCreateCloudChatEmbeddedUser'
+
+const createMock = createCloudChatEmbeddedUser as ReturnType<typeof vi.fn>
+const loggerInfo = logger.info as unknown as ReturnType<typeof vi.fn>
+const loggerWarn = logger.warn as unknown as ReturnType<typeof vi.fn>
+
+const userFixture = {
+  id: 'user-1',
+  email: 'jit@local.test',
+  name: 'JIT',
+  image: null,
+  emailVerified: new Date('2026-05-06T00:00:00Z'),
+  createdAt: new Date('2026-05-05T12:00:00Z'),
+}
+
+const buildPrismaMock = (
+  findUniqueImpl?: ReturnType<typeof vi.fn>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): any => ({
+  user: {
+    findUnique: findUniqueImpl ?? vi.fn(async () => null),
+  },
+})
+
+const basePayload = {
+  email: 'jit@local.test',
+  email_verified: true,
+  name: 'JIT',
+  'custom:hub_role': 'CLIENT',
+  'custom:eddie_workspaces': 'ws-a,ws-b',
+  sub: 'sub-1',
+  exp: 9999999999,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any
+
+describe('findOrCreateCloudChatEmbeddedUser', () => {
+  beforeEach(() => {
+    createMock.mockReset()
+    loggerInfo.mockReset()
+    loggerWarn.mockReset()
+  })
+
+  it('returns null and logs warn when payload has no email', async () => {
+    const p = buildPrismaMock()
+
+    const result = await findOrCreateCloudChatEmbeddedUser(p, {
+      sub: 'sub-x',
+      'cognito:username': 'u',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+
+    expect(result).toBeNull()
+    expect(loggerWarn).toHaveBeenCalledWith(
+      'cloudchat-embedded payload missing email',
+      { sub: 'sub-x', cognitoUsername: 'u' }
+    )
+    expect(p.user.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('returns existing user without calling createCloudChatEmbeddedUser', async () => {
+    const findUnique = vi.fn(async () => userFixture)
+    const p = buildPrismaMock(findUnique)
+
+    const result = await findOrCreateCloudChatEmbeddedUser(p, basePayload)
+
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { email: 'jit@local.test' },
+    })
+    expect(createMock).not.toHaveBeenCalled()
+    expect(result).toBe(userFixture)
+  })
+
+  it("creates user when absent and logs info 'JIT-provisioned'", async () => {
+    const findUnique = vi.fn(async () => null)
+    const p = buildPrismaMock(findUnique)
+    createMock.mockResolvedValueOnce(userFixture)
+
+    const result = await findOrCreateCloudChatEmbeddedUser(p, basePayload)
+
+    expect(createMock).toHaveBeenCalledWith({
+      p,
+      email: 'jit@local.test',
+      name: 'JIT',
+      emailVerified: expect.any(Date),
+    })
+    expect(loggerInfo).toHaveBeenCalledWith(
+      'JIT-provisioned cloudchat-embedded user',
+      {
+        userId: 'user-1',
+        email: 'jit@local.test',
+        hubRole: 'CLIENT',
+        eddieWorkspacesCount: 2,
+      }
+    )
+    expect(result).toBe(userFixture)
+  })
+
+  it("on P2002: refetches and returns user, logs info 'race resolved'", async () => {
+    const findUnique = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(userFixture)
+    const p = buildPrismaMock(findUnique)
+    const p2002 = new Prisma.PrismaClientKnownRequestError(
+      'Unique constraint failed',
+      { code: 'P2002', clientVersion: '5.12.1' }
+    )
+    createMock.mockRejectedValueOnce(p2002)
+
+    const result = await findOrCreateCloudChatEmbeddedUser(p, basePayload)
+
+    expect(findUnique).toHaveBeenCalledTimes(2)
+    expect(loggerInfo).toHaveBeenCalledWith(
+      'cloudchat-embedded JIT race resolved',
+      { email: 'jit@local.test' }
+    )
+    expect(result).toBe(userFixture)
+  })
+
+  it('on P2002 + refetch returns null: rethrows', async () => {
+    const findUnique = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+    const p = buildPrismaMock(findUnique)
+    const p2002 = new Prisma.PrismaClientKnownRequestError(
+      'Unique constraint failed',
+      { code: 'P2002', clientVersion: '5.12.1' }
+    )
+    createMock.mockRejectedValueOnce(p2002)
+
+    await expect(
+      findOrCreateCloudChatEmbeddedUser(p, basePayload)
+    ).rejects.toBe(p2002)
+  })
+
+  it('on non-P2002 error: logs warn JIT refused and returns null', async () => {
+    const findUnique = vi.fn(async () => null)
+    const p = buildPrismaMock(findUnique)
+    createMock.mockRejectedValueOnce(new Error('db: connection lost'))
+
+    const result = await findOrCreateCloudChatEmbeddedUser(p, basePayload)
+
+    expect(result).toBeNull()
+    expect(loggerWarn).toHaveBeenCalledWith('cloudchat-embedded JIT refused', {
+      email: 'jit@local.test',
+      reason: 'db: connection lost',
+    })
+  })
+})

--- a/apps/builder/src/features/auth/helpers/findOrCreateCloudChatEmbeddedUser.ts
+++ b/apps/builder/src/features/auth/helpers/findOrCreateCloudChatEmbeddedUser.ts
@@ -1,0 +1,59 @@
+import { PrismaClient, User } from '@typebot.io/prisma'
+import { JWTPayload } from 'jose'
+import logger from '@/helpers/logger'
+import { CognitoJWTPayload } from '@/features/auth/types/cognito'
+import { createCloudChatEmbeddedUser } from './createCloudChatEmbeddedUser'
+import { isPrismaUniqueViolation } from './isPrismaUniqueViolation'
+
+export const findOrCreateCloudChatEmbeddedUser = async (
+  p: PrismaClient,
+  payload: JWTPayload & CognitoJWTPayload
+): Promise<User | null> => {
+  if (typeof payload.email !== 'string' || payload.email.length === 0) {
+    logger.warn('cloudchat-embedded payload missing email', {
+      sub: payload.sub,
+      cognitoUsername: payload['cognito:username'],
+    })
+    return null
+  }
+
+  const existing = await p.user.findUnique({
+    where: { email: payload.email },
+  })
+  if (existing) return existing
+
+  try {
+    const user = await createCloudChatEmbeddedUser({
+      p,
+      email: payload.email,
+      name: payload.name ?? null,
+      emailVerified: payload.email_verified === true ? new Date() : null,
+    })
+    logger.info('JIT-provisioned cloudchat-embedded user', {
+      userId: user.id,
+      email: user.email,
+      hubRole: payload['custom:hub_role'],
+      eddieWorkspacesCount: (payload['custom:eddie_workspaces'] ?? '')
+        .split(',')
+        .filter(Boolean).length,
+    })
+    return user
+  } catch (err) {
+    if (isPrismaUniqueViolation(err)) {
+      const raced = await p.user.findUnique({
+        where: { email: payload.email },
+      })
+      if (raced) {
+        logger.info('cloudchat-embedded JIT race resolved', {
+          email: payload.email,
+        })
+        return raced
+      }
+    }
+    logger.warn('cloudchat-embedded JIT refused', {
+      email: payload.email,
+      reason: err instanceof Error ? err.message : 'unknown',
+    })
+    return null
+  }
+}

--- a/apps/builder/src/features/auth/helpers/findOrCreateCloudChatEmbeddedUser.ts
+++ b/apps/builder/src/features/auth/helpers/findOrCreateCloudChatEmbeddedUser.ts
@@ -49,6 +49,7 @@ export const findOrCreateCloudChatEmbeddedUser = async (
         })
         return raced
       }
+      throw err
     }
     logger.warn('cloudchat-embedded JIT refused', {
       email: payload.email,

--- a/apps/builder/src/features/auth/helpers/getAuthenticatedUser.ts
+++ b/apps/builder/src/features/auth/helpers/getAuthenticatedUser.ts
@@ -8,6 +8,7 @@ import { mockedUser } from '@typebot.io/lib/mockedUser'
 import { emailIsCloudhumans } from '@typebot.io/lib'
 import { DatabaseUserWithCognito } from '../types/cognito'
 import { verifyCognitoToken } from './verifyCognitoToken'
+import { findOrCreateCloudChatEmbeddedUser } from './findOrCreateCloudChatEmbeddedUser'
 import { patchSetCookieForPartitioned } from './cookiePartitioning'
 import logger from '@/helpers/logger'
 
@@ -43,9 +44,7 @@ const authenticateByEmbeddedToken = async (
       cognitoToken: token,
     })
 
-    const user = await prisma.user.findUnique({
-      where: { email: payload.email },
-    })
+    const user = await findOrCreateCloudChatEmbeddedUser(prisma, payload)
 
     if (!user) return
 


### PR DESCRIPTION
Usuárias do tenant Boca Rosa (admins no CloudChat) eram redirecionadas pra tela de login ao abrir a aba Conteúdos, que carrega o microfrontend da claudia-app. A causa raiz é uma lacuna de provisionamento aqui no Eddie: o usuário do typebot só era criado (JIT) no sign-in do builder embedded (`cloudchatEmbeddedAuthorize`). Quem nunca abriu o builder — só usou a aba Conteúdos — não tinha registro de `user`.

A tela de Conteúdos chama a API do Eddie direto (`/api/v1/typebots?apiGateway=true`), que cai em `authenticateByEmbeddedToken`. Esse caminho só fazia lookup por email e retornava 401 quando o usuário não existia. O 401 dispara o interceptor bearer da claudia-app, que chama `logout()` → redireciona pro login (o "loop de carregamento" relatado).

A correção extrai `findOrCreateCloudChatEmbeddedUser` (find-or-create com tratamento de corrida em unique violation — relevante porque a tela dispara N chamadas paralelas por workspace) e passa a usá-lo nos dois caminhos: API e sign-in. A criação continua condicionada a um token Cognito verificado (JWKS + issuer + audience em produção) e só provisiona o próprio email verificado do token — ninguém consegue forçar a criação de email arbitrário.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<sub>Reviews (2): Last reviewed commit: ["🐛bug: rethrow on P2002 with null refetc..."](https://github.com/cloudhumans/typebot.io/commit/682f3d373cf870cd36fda47e2689329ababe0a43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34993297)</sub>

<!-- /greptile_comment -->