### PR TITLE
✨feature: tier visit limit by block type with warn

### DIFF
--- a/packages/bot-engine/enforceBlockVisitLimit.ts
+++ b/packages/bot-engine/enforceBlockVisitLimit.ts
@@ -6,6 +6,7 @@ import { Block, Group, SessionState } from '@typebot.io/schemas'
 // Legacy schema enum value (`OpenAI`) plus forge block ids (lowercase, kebab).
 const LLM_BLOCK_TYPES = new Set<string>([
   'OpenAI',
+  'Zemantic AI',
   'openai',
   'anthropic',
   'mistral',
@@ -69,6 +70,10 @@ export const enforceBlockVisitLimit = ({
   const warnThreshold = isLlm
     ? env.LLM_BLOCK_VISIT_WARN_THRESHOLD
     : env.BLOCK_VISIT_WARN_THRESHOLD
+
+  // Fast path for the common case: nothing to log this visit.
+  if (visitCount !== warnThreshold && visitCount <= limit)
+    return { kind: 'continue', state: newState }
 
   const typebot = newState.typebotsQueue[0].typebot
   const workspaceName = typebot.workspaceName ?? 'unknown'

--- a/packages/bot-engine/enforceBlockVisitLimit.ts
+++ b/packages/bot-engine/enforceBlockVisitLimit.ts
@@ -1,0 +1,122 @@
+import { env } from '@typebot.io/env'
+import logger from '@typebot.io/lib/logger'
+import { Block, Group, SessionState } from '@typebot.io/schemas'
+
+// Block type identifiers for LLM-call integrations.
+// Legacy schema enum value (`OpenAI`) plus forge block ids (lowercase, kebab).
+const LLM_BLOCK_TYPES = new Set<string>([
+  'OpenAI',
+  'openai',
+  'anthropic',
+  'mistral',
+  'open-router',
+  'together-ai',
+  'zemantic-ai',
+  'dify-ai',
+])
+
+export const isLlmBlock = (blockType: string): boolean =>
+  LLM_BLOCK_TYPES.has(blockType)
+
+type Outcome =
+  | { kind: 'continue'; state: SessionState }
+  | { kind: 'terminate'; state: SessionState }
+
+type Params = {
+  state: SessionState
+  block: Block
+  group: Group
+  sessionId?: string
+  willSkipBubble: boolean
+}
+
+/**
+ * Increments the per-block visit counter on the session state and emits
+ * structured warn/error logs when configured thresholds are crossed.
+ *
+ * Returns:
+ * - `{kind:'continue'}` — caller proceeds with the block; updated state included.
+ * - `{kind:'terminate'}` — caller must short-circuit the run, returning the
+ *   updated state with `currentBlockId` cleared so the engine treats the
+ *   session as ended.
+ *
+ * Disabled (no state change, no logs) when `BLOCK_VISIT_LIMIT_ENABLED` is
+ * false or the bubble would be skipped this turn anyway.
+ */
+export const enforceBlockVisitLimit = ({
+  state,
+  block,
+  group,
+  sessionId,
+  willSkipBubble,
+}: Params): Outcome => {
+  if (!env.BLOCK_VISIT_LIMIT_ENABLED || willSkipBubble)
+    return { kind: 'continue', state }
+
+  const visitCount = (state.visitedBlockCounts?.[block.id] ?? 0) + 1
+  const newState: SessionState = {
+    ...state,
+    visitedBlockCounts: {
+      ...(state.visitedBlockCounts ?? {}),
+      [block.id]: visitCount,
+    },
+  }
+
+  const isLlm = isLlmBlock(block.type)
+  const limit = isLlm
+    ? env.MAX_LLM_BLOCK_VISITS_PER_SESSION
+    : env.MAX_BLOCK_VISITS_PER_SESSION
+  const warnThreshold = isLlm
+    ? env.LLM_BLOCK_VISIT_WARN_THRESHOLD
+    : env.BLOCK_VISIT_WARN_THRESHOLD
+
+  const typebot = newState.typebotsQueue[0].typebot
+  const workspaceName = typebot.workspaceName ?? 'unknown'
+  const baseLogPayload = {
+    workspace: {
+      id: typebot.workspaceId ?? 'unknown',
+      name: workspaceName,
+    },
+    workflow: {
+      id: typebot.id,
+      name: typebot.name ?? 'unknown',
+      schema_version: String(typebot.version ?? 'unknown'),
+      execution_id: sessionId ?? 'preview',
+      version_id: typebot.typebotHistoryId ?? 'unknown',
+    },
+    typebot_block: {
+      id: block.id,
+      type: block.type,
+    },
+    typebot_group: {
+      id: group.id,
+      name: group.title,
+    },
+    is_llm: isLlm,
+  }
+
+  if (visitCount === warnThreshold) {
+    logger.warn(
+      `${workspaceName} - Block visit warning threshold reached`,
+      {
+        ...baseLogPayload,
+        visit_count: visitCount,
+        threshold: warnThreshold,
+      }
+    )
+  }
+
+  if (visitCount > limit) {
+    logger.error(`${workspaceName} - Block visit limit exceeded`, {
+      ...baseLogPayload,
+      visit_count: visitCount,
+      limit,
+    })
+    return {
+      kind: 'terminate',
+      state: { ...newState, currentBlockId: undefined },
+    }
+  }
+
+  return { kind: 'continue', state: newState }
+}

--- a/packages/bot-engine/executeGroup.ts
+++ b/packages/bot-engine/executeGroup.ts
@@ -40,6 +40,7 @@ import {
   parseBubbleBlock,
 } from './parseBubbleBlock'
 import logger from '@typebot.io/lib/logger'
+import { enforceBlockVisitLimit } from './enforceBlockVisitLimit'
 
 type ContextProps = {
   version: 1 | 2
@@ -111,58 +112,22 @@ export const executeGroup = async (
       isBubbleBlock(block) &&
       (!block.content || (firstBubbleWasStreamed && index === 0))
 
-    if (env.BLOCK_VISIT_LIMIT_ENABLED && !willSkipBubble) {
-      const visitCount =
-        (newSessionState.visitedBlockCounts?.[block.id] ?? 0) + 1
-      newSessionState = {
-        ...newSessionState,
-        visitedBlockCounts: {
-          ...(newSessionState.visitedBlockCounts ?? {}),
-          [block.id]: visitCount,
-        },
-      }
-
-      if (visitCount > env.MAX_BLOCK_VISITS_PER_SESSION) {
-        const offendingTypebot = newSessionState.typebotsQueue[0].typebot
-        const offendingWorkspaceName =
-          offendingTypebot.workspaceName ?? 'unknown'
-        logger.error(
-          `${offendingWorkspaceName} - Block visit limit exceeded`,
-          {
-            workspace: {
-              id: offendingTypebot.workspaceId ?? 'unknown',
-              name: offendingWorkspaceName,
-            },
-            workflow: {
-              id: offendingTypebot.id,
-              name: offendingTypebot.name ?? 'unknown',
-              schema_version: String(offendingTypebot.version ?? 'unknown'),
-              execution_id: sessionId ?? 'preview',
-              version_id: offendingTypebot.typebotHistoryId ?? 'unknown',
-            },
-            typebot_block: {
-              id: block.id,
-              type: block.type,
-            },
-            typebot_group: {
-              id: group.id,
-              name: group.title,
-            },
-            visit_count: visitCount,
-            limit: env.MAX_BLOCK_VISITS_PER_SESSION,
-          }
-        )
-        return {
-          messages,
-          newSessionState: {
-            ...newSessionState,
-            currentBlockId: undefined,
-          },
-          clientSideActions,
-          logs,
-          visitedEdges,
-          setVariableHistory,
-        }
+    const visitLimitOutcome = enforceBlockVisitLimit({
+      state: newSessionState,
+      block,
+      group,
+      sessionId,
+      willSkipBubble,
+    })
+    newSessionState = visitLimitOutcome.state
+    if (visitLimitOutcome.kind === 'terminate') {
+      return {
+        messages,
+        newSessionState,
+        clientSideActions,
+        logs,
+        visitedEdges,
+        setVariableHistory,
       }
     }
 

--- a/packages/env/env.ts
+++ b/packages/env/env.ts
@@ -83,6 +83,13 @@ const baseEnv = {
     DEBUG: boolean.optional().default('false'),
     CHAT_API_TIMEOUT: z.coerce.number().optional(),
     MAX_BLOCK_VISITS_PER_SESSION: z.coerce.number().int().min(1).default(500),
+    MAX_LLM_BLOCK_VISITS_PER_SESSION: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .default(50),
+    BLOCK_VISIT_WARN_THRESHOLD: z.coerce.number().int().min(1).default(100),
+    LLM_BLOCK_VISIT_WARN_THRESHOLD: z.coerce.number().int().min(1).default(5),
     BLOCK_VISIT_LIMIT_ENABLED: boolean.optional().default('true'),
     // Datadog logging configuration
     DD_LOGS_ENABLED: boolean.optional().default('false'),

--- a/packages/env/env.ts
+++ b/packages/env/env.ts
@@ -82,13 +82,13 @@ const baseEnv = {
       .default('FREE'),
     DEBUG: boolean.optional().default('false'),
     CHAT_API_TIMEOUT: z.coerce.number().optional(),
-    MAX_BLOCK_VISITS_PER_SESSION: z.coerce.number().int().min(1).default(500),
+    MAX_BLOCK_VISITS_PER_SESSION: z.coerce.number().int().min(1).default(200),
     MAX_LLM_BLOCK_VISITS_PER_SESSION: z.coerce
       .number()
       .int()
       .min(1)
-      .default(50),
-    BLOCK_VISIT_WARN_THRESHOLD: z.coerce.number().int().min(1).default(100),
+      .default(10),
+    BLOCK_VISIT_WARN_THRESHOLD: z.coerce.number().int().min(1).default(20),
     LLM_BLOCK_VISIT_WARN_THRESHOLD: z.coerce.number().int().min(1).default(5),
     BLOCK_VISIT_LIMIT_ENABLED: boolean.optional().default('true'),
     // Datadog logging configuration


### PR DESCRIPTION
## Problema

O PR [#208](https://github.com/cloudhumans/typebot.io/pull/208) cobriu o caso geral (cap único de visitas por bloco), mas trata Set Variable e bloco OpenAI no mesmo balde — blocos de LLM são muito mais caros (custo de API por call) e merecem corte muito mais agressivo. Além disso, hoje só descobrimos o problema **depois** que o limite estoura: não há sinal antes pra investigar/agir antes do kill.

## Mudança

Dois eixos sobre a base do #208:

1. **Tier por tipo de bloco**: blocos que fazem chamada de LLM (`OpenAI` legacy + `Zemantic AI` legacy + forge: `openai`, `anthropic`, `mistral`, `open-router`, `together-ai`, `zemantic-ai`, `dify-ai`) têm cap próprio (`MAX_LLM_BLOCK_VISITS_PER_SESSION`, default **10**). O cap geral (`MAX_BLOCK_VISITS_PER_SESSION`, default **200**) continua valendo pros demais blocos.

2. **Warn-tier** (sinal antecipado): `logger.warn` na primeira vez que a contagem cruza um threshold intermediário (`BLOCK_VISIT_WARN_THRESHOLD` default **20**, `LLM_BLOCK_VISIT_WARN_THRESHOLD` default **5**). Dispara uma vez por bloco por sessão (`visitCount === threshold`, não `>=`), então não vira tempestade de log se a sessão estiver em loop. Permite criar monitor no Datadog que avisa antes da sessão queimar o cap inteiro.

Tudo o que envolve essa lógica (classificação, contador, comparação, payload de log estruturado) saiu de dentro do `executeGroup.ts` pra um novo helper `enforceBlockVisitLimit.ts`, seguindo o padrão dos demais helpers do `bot-engine` (single-concern, arquivo flat). Sobra ~13 linhas de invocação no loop principal vs 72 antes, e o safeguard fica testável isoladamente.

O log tem `@is_llm` como facet booleano, então um único monitor Datadog `service:typebot-viewer "Block visit ..." @is_llm:true` resolve toda a separação LLM vs catch-all sem regex.

Ref: cloudhumans/ClaudIA #6816

<!-- greptile_comment -->

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[executeGroup loop — block iteration] --> B{BLOCK_VISIT_LIMIT_ENABLED\n&& !willSkipBubble?}
    B -- No --> C[return continue, state unchanged]
    B -- Yes --> D[increment visitCount\nfor block.id in state]
    D --> E{isLlmBlock\nblock.type?}
    E -- Yes --> F[limit = MAX_LLM_BLOCK_VISITS_PER_SESSION\nwarnThreshold = LLM_BLOCK_VISIT_WARN_THRESHOLD]
    E -- No --> G[limit = MAX_BLOCK_VISITS_PER_SESSION\nwarnThreshold = BLOCK_VISIT_WARN_THRESHOLD]
    F --> H{visitCount !== warnThreshold\n&& visitCount ≤ limit?}
    G --> H
    H -- Yes\nfast path --> C
    H -- No --> I{visitCount ===\nwarnThreshold?}
    I -- Yes --> J[logger.warn\nthreshold reached]
    J --> K{visitCount > limit?}
    I -- No --> K
    K -- No --> C
    K -- Yes --> L[logger.error\nlimit exceeded]
    L --> M[return terminate\ncurrentBlockId = undefined]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fbot-engine%2FenforceBlockVisitLimit.ts%3A1-17%0AConstantes%20de%20tipo%20LLM%20duplicadas%20com%20string%20literal%20em%20vez%20de%20usar%20o%20enum%20%60IntegrationBlockType%60.%20Os%20valores%20%60'OpenAI'%60%20e%20%60'Zemantic%20AI'%60%20j%C3%A1%20existem%20como%20%60IntegrationBlockType.OPEN_AI%60%20e%20%60IntegrationBlockType.ZEMANTIC_AI%60%20em%20%60%40typebot.io%2Fschemas%60%20%E2%80%94%20que%20j%C3%A1%20%C3%A9%20importado%20indiretamente%20via%20o%20%60Block%60%20no%20mesmo%20arquivo.%20Usar%20o%20enum%20elimina%20o%20risco%20de%20drift%20silencioso%20caso%20os%20valores%20do%20enum%20sejam%20renomeados%20no%20futuro.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20env%20%7D%20from%20'%40typebot.io%2Fenv'%0Aimport%20logger%20from%20'%40typebot.io%2Flib%2Flogger'%0Aimport%20%7B%20Block%2C%20Group%2C%20IntegrationBlockType%2C%20SessionState%20%7D%20from%20'%40typebot.io%2Fschemas'%0A%0A%2F%2F%20Block%20type%20identifiers%20for%20LLM-call%20integrations.%0A%2F%2F%20Legacy%20schema%20enum%20values%20plus%20forge%20block%20ids%20%28lowercase%2C%20kebab%29.%0Aconst%20LLM_BLOCK_TYPES%20%3D%20new%20Set%3Cstring%3E%28%5B%0A%20%20IntegrationBlockType.OPEN_AI%2C%0A%20%20IntegrationBlockType.ZEMANTIC_AI%2C%0A%20%20'openai'%2C%0A%20%20'anthropic'%2C%0A%20%20'mistral'%2C%0A%20%20'open-router'%2C%0A%20%20'together-ai'%2C%0A%20%20'zemantic-ai'%2C%0A%20%20'dify-ai'%2C%0A%5D%29%0A%60%60%60%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=212&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fbot-engine%2FenforceBlockVisitLimit.ts%3A1-17%0AConstantes%20de%20tipo%20LLM%20duplicadas%20com%20string%20literal%20em%20vez%20de%20usar%20o%20enum%20%60IntegrationBlockType%60.%20Os%20valores%20%60'OpenAI'%60%20e%20%60'Zemantic%20AI'%60%20j%C3%A1%20existem%20como%20%60IntegrationBlockType.OPEN_AI%60%20e%20%60IntegrationBlockType.ZEMANTIC_AI%60%20em%20%60%40typebot.io%2Fschemas%60%20%E2%80%94%20que%20j%C3%A1%20%C3%A9%20importado%20indiretamente%20via%20o%20%60Block%60%20no%20mesmo%20arquivo.%20Usar%20o%20enum%20elimina%20o%20risco%20de%20drift%20silencioso%20caso%20os%20valores%20do%20enum%20sejam%20renomeados%20no%20futuro.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20env%20%7D%20from%20'%40typebot.io%2Fenv'%0Aimport%20logger%20from%20'%40typebot.io%2Flib%2Flogger'%0Aimport%20%7B%20Block%2C%20Group%2C%20IntegrationBlockType%2C%20SessionState%20%7D%20from%20'%40typebot.io%2Fschemas'%0A%0A%2F%2F%20Block%20type%20identifiers%20for%20LLM-call%20integrations.%0A%2F%2F%20Legacy%20schema%20enum%20values%20plus%20forge%20block%20ids%20%28lowercase%2C%20kebab%29.%0Aconst%20LLM_BLOCK_TYPES%20%3D%20new%20Set%3Cstring%3E%28%5B%0A%20%20IntegrationBlockType.OPEN_AI%2C%0A%20%20IntegrationBlockType.ZEMANTIC_AI%2C%0A%20%20'openai'%2C%0A%20%20'anthropic'%2C%0A%20%20'mistral'%2C%0A%20%20'open-router'%2C%0A%20%20'together-ai'%2C%0A%20%20'zemantic-ai'%2C%0A%20%20'dify-ai'%2C%0A%5D%29%0A%60%60%60%0A%0A&pr=212&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/bot-engine/enforceBlockVisitLimit.ts:1-17
Constantes de tipo LLM duplicadas com string literal em vez de usar o enum `IntegrationBlockType`. Os valores `'OpenAI'` e `'Zemantic AI'` já existem como `IntegrationBlockType.OPEN_AI` e `IntegrationBlockType.ZEMANTIC_AI` em `@typebot.io/schemas` — que já é importado indiretamente via o `Block` no mesmo arquivo. Usar o enum elimina o risco de drift silencioso caso os valores do enum sejam renomeados no futuro.

```suggestion
import { env } from '@typebot.io/env'
import logger from '@typebot.io/lib/logger'
import { Block, Group, IntegrationBlockType, SessionState } from '@typebot.io/schemas'

// Block type identifiers for LLM-call integrations.
// Legacy schema enum values plus forge block ids (lowercase, kebab).
const LLM_BLOCK_TYPES = new Set<string>([
  IntegrationBlockType.OPEN_AI,
  IntegrationBlockType.ZEMANTIC_AI,
  'openai',
  'anthropic',
  'mistral',
  'open-router',
  'together-ai',
  'zemantic-ai',
  'dify-ai',
])
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["🩹enhancement: refine block-visit-limit ..."](https://github.com/cloudhumans/typebot.io/commit/b39f09135537d3177d8130949fdfefe1544baf4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35153261)</sub>

<!-- /greptile_comment -->