### PR TITLE
add design specs for security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ snapshots
 .env
 .typebot-build
 .pnpm-store
+.antigravitycli

--- a/docs/superpowers/plans/2026-06-02-credential-security-implementation-plan.md
+++ b/docs/superpowers/plans/2026-06-02-credential-security-implementation-plan.md
@@ -1,0 +1,189 @@
+# Implementation Plan: Credential Security (REST Data Sources)
+
+This implementation plan outlines the exact file modifications, additions, and validation steps required to introduce secure workspace-scoped REST credentials in the HTTP Request blocks.
+
+---
+
+## 🏗️ 1. Schema & Validation Layer
+
+We will define the schema for the REST API Credentials inside the schemas package. Since we reuse the existing `Credentials` database table, no Prisma migration is needed.
+
+### 📁 Files to Modify:
+* **`packages/schemas/features/blocks/integrations/webhook/schema.ts`**
+  - Define `restApiCredentialsSchema` using `credentialsBaseSchema`.
+  - Add `credentialsId?: string` to `httpRequestOptionsV5Schema`.
+* **`packages/schemas/features/credentials.ts`**
+  - Import `restApiCredentialsSchema`.
+  - Register it in the `credentialsSchema` discriminated union.
+
+### 📝 Code Specifications:
+
+#### `packages/schemas/features/blocks/integrations/webhook/schema.ts`
+```typescript
+import { credentialsBaseSchema } from '../../shared'
+
+export const restApiCredentialsSchema = z
+  .object({
+    type: z.literal('rest-api'),
+    data: z.object({
+      baseUrl: z.string().url("A URL Base configurada precisa ser válida."),
+      headers: z.array(
+        z.object({
+          key: z.string().min(1, "A chave do header não pode ser vazia."),
+          value: z.string(),
+        })
+      ).optional(),
+      queryParams: z.array(
+        z.object({
+          key: z.string().min(1, "A chave do parâmetro não pode ser vazia."),
+          value: z.string(),
+        })
+      ).optional(),
+      createdById: z.string().min(1, "O ID do usuário criador é obrigatório."),
+    }),
+  })
+  .merge(credentialsBaseSchema)
+
+export type RestApiCredentials = z.infer<typeof restApiCredentialsSchema>
+```
+
+Add `credentialsId` inside `httpRequestOptionsV5Schema`:
+```typescript
+export const httpRequestOptionsV5Schema = z.object({
+  credentialsId: z.string().optional(),
+  variablesForTest: z.array(variableForTestSchema).optional(),
+  // ... (rest remains unchanged)
+})
+```
+
+---
+
+## 📡 2. Backend & API Layer (tRPC Router)
+
+We need to register the new schema in the creation endpoint and add a secure query to expose credential metadata to the builder without sending actual secrets to the client.
+
+### 📁 Files to Modify/Create:
+* **`apps/builder/src/features/credentials/api/createCredentials.ts`**
+  - Import `restApiCredentialsSchema` and include its fields in the validation union.
+* **`apps/builder/src/features/credentials/api/getRestApiCredential.ts`** (NEW)
+  - Implement a secure read endpoint that returns only masked fields (e.g. replacing secret values with `••••••••`).
+* **`apps/builder/src/features/credentials/api/router.ts`**
+  - Register `getRestApiCredential` query.
+
+### 📝 Code Specifications:
+
+#### `apps/builder/src/features/credentials/api/getRestApiCredential.ts`
+```typescript
+import prisma from '@typebot.io/lib/prisma'
+import { authenticatedProcedure } from '@/helpers/server/trpc'
+import { TRPCError } from '@trpc/server'
+import { decrypt } from '@typebot.io/lib/api/encryption/decrypt'
+import { z } from 'zod'
+import { isReadWorkspaceFobidden } from '@/features/workspace/helpers/isReadWorkspaceFobidden'
+import { RestApiCredentials } from '@typebot.io/schemas'
+
+export const getRestApiCredential = authenticatedProcedure
+  .input(
+    z.object({
+      workspaceId: z.string(),
+      credentialsId: z.string(),
+    })
+  )
+  .output(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      baseUrl: z.string(),
+      headers: z.array(z.object({ key: z.string(), value: z.string() })),
+      queryParams: z.array(z.object({ key: z.string(), value: z.string() })),
+    })
+  )
+  .query(async ({ input: { workspaceId, credentialsId }, ctx: { user } }) => {
+    const workspace = await prisma.workspace.findFirst({
+      where: { id: workspaceId },
+      select: {
+        id: true,
+        members: true,
+        credentials: {
+          where: { id: credentialsId, type: 'rest-api' },
+        },
+      },
+    })
+    
+    if (!workspace || isReadWorkspaceFobidden(workspace, user))
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Workspace not found' })
+
+    const credential = workspace.credentials[0]
+    if (!credential)
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Credential not found' })
+
+    const decrypted = (await decrypt(credential.data, credential.iv)) as RestApiCredentials['data']
+
+    return {
+      id: credential.id,
+      name: credential.name,
+      baseUrl: decrypted.baseUrl,
+      headers: (decrypted.headers ?? []).map(h => ({ key: h.key, value: '••••••••' })),
+      queryParams: (decrypted.queryParams ?? []).map(q => ({ key: q.key, value: '••••••••' })),
+    }
+  })
+```
+
+---
+
+## 🎨 3. UI Layer (React Components)
+
+Introduce the selection flow and lock down inputs in the settings panel.
+
+### 📁 Files to Modify/Create:
+* **`apps/builder/src/features/blocks/integrations/webhook/components/RestApiCredentialsModal.tsx`** (NEW)
+  - Credentials creation modal allowing workspace admins to define secure credentials.
+* **`apps/builder/src/features/blocks/integrations/webhook/components/HttpRequestSettings.tsx`**
+  - Add the `CredentialsDropdown` component.
+  - Implement dynamic rendering: if a credential is selected, show locked URL combination, otherwise display a normal URL text input.
+* **`apps/builder/src/features/blocks/integrations/webhook/components/HttpRequestAdvancedConfigForm.tsx`**
+  - Pass down credential configuration and display read-only inherited headers & query parameters when active.
+
+---
+
+## 🚀 4. Runtime Layer (Bot Engine)
+
+Execute safe concatenation and merge values correctly on the server side during bot execution.
+
+### 📁 Files to Modify:
+* **`packages/bot-engine/blocks/integrations/webhook/executeWebhookBlock.ts`**
+  - When running an HTTP block, if `block.options.credentialsId` is defined:
+    1. Fetch and decrypt the credential from the DB.
+    2. Interpolate variables on BOTH the credentials base parameters and the block configurations.
+    3. Concatenate the URLs safely: `const resolvedUrl = cleanUrlConcat(parsedBaseUrl, blockUrlSuffix)`.
+    4. Merge headers: global headers + local headers (local overrides global).
+    5. Merge query parameters: global queryParams + local queryParams (local overrides global).
+    6. Mask global header values in transaction log details to ensure secret variables are never logged.
+
+### 📝 Code Specifications (Concatenation & Merging logic):
+```typescript
+const cleanUrlConcat = (base: string, suffix: string): string => {
+  const cleanBase = base.endsWith('/') ? base.slice(0, -1) : base
+  const cleanSuffix = suffix.startsWith('/') ? suffix : `/${suffix}`
+  return `${cleanBase}${cleanSuffix}`
+}
+```
+
+---
+
+## 🧪 5. Testing & Verification Checklist
+
+To verify that the feature works and maintains retrocompatibility:
+
+### ⚙️ Unit & Integration Tests
+1. **Zod Validation Test**: Verify that valid `rest-api` credential values pass schema check, and invalid/empty fields fail.
+2. **Merging Rules Test**: Verify that local headers/query params override global values in `executeWebhookBlock.ts`.
+3. **Safe Concatenation Test**: Verify that combinations like `http://example.com/` + `/path` resolve to `http://example.com/path` without doubling slashes.
+4. **Credential Decryption Failure handling**: Verify behavior if a referenced credential has been deleted or cannot be decrypted.
+
+### 🌐 E2E & Playwright Coverage
+* Add a test case in `apps/builder/src/features/blocks/integrations/webhook/webhook.spec.ts` (or playwright spec):
+  - Add a REST API Credential named "Test Sec Cred" with headers and a base URL.
+  - Create a flow with an HTTP block. Select the "Test Sec Cred" credential.
+  - Validate that the URL input becomes locked, showing the base URL tag, and allows typing only the path suffix.
+  - Test run the block and assert that request executes successfully and header secrets are masked in logs.

--- a/docs/superpowers/specs/2026-06-02-credential-security-design.md
+++ b/docs/superpowers/specs/2026-06-02-credential-security-design.md
@@ -1,0 +1,115 @@
+# Design Specification: Credential Security (REST Data Sources)
+
+**Date**: 2026-06-02  
+**Status**: Approved  
+**Author**: Antigravity AI  
+
+---
+
+## 🎯 Executive Summary
+This design document specifies the architecture, data layer, UI components, and secure execution runtime for the **Credential Security (REST Data Sources)** feature. 
+The feature introduces workspace-scoped REST API credentials to mask secrets and lock Base URLs, preventing token exfiltration in HTTP blocks while supporting dynamic variable interpolation.
+
+---
+
+## 💾 1. Data Layer: REST Data Source Schema
+
+We reuse the existing generic `Credentials` Prisma model in the database to prevent database migrations and preserve retrocompatibility.
+
+### 1.1 Database Representation (`Credentials` Table)
+* `type`: `"rest-api"`
+* `name`: User-defined label (e.g., `"Stripe Production"`).
+* `workspaceId`: Binds the credential strictly to the owner workspace.
+* `data`: Symmetric-key encrypted JSON payload using `ENCRYPTION_SECRET`.
+* `iv`: Initialization vector for the encrypted string.
+* `createdAt`: Automatically populated database timestamp.
+
+### 1.2 Encrypted JSON Schema (`data` payload)
+The decrypted JSON structure inside the `data` field contains base URL, headers, query parameters, and creator auditing metadata:
+```json
+{
+  "baseUrl": "https://api.stripe.com/v1",
+  "headers": [
+    {
+      "key": "Authorization",
+      "value": "Bearer sk_test_51Nz..."
+    }
+  ],
+  "queryParams": [
+    {
+      "key": "api_key",
+      "value": "sec_12345"
+    }
+  ],
+  "createdById": "cl_user_id_123"
+}
+```
+
+### 1.3 Schema Validation (Zod)
+We define the structure validation in `@typebot.io/schemas`:
+```typescript
+import { z } from 'zod'
+
+export const restApiCredentialDataSchema = z.object({
+  baseUrl: z.string().url("A URL Base configurada precisa ser válida."),
+  headers: z.array(z.object({
+    key: z.string().min(1, "A chave do header não pode ser vazia."),
+    value: z.string()
+  })),
+  queryParams: z.array(z.object({
+    key: z.string().min(1, "A chave do parâmetro não pode ser vazia."),
+    value: z.string()
+  })),
+  createdById: z.string().min(1, "O ID do usuário criador é obrigatório.")
+})
+
+export type RestApiCredentialData = z.infer<typeof restApiCredentialDataSchema>
+```
+
+---
+
+## 🎨 2. UI Layer: REST Credentials & HTTP Block URL Locking
+
+### 2.1 Credentials Management Modal (`RestApiCredentialsModal.tsx`)
+A new modal is opened when the builder clicks "Connect New" in the HTTP block's `CredentialsDropdown`.
+* **Inputs**:
+  - Name (String input).
+  - Base URL (String input, validated as URL).
+  - Headers Table: Dynamic key-value row insertion. Header values are masked (using input `type="password"`) for security, displaying `••••••••` upon reload.
+  - Query Params Table: Dynamic key-value row insertion with masked values.
+* **Auditing**: Automatically captures `ctx.user.id` on submit and stores it in the credential's JSON metadata payload.
+
+### 2.2 Block UI State Transitions
+The HTTP Request Block settings panel dynamically adjusts based on the active `CredentialsDropdown` state:
+
+* **State 1: Custom URL / No Authentication**
+  - Displays a single, open URL text input.
+  - Allows full inline editing of local headers and query parameters.
+  - Guarantees 100% retrocompatibility with legacy blocks (where `credentialsId` is undefined).
+* **State 2: Secured Credential Active**
+  - Replaces the URL text input with a locked combination: `[ 🔒 Credential Base URL ]` (Read-only tag) followed by `[ Suffix / Relative Path Suffix ]` (Editable input).
+  - Shows inherited global headers and query parameters at the top of their respective lists as read-only, masked entries (e.g. `Authorization: ••••••••••••`).
+
+---
+
+## 🚀 3. Execution Layer: Safe Server-Side Runtime & Parsing
+
+### 3.1 Parsing & Merging (`executeWebhookBlock.ts`)
+When the bot-engine runs an HTTP block:
+1. **Fetch & Decrypt**: If `block.options.credentialsId` is present, the server retrieves and decrypts the credentials payload from the DB.
+2. **Variable Interpolation**: Apply `parseVariables` over the decrypted credentials fields (`baseUrl`, `headers`, `queryParams`) and the block-level configuration fields.
+3. **Merging Rules**:
+   - **URL Resolution**: `parsedBaseUrl` is concatenated with `parsedSubPath` (normalizing double slashes).
+   - **Headers**: Merge parsed global headers and local headers. Block-level local headers override global ones in case of duplicate keys.
+   - **Query Params**: Merge parsed global and local parameters. Block-level local parameters override global ones.
+
+### 3.2 Logging Security
+All transaction traces and error messages stored in `ChatLog` must mask variables originating from the secure credentials database record, preserving secrecy in production dashboard listings.
+
+---
+
+## 🧪 4. Testing Plan
+* **Prisma Validation**: Test the schema serialization and deserialization of the new Zod definition.
+* **Variables Parsing**: Test variable parsing within the base URL, headers, and query parameters of the credential.
+* **Merging Test**: Verify that block-level parameters override credential-level parameters correctly.
+* **UI State Checks**: Ensure legacy HTTP blocks correctly fall back to the open URL input.


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Security Review</h3></summary>

- **Vazamento de `queryParams` em logs** (`plans/2026-06-02-credential-security-implementation-plan.md`, linha 161): O passo de runtime especifica mascarar apenas headers globais nos `ChatLog`, omitindo `queryParams`. Como a própria spec de dados inclui segredos em `queryParams` (ex: `api_key`), uma implementação que siga literalmente o plano exporá esses valores nos logs de produção.
</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor User as Builder User
    participant UI as Builder UI
    participant tRPC as tRPC Router
    participant DB as Prisma / DB
    participant Crypto as Encryption Layer
    participant Engine as Bot Engine

    User->>UI: Criar nova credencial REST
    UI->>tRPC: createCredentials(workspaceId, data)
    tRPC->>Crypto: encrypt(data, ENCRYPTION_SECRET)
    Crypto-->>tRPC: "{ encryptedData, iv }"
    tRPC->>DB: "credentials.create({ type: rest-api, data, iv })"
    DB-->>tRPC: "{ id, name }"
    tRPC-->>UI: credentialId

    User->>UI: Abrir settings do bloco HTTP
    UI->>tRPC: getRestApiCredential(workspaceId, credentialsId)
    tRPC->>DB: workspace.findFirst(credentials where id)
    DB-->>tRPC: "{ data, iv }"
    tRPC->>Crypto: decrypt(data, iv)
    Crypto-->>tRPC: "{ baseUrl, headers, queryParams }"
    tRPC-->>UI: "{ baseUrl, headers:[masked], queryParams:[masked] }"
    Note over UI: URL bloqueada + campos mascarados exibidos

    User->>UI: Executar Bot
    UI->>Engine: executeWebhookBlock(block + credentialsId)
    Engine->>DB: buscar e descriptografar credencial
    DB-->>Engine: "{ baseUrl, headers, queryParams }"
    Engine->>Engine: cleanUrlConcat(baseUrl, suffix)
    Engine->>Engine: merge headers e queryParams
    Engine->>Engine: mascarar valores de credencial nos logs
    Engine-->>UI: resposta HTTP
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Adocs%2Fsuperpowers%2Fplans%2F2026-06-02-credential-security-implementation-plan.md%3A165-169%0A**%60cleanUrlConcat%60%20adiciona%20barra%20indesejada%20quando%20o%20sufixo%20%C3%A9%20vazio**%0A%0AQuando%20o%20usu%C3%A1rio%20n%C3%A3o%20preenche%20nenhum%20sufixo%20de%20caminho%20%28campo%20em%20branco%29%2C%20a%20fun%C3%A7%C3%A3o%20recebe%20%60suffix%20%3D%20%22%22%60.%20Como%20%60%22%22.startsWith%28'%2F'%29%60%20%C3%A9%20%60false%60%2C%20%60cleanSuffix%60%20vira%20%60%22%2F%22%60%2C%20e%20a%20URL%20resultante%20fica%20%60https%3A%2F%2Fapi.stripe.com%2Fv1%2F%60%20com%20barra%20final%20%E2%80%94%20diferente%20da%20%60baseUrl%60%20salva%20na%20credencial.%20Algumas%20APIs%20REST%20%28como%20a%20pr%C3%B3pria%20Stripe%29%20diferenciam%20rotas%20com%20e%20sem%20trailing%20slash%2C%20o%20que%20pode%20causar%20erros%20%60404%60%20para%20credenciais%20que%20apontam%20para%20raiz%20de%20vers%C3%A3o%20da%20API.%20A%20l%C3%B3gica%20precisa%20tratar%20o%20caso%20de%20%60suffix%60%20vazio%20antes%20de%20for%C3%A7ar%20o%20prefixo%20%60%22%2F%22%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Adocs%2Fsuperpowers%2Fplans%2F2026-06-02-credential-security-implementation-plan.md%3A30-41%0A**Inconsist%C3%AAncia%20na%20obrigatoriedade%20de%20%60headers%60%20e%20%60queryParams%60%20entre%20spec%20e%20plano**%0A%0AO%20design%20spec%20%28%602026-06-02-credential-security-design.md%60%2C%20linhas%2055%E2%80%9362%29%20define%20%60headers%60%20e%20%60queryParams%60%20como%20arrays%20**obrigat%C3%B3rios**%20no%20%60restApiCredentialDataSchema%60.%20Aqui%2C%20o%20plano%20os%20declara%20como%20%60.optional%28%29%60.%20Essa%20diverg%C3%AAncia%20pode%20gerar%20duas%20implementa%C3%A7%C3%B5es%20incompat%C3%ADveis%3A%20credenciais%20salvas%20sem%20esses%20campos%20passar%C3%A3o%20pela%20valida%C3%A7%C3%A3o%20do%20plano%2C%20mas%20falhar%C3%A3o%20ao%20serem%20lidas%20por%20um%20sistema%20que%20espera%20arrays%20obrigat%C3%B3rios%20%28ou%20vice-versa%29.%20O%20comportamento%20de%20fallback%20%60%3F%3F%20%5B%5D%60%20em%20%60getRestApiCredential.ts%60%20foi%20adicionado%20justamente%20por%20conta%20do%20%60.optional%28%29%60%2C%20mas%20n%C3%A3o%20%C3%A9%20necess%C3%A1rio%20se%20o%20schema%20exigir%20os%20campos.%20%C3%89%20preciso%20alinhar%20os%20dois%20documentos%20antes%20de%20implementar.%0A%0A%23%23%23%20Issue%203%20of%203%0Adocs%2Fsuperpowers%2Fplans%2F2026-06-02-credential-security-implementation-plan.md%3A161%0A**Mascaramento%20de%20logs%20incompleto%3A%20%60queryParams%60%20n%C3%A3o%20%C3%A9%20mencionado**%0A%0AO%20passo%206%20especifica%20mascarar%20apenas%20%22valores%20de%20headers%20globais%22%20nos%20logs%20de%20transa%C3%A7%C3%A3o.%20No%20entanto%2C%20%60queryParams%60%20tamb%C3%A9m%20pode%20conter%20segredos%20%28ex.%3A%20%60%3Fapi_key%3Dsk_live_...%60%29%2C%20e%20o%20pr%C3%B3prio%20example%20de%20payload%20do%20design%20spec%20mostra%20um%20%60queryParam%60%20com%20valor%20secreto%20%28%60%22value%22%3A%20%22sec_12345%22%60%29.%20A%20se%C3%A7%C3%A3o%203.2%20do%20spec%20exige%20mascarar%20todos%20os%20campos%20da%20credencial%20%28%60ChatLog%60%20n%C3%A3o%20deve%20expor%20nenhum%20segredo%29%2C%20mas%20um%20desenvolvedor%20seguindo%20apenas%20o%20plano%20pode%20implementar%20o%20mascaramento%20somente%20para%20headers%2C%20deixando%20valores%20de%20%60queryParams%60%20expostos%20nos%20logs%20da%20produ%C3%A7%C3%A3o.%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=213&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Adocs%2Fsuperpowers%2Fplans%2F2026-06-02-credential-security-implementation-plan.md%3A165-169%0A**%60cleanUrlConcat%60%20adiciona%20barra%20indesejada%20quando%20o%20sufixo%20%C3%A9%20vazio**%0A%0AQuando%20o%20usu%C3%A1rio%20n%C3%A3o%20preenche%20nenhum%20sufixo%20de%20caminho%20%28campo%20em%20branco%29%2C%20a%20fun%C3%A7%C3%A3o%20recebe%20%60suffix%20%3D%20%22%22%60.%20Como%20%60%22%22.startsWith%28'%2F'%29%60%20%C3%A9%20%60false%60%2C%20%60cleanSuffix%60%20vira%20%60%22%2F%22%60%2C%20e%20a%20URL%20resultante%20fica%20%60https%3A%2F%2Fapi.stripe.com%2Fv1%2F%60%20com%20barra%20final%20%E2%80%94%20diferente%20da%20%60baseUrl%60%20salva%20na%20credencial.%20Algumas%20APIs%20REST%20%28como%20a%20pr%C3%B3pria%20Stripe%29%20diferenciam%20rotas%20com%20e%20sem%20trailing%20slash%2C%20o%20que%20pode%20causar%20erros%20%60404%60%20para%20credenciais%20que%20apontam%20para%20raiz%20de%20vers%C3%A3o%20da%20API.%20A%20l%C3%B3gica%20precisa%20tratar%20o%20caso%20de%20%60suffix%60%20vazio%20antes%20de%20for%C3%A7ar%20o%20prefixo%20%60%22%2F%22%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Adocs%2Fsuperpowers%2Fplans%2F2026-06-02-credential-security-implementation-plan.md%3A30-41%0A**Inconsist%C3%AAncia%20na%20obrigatoriedade%20de%20%60headers%60%20e%20%60queryParams%60%20entre%20spec%20e%20plano**%0A%0AO%20design%20spec%20%28%602026-06-02-credential-security-design.md%60%2C%20linhas%2055%E2%80%9362%29%20define%20%60headers%60%20e%20%60queryParams%60%20como%20arrays%20**obrigat%C3%B3rios**%20no%20%60restApiCredentialDataSchema%60.%20Aqui%2C%20o%20plano%20os%20declara%20como%20%60.optional%28%29%60.%20Essa%20diverg%C3%AAncia%20pode%20gerar%20duas%20implementa%C3%A7%C3%B5es%20incompat%C3%ADveis%3A%20credenciais%20salvas%20sem%20esses%20campos%20passar%C3%A3o%20pela%20valida%C3%A7%C3%A3o%20do%20plano%2C%20mas%20falhar%C3%A3o%20ao%20serem%20lidas%20por%20um%20sistema%20que%20espera%20arrays%20obrigat%C3%B3rios%20%28ou%20vice-versa%29.%20O%20comportamento%20de%20fallback%20%60%3F%3F%20%5B%5D%60%20em%20%60getRestApiCredential.ts%60%20foi%20adicionado%20justamente%20por%20conta%20do%20%60.optional%28%29%60%2C%20mas%20n%C3%A3o%20%C3%A9%20necess%C3%A1rio%20se%20o%20schema%20exigir%20os%20campos.%20%C3%89%20preciso%20alinhar%20os%20dois%20documentos%20antes%20de%20implementar.%0A%0A%23%23%23%20Issue%203%20of%203%0Adocs%2Fsuperpowers%2Fplans%2F2026-06-02-credential-security-implementation-plan.md%3A161%0A**Mascaramento%20de%20logs%20incompleto%3A%20%60queryParams%60%20n%C3%A3o%20%C3%A9%20mencionado**%0A%0AO%20passo%206%20especifica%20mascarar%20apenas%20%22valores%20de%20headers%20globais%22%20nos%20logs%20de%20transa%C3%A7%C3%A3o.%20No%20entanto%2C%20%60queryParams%60%20tamb%C3%A9m%20pode%20conter%20segredos%20%28ex.%3A%20%60%3Fapi_key%3Dsk_live_...%60%29%2C%20e%20o%20pr%C3%B3prio%20example%20de%20payload%20do%20design%20spec%20mostra%20um%20%60queryParam%60%20com%20valor%20secreto%20%28%60%22value%22%3A%20%22sec_12345%22%60%29.%20A%20se%C3%A7%C3%A3o%203.2%20do%20spec%20exige%20mascarar%20todos%20os%20campos%20da%20credencial%20%28%60ChatLog%60%20n%C3%A3o%20deve%20expor%20nenhum%20segredo%29%2C%20mas%20um%20desenvolvedor%20seguindo%20apenas%20o%20plano%20pode%20implementar%20o%20mascaramento%20somente%20para%20headers%2C%20deixando%20valores%20de%20%60queryParams%60%20expostos%20nos%20logs%20da%20produ%C3%A7%C3%A3o.%0A%0A&pr=213&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
docs/superpowers/plans/2026-06-02-credential-security-implementation-plan.md:165-169
**`cleanUrlConcat` adiciona barra indesejada quando o sufixo é vazio**

Quando o usuário não preenche nenhum sufixo de caminho (campo em branco), a função recebe `suffix = ""`. Como `"".startsWith('/')` é `false`, `cleanSuffix` vira `"/"`, e a URL resultante fica `https://api.stripe.com/v1/` com barra final — diferente da `baseUrl` salva na credencial. Algumas APIs REST (como a própria Stripe) diferenciam rotas com e sem trailing slash, o que pode causar erros `404` para credenciais que apontam para raiz de versão da API. A lógica precisa tratar o caso de `suffix` vazio antes de forçar o prefixo `"/"`.

### Issue 2 of 3
docs/superpowers/plans/2026-06-02-credential-security-implementation-plan.md:30-41
**Inconsistência na obrigatoriedade de `headers` e `queryParams` entre spec e plano**

O design spec (`2026-06-02-credential-security-design.md`, linhas 55–62) define `headers` e `queryParams` como arrays **obrigatórios** no `restApiCredentialDataSchema`. Aqui, o plano os declara como `.optional()`. Essa divergência pode gerar duas implementações incompatíveis: credenciais salvas sem esses campos passarão pela validação do plano, mas falharão ao serem lidas por um sistema que espera arrays obrigatórios (ou vice-versa). O comportamento de fallback `?? []` em `getRestApiCredential.ts` foi adicionado justamente por conta do `.optional()`, mas não é necessário se o schema exigir os campos. É preciso alinhar os dois documentos antes de implementar.

### Issue 3 of 3
docs/superpowers/plans/2026-06-02-credential-security-implementation-plan.md:161
**Mascaramento de logs incompleto: `queryParams` não é mencionado**

O passo 6 especifica mascarar apenas "valores de headers globais" nos logs de transação. No entanto, `queryParams` também pode conter segredos (ex.: `?api_key=sk_live_...`), e o próprio example de payload do design spec mostra um `queryParam` com valor secreto (`"value": "sec_12345"`). A seção 3.2 do spec exige mascarar todos os campos da credencial (`ChatLog` não deve expor nenhum segredo), mas um desenvolvedor seguindo apenas o plano pode implementar o mascaramento somente para headers, deixando valores de `queryParams` expostos nos logs da produção.

`````

</details>

<sub>Reviews (25): Last reviewed commit: ["docs: add REST credentials security plan..."](https://github.com/cloudhumans/typebot.io/commit/7ef98604abeefc8e1342634d441b35f24fb5d47e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35225265)</sub>

<!-- /greptile_comment -->