### PR TITLE
🐛bug: narrow firstBubbleWasStreamed in willSkipBubble

### DIFF
--- a/packages/bot-engine/executeGroup.ts
+++ b/packages/bot-engine/executeGroup.ts
@@ -110,7 +110,7 @@ export const executeGroup = async (
 
     const willSkipBubble =
       isBubbleBlock(block) &&
-      (!block.content || (firstBubbleWasStreamed && index === 0))
+      (!block.content || (firstBubbleWasStreamed === true && index === 0))
 
     const visitLimitOutcome = enforceBlockVisitLimit({
       state: newSessionState,


### PR DESCRIPTION
## Problema

O merge do PR [#212](https://github.com/cloudhumans/typebot.io/pull/212) quebrou o build do \`main\` (run [26882725403](https://github.com/cloudhumans/typebot.io/actions/runs/26882725403)):

\`\`\`
packages/bot-engine/executeGroup.ts:120:7
Type error: Type 'boolean | undefined' is not assignable to type 'boolean'.
\`\`\`

O const \`willSkipBubble\` foi inferido como \`boolean | undefined\` porque \`firstBubbleWasStreamed\` é opcional em \`ContextProps\` (\`?: boolean\`) e \`undefined && index === 0\` vaza \`undefined\` pra fora do \`||\` e do \`&&\` externos. A helper \`enforceBlockVisitLimit\` exige \`willSkipBubble: boolean\` estrito.

O mesmo padrão funcionava no PR [#208](https://github.com/cloudhumans/typebot.io/pull/208) porque a expressão era inline num \`if (...)\` (contexto truthy aceita a union). O PR #212 extraiu pra const tipado, deixando o type leak visível.

Não foi pego localmente porque o devbox roda \`next dev\` (looser); CI usa \`next build\` (strict).

## Mudança

Estreita o check pra \`firstBubbleWasStreamed === true\`, fazendo a expressão inteira tipar como \`boolean\` puro. Diff de 1 linha, runtime idêntico (valor possível só é \`true | false | undefined\`).

Validado local rodando \`pnpm exec tsc --noEmit\` no container \`typebot-builder\` — passou sem erros.

<!-- greptile_comment -->

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Loop sobre group.blocks] --> B[index++]
    B --> C{block.type === NOTE?}
    C -- sim --> A
    C -- não --> D["willSkipBubble =\nisBubbleBlock(block) &&\n(!block.content || firstBubbleWasStreamed === true && index === 0)"]
    D --> E[enforceBlockVisitLimit\nwillSkipBubble: boolean]
    E --> F{isBubbleBlock?}
    F -- sim --> G{"!block.content ||\nfirstBubbleWasStreamed && index === 0"}
    G -- sim --> A
    G -- não --> H[parseBubbleBlock → messages.push]
    F -- não --> I[executar bloco de input/lógica]
    H --> A
    I --> A
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/bot-engine/executeGroup.ts`, line 135 ([link](https://github.com/cloudhumans/typebot.io/blob/ba9def4345e3e5c7811c375971d178cc0c4c0bf4/packages/bot-engine/executeGroup.ts#L135)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Inconsistência de padrão: a verificação na linha 135 ainda usa `firstBubbleWasStreamed` como truthy check, enquanto a linha 113 (corrigida neste PR) passou a usar `=== true`. Embora o comportamento em runtime seja idêntico (ambas as linhas lidam com os mesmos valores possíveis: `true | false | undefined`), se alguém extrair a expressão da linha 135 para um `const` tipado no futuro, o mesmo erro de build vai reaparecer.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/bot-engine/executeGroup.ts
   Line: 135

   Comment:
   Inconsistência de padrão: a verificação na linha 135 ainda usa `firstBubbleWasStreamed` como truthy check, enquanto a linha 113 (corrigida neste PR) passou a usar `=== true`. Embora o comportamento em runtime seja idêntico (ambas as linhas lidam com os mesmos valores possíveis: `true | false | undefined`), se alguém extrair a expressão da linha 135 para um `const` tipado no futuro, o mesmo erro de build vai reaparecer.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fbot-engine%2FexecuteGroup.ts%0ALine%3A%20135%0A%0AComment%3A%0AInconsist%C3%AAncia%20de%20padr%C3%A3o%3A%20a%20verifica%C3%A7%C3%A3o%20na%20linha%20135%20ainda%20usa%20%60firstBubbleWasStreamed%60%20como%20truthy%20check%2C%20enquanto%20a%20linha%20113%20%28corrigida%20neste%20PR%29%20passou%20a%20usar%20%60%3D%3D%3D%20true%60.%20Embora%20o%20comportamento%20em%20runtime%20seja%20id%C3%AAntico%20%28ambas%20as%20linhas%20lidam%20com%20os%20mesmos%20valores%20poss%C3%ADveis%3A%20%60true%20%7C%20false%20%7C%20undefined%60%29%2C%20se%20algu%C3%A9m%20extrair%20a%20express%C3%A3o%20da%20linha%20135%20para%20um%20%60const%60%20tipado%20no%20futuro%2C%20o%20mesmo%20erro%20de%20build%20vai%20reaparecer.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28!block.content%20%7C%7C%20%28firstBubbleWasStreamed%20%3D%3D%3D%20true%20%26%26%20index%20%3D%3D%3D%200%29%29%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudhumans%2Ftypebot.io&pr=215&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fbot-engine%2FexecuteGroup.ts%0ALine%3A%20135%0A%0AComment%3A%0AInconsist%C3%AAncia%20de%20padr%C3%A3o%3A%20a%20verifica%C3%A7%C3%A3o%20na%20linha%20135%20ainda%20usa%20%60firstBubbleWasStreamed%60%20como%20truthy%20check%2C%20enquanto%20a%20linha%20113%20%28corrigida%20neste%20PR%29%20passou%20a%20usar%20%60%3D%3D%3D%20true%60.%20Embora%20o%20comportamento%20em%20runtime%20seja%20id%C3%AAntico%20%28ambas%20as%20linhas%20lidam%20com%20os%20mesmos%20valores%20poss%C3%ADveis%3A%20%60true%20%7C%20false%20%7C%20undefined%60%29%2C%20se%20algu%C3%A9m%20extrair%20a%20express%C3%A3o%20da%20linha%20135%20para%20um%20%60const%60%20tipado%20no%20futuro%2C%20o%20mesmo%20erro%20de%20build%20vai%20reaparecer.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28!block.content%20%7C%7C%20%28firstBubbleWasStreamed%20%3D%3D%3D%20true%20%26%26%20index%20%3D%3D%3D%200%29%29%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=215&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fbot-engine%2FexecuteGroup.ts%3A135%0AInconsist%C3%AAncia%20de%20padr%C3%A3o%3A%20a%20verifica%C3%A7%C3%A3o%20na%20linha%20135%20ainda%20usa%20%60firstBubbleWasStreamed%60%20como%20truthy%20check%2C%20enquanto%20a%20linha%20113%20%28corrigida%20neste%20PR%29%20passou%20a%20usar%20%60%3D%3D%3D%20true%60.%20Embora%20o%20comportamento%20em%20runtime%20seja%20id%C3%AAntico%20%28ambas%20as%20linhas%20lidam%20com%20os%20mesmos%20valores%20poss%C3%ADveis%3A%20%60true%20%7C%20false%20%7C%20undefined%60%29%2C%20se%20algu%C3%A9m%20extrair%20a%20express%C3%A3o%20da%20linha%20135%20para%20um%20%60const%60%20tipado%20no%20futuro%2C%20o%20mesmo%20erro%20de%20build%20vai%20reaparecer.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28!block.content%20%7C%7C%20%28firstBubbleWasStreamed%20%3D%3D%3D%20true%20%26%26%20index%20%3D%3D%3D%200%29%29%20%7B%0A%60%60%60%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=215&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fbot-engine%2FexecuteGroup.ts%3A135%0AInconsist%C3%AAncia%20de%20padr%C3%A3o%3A%20a%20verifica%C3%A7%C3%A3o%20na%20linha%20135%20ainda%20usa%20%60firstBubbleWasStreamed%60%20como%20truthy%20check%2C%20enquanto%20a%20linha%20113%20%28corrigida%20neste%20PR%29%20passou%20a%20usar%20%60%3D%3D%3D%20true%60.%20Embora%20o%20comportamento%20em%20runtime%20seja%20id%C3%AAntico%20%28ambas%20as%20linhas%20lidam%20com%20os%20mesmos%20valores%20poss%C3%ADveis%3A%20%60true%20%7C%20false%20%7C%20undefined%60%29%2C%20se%20algu%C3%A9m%20extrair%20a%20express%C3%A3o%20da%20linha%20135%20para%20um%20%60const%60%20tipado%20no%20futuro%2C%20o%20mesmo%20erro%20de%20build%20vai%20reaparecer.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28!block.content%20%7C%7C%20%28firstBubbleWasStreamed%20%3D%3D%3D%20true%20%26%26%20index%20%3D%3D%3D%200%29%29%20%7B%0A%60%60%60%0A%0A&pr=215&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/bot-engine/executeGroup.ts:135
Inconsistência de padrão: a verificação na linha 135 ainda usa `firstBubbleWasStreamed` como truthy check, enquanto a linha 113 (corrigida neste PR) passou a usar `=== true`. Embora o comportamento em runtime seja idêntico (ambas as linhas lidam com os mesmos valores possíveis: `true | false | undefined`), se alguém extrair a expressão da linha 135 para um `const` tipado no futuro, o mesmo erro de build vai reaparecer.

```suggestion
      if (!block.content || (firstBubbleWasStreamed === true && index === 0)) {
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🐛bug: narrow firstBubbleWasStreamed in ..."](https://github.com/cloudhumans/typebot.io/commit/ba9def4345e3e5c7811c375971d178cc0c4c0bf4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35379902)</sub>

<!-- /greptile_comment -->