### PR TITLE
fix(mcp): respect optional Declare Variables flag in tool JSON Schema

### DIFF
--- a/apps/builder/src/features/mcp/helpers/transformToMCPTool.test.ts
+++ b/apps/builder/src/features/mcp/helpers/transformToMCPTool.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { transformToMCPTool } from './transformToMCPTool'
+import type { WorkflowTool } from '../types'
+
+const baseTool: WorkflowTool = {
+  id: 'tool-id',
+  name: 'My Tool',
+  tenant: 'acme',
+  description: 'A tool',
+  isPublished: true,
+  variables: [],
+  publicName: 'my-tool',
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+}
+
+describe('transformToMCPTool', () => {
+  it('keeps an optional variable (required: false) in properties but out of required', () => {
+    const result = transformToMCPTool({
+      ...baseTool,
+      variables: [
+        { name: 'valorContraproposta', description: 'desc', required: false },
+      ],
+    })
+
+    expect(result.inputSchema.properties).toHaveProperty('valorContraproposta')
+    expect(result.inputSchema.required).not.toContain('valorContraproposta')
+    expect(result.inputSchema.required).toEqual([])
+  })
+
+  it('keeps a variable with required: true in the required array', () => {
+    const result = transformToMCPTool({
+      ...baseTool,
+      variables: [{ name: 'orderId', description: 'desc', required: true }],
+    })
+
+    expect(result.inputSchema.properties).toHaveProperty('orderId')
+    expect(result.inputSchema.required).toContain('orderId')
+  })
+
+  it('treats a variable with no required flag as required (legacy default)', () => {
+    const result = transformToMCPTool({
+      ...baseTool,
+      variables: [{ name: 'legacyVar', description: 'desc' }],
+    })
+
+    expect(result.inputSchema.properties).toHaveProperty('legacyVar')
+    expect(result.inputSchema.required).toContain('legacyVar')
+  })
+
+  it('handles a mix of required and optional variables', () => {
+    const result = transformToMCPTool({
+      ...baseTool,
+      variables: [
+        { name: 'mandatory', description: 'm', required: true },
+        { name: 'optional', description: 'o', required: false },
+        { name: 'defaulted', description: 'd' },
+      ],
+    })
+
+    expect(Object.keys(result.inputSchema.properties)).toEqual([
+      'mandatory',
+      'optional',
+      'defaulted',
+    ])
+    expect(result.inputSchema.required).toEqual(['mandatory', 'defaulted'])
+  })
+})

--- a/apps/builder/src/features/mcp/helpers/transformToMCPTool.ts
+++ b/apps/builder/src/features/mcp/helpers/transformToMCPTool.ts
@@ -20,7 +20,11 @@ export function transformToMCPTool(tool: WorkflowTool) {
         type: 'string',
         description: v.description || `Input for ${v.name}`,
       }
-      required.push(v.name)
+      // Only mandatory inputs go into `required`. A variable declared as
+      // optional in the editor (`required: false`) stays in `properties` but
+      // out of `required`, so the agent may omit it instead of sending "".
+      // `undefined`/`true` keeps the legacy default of mandatory.
+      if (v.required !== false) required.push(v.name)
     }
   })
 

--- a/apps/builder/src/features/mcp/services/getWorkflowTools.test.ts
+++ b/apps/builder/src/features/mcp/services/getWorkflowTools.test.ts
@@ -1,0 +1,94 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { getWorkflowTools } from './getWorkflowTools'
+import prisma from '@typebot.io/lib/prisma'
+
+vi.mock('@typebot.io/lib/prisma', () => ({
+  default: {
+    typebot: {
+      findMany: vi.fn(),
+    },
+  },
+}))
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const findManyMock = (prisma as any).typebot.findMany as ReturnType<
+  typeof vi.fn
+>
+
+const makeToolTypebot = (
+  declaredVariables: Array<{
+    variableId: string
+    description?: string
+    required?: boolean
+  }>
+) => ({
+  id: 'typebot-1234567',
+  name: 'Solides Tool',
+  tenant: 'solides',
+  toolDescription: 'Send a counter proposal',
+  settings: { general: { type: 'TOOL' } },
+  variables: [
+    { id: 'v1', name: 'valorContraproposta', description: 'amount' },
+    { id: 'v2', name: 'orderId', description: 'order id' },
+  ],
+  publicId: 'solides-tool',
+  groups: [
+    {
+      blocks: [
+        {
+          type: 'Declare variables',
+          options: { variables: declaredVariables },
+        },
+      ],
+    },
+  ],
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+  publishedTypebot: { id: 'pub-1' },
+})
+
+describe('getWorkflowTools', () => {
+  beforeEach(() => {
+    findManyMock.mockReset()
+  })
+
+  it('propagates required: false from the Declare Variables block', async () => {
+    findManyMock.mockResolvedValue([
+      makeToolTypebot([
+        { variableId: 'v1', description: 'amount', required: false },
+        { variableId: 'v2', description: 'order id', required: true },
+      ]),
+    ])
+
+    const { tools } = await getWorkflowTools({ tenant: 'solides' })
+
+    expect(tools).toHaveLength(1)
+    const optional = tools[0].variables.find(
+      (v) => v.name === 'valorContraproposta'
+    )
+    const mandatory = tools[0].variables.find((v) => v.name === 'orderId')
+    expect(optional?.required).toBe(false)
+    expect(mandatory?.required).toBe(true)
+  })
+
+  it('defaults required to true when the flag is absent (legacy tools)', async () => {
+    findManyMock.mockResolvedValue([
+      makeToolTypebot([{ variableId: 'v1', description: 'amount' }]),
+    ])
+
+    const { tools } = await getWorkflowTools({ tenant: 'solides' })
+
+    const variable = tools[0].variables.find(
+      (v) => v.name === 'valorContraproposta'
+    )
+    expect(variable?.required).toBe(true)
+  })
+})

--- a/apps/builder/src/features/mcp/services/getWorkflowTools.ts
+++ b/apps/builder/src/features/mcp/services/getWorkflowTools.ts
@@ -90,13 +90,20 @@ export async function getWorkflowTools({
 
       let variables = declaredVariables
         .map((v) => {
-          const vObj = v as { variableId?: string; description?: string }
+          const vObj = v as {
+            variableId?: string
+            description?: string
+            required?: boolean
+          }
           const variable = typebotVariables.find(
             (tv) => tv.id === vObj.variableId
           )
           return {
             name: variable?.name,
             description: vObj.description,
+            // `required` defaults to true in the Declare Variables schema, so
+            // an absent flag (legacy tools) keeps the variable mandatory.
+            required: vObj.required ?? true,
           }
         })
         .filter((v) => v.name)

--- a/apps/builder/src/features/mcp/types.ts
+++ b/apps/builder/src/features/mcp/types.ts
@@ -10,6 +10,7 @@ export interface WorkflowTool {
   variables: Array<{
     name?: string
     description?: string
+    required?: boolean
   }>
   publicName: string
   createdAt: Date

--- a/apps/builder/src/features/typebot/api/listTypebots.test.ts
+++ b/apps/builder/src/features/typebot/api/listTypebots.test.ts
@@ -45,8 +45,10 @@ describe('listTypebots', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    vi.mocked(prisma.workspace.findUnique).mockResolvedValue(mockWorkspace as any)
+    vi.mocked(prisma.workspace.findUnique).mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockWorkspace as any
+    )
     vi.mocked(getUserRoleInWorkspace).mockReturnValue(WorkspaceRole.ADMIN)
   })
 

--- a/apps/builder/src/features/typebot/api/listTypebots.ts
+++ b/apps/builder/src/features/typebot/api/listTypebots.ts
@@ -171,7 +171,9 @@ export const listTypebots = authenticatedProcedure
       return {
         typebots: typebots
           .map((typebot) => {
-            const parsedSettings = toolSettingsSchema.safeParse(typebot.settings)
+            const parsedSettings = toolSettingsSchema.safeParse(
+              typebot.settings
+            )
             const isTool =
               parsedSettings.success &&
               parsedSettings.data.general?.type === 'TOOL'


### PR DESCRIPTION
## Bug

Input variables declared as **optional** in a TOOL-type Typebot flow (the `required: false` flag, rendered as "(optional)" in the editor) were exposed as **`required`** in the JSON Schema of the tool served via MCP.

Because the schema marked them mandatory, the agentic agent always sent the variable. When it had no value it sent `""`, which broke the flow downstream.

Real prod case: tenant **Solides**, variable **`valorContraproposta`** — the agent kept sending an empty counter-proposal value and the flow failed.

## Root cause

The `required` flag is correctly defined and persisted by the Declare Variables block schema (`packages/schemas/.../declareVariables/schema.ts`, `required: z.boolean().optional().default(true)`) and the editor UI reads it correctly (`DeclareVariablesContent.tsx` uses `v.required === false`).

The breakage was on the MCP schema-generation path, in `apps/builder/src/features/mcp/`:

1. **`services/getWorkflowTools.ts`** — the `.map` over `declaredVariables` cast each entry to `{ variableId, description }` (no `required`) and did not return it, so the flag was dropped here.
2. **`types.ts`** — `WorkflowTool.variables` had no `required` field, so even if it had been forwarded, the type erased it.
3. **`helpers/transformToMCPTool.ts`** — every variable with a `name` was pushed into the `required` array **unconditionally**.

So the flag was discarded twice and then every variable was force-marked required.

## Fix

Propagate the flag end-to-end:

- `getWorkflowTools.ts`: extract and forward `required: vObj.required ?? true`.
- `types.ts`: add `required?: boolean` to `WorkflowTool.variables`.
- `transformToMCPTool.ts`: `if (v.required !== false) required.push(v.name)`.

Semantics mirror the editor's `=== false` check:
- `undefined` / `true` → variable stays **mandatory** (safe default, keeps legacy tools without the field working unchanged).
- `false` → variable stays in `properties` but is dropped from `required`, so the agent may omit it instead of sending `""`.

## Edge note (out of scope, documented)

`getWorkflowTools.ts` has a fallback path: when a tool has **no Declare Variables block**, it derives the tool inputs from all typebot variables that have a name + description. That path has no `required` information available, so those variables continue to default to mandatory (`required: true`). This matches today's behavior and is intentionally left unchanged here.

## Tests

Added unit tests (vitest, following the existing `*.test.ts` convention in the builder app):

- `transformToMCPTool.test.ts`:
  - optional variable (`required: false`) is **excluded** from `required` but **present** in `properties`
  - `required: true` and a variable with no flag both stay in `required`
  - mixed set produces the expected `required` subset
- `getWorkflowTools.test.ts`:
  - `required: false` / `required: true` propagate from the Declare Variables block
  - absent flag defaults to `required: true` (legacy tools)

```
 Test Files  2 passed (2)
      Tests  6 passed (6)
```

The first commit (`style(typebot): unbreak lint+format gate ...`) is an unrelated formatting/comment-only fix: `origin/main` could not pass the `pnpm lint && pnpm format:check` pre-commit gate because prettier wants PR #209's `listTypebots.test.ts` mock wrapped across lines, which pushed `as any` out from under its `eslint-disable-next-line`. Moved the disable comment so both gates pass; no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent
    participant MCP as MCP Server
    participant GWT as getWorkflowTools
    participant DB as Prisma / DB
    participant TMCP as transformToMCPTool

    Agent->>MCP: list_tools (tenant)
    MCP->>GWT: "getWorkflowTools({ tenant })"
    GWT->>DB: findMany (TOOL typebots)
    DB-->>GWT: typebots with groups/variables
    GWT->>GWT: extract DeclareVariables blocks
    GWT->>GWT: "map(v => { name, description, required: vObj.required ?? true })"
    GWT-->>MCP: WorkflowTool[] (variables com required flag)
    MCP->>TMCP: transformToMCPTool(tool)
    TMCP->>TMCP: forEach variable
    alt "v.required !== false (obrigatória ou legada)"
        TMCP->>TMCP: required.push(v.name)
    else "v.required === false (opcional)"
        TMCP->>TMCP: apenas adiciona a properties
    end
    TMCP-->>MCP: "{ inputSchema: { properties, required[] } }"
    MCP-->>Agent: JSON Schema com required correto
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/builder/src/features/mcp/services/getWorkflowTools.ts`, line 111-118 ([link](https://github.com/cloudhumans/typebot.io/blob/9119d26e9e0d6cbbc7694a01056f43d94188cad5/apps/builder/src/features/mcp/services/getWorkflowTools.ts#L111-L118)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Consistência entre os dois caminhos de retorno: o caminho principal sempre entrega `required: true | false`, mas o fallback entrega `required: undefined`. Funcionalmente equivalente graças ao `!== false` em `transformToMCPTool`, porém torna a interface `WorkflowTool.variables` assimétrica para qualquer futuro consumidor que inspecione o campo diretamente.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/builder/src/features/mcp/services/getWorkflowTools.ts
   Line: 111-118

   Comment:
   Consistência entre os dois caminhos de retorno: o caminho principal sempre entrega `required: true | false`, mas o fallback entrega `required: undefined`. Funcionalmente equivalente graças ao `!== false` em `transformToMCPTool`, porém torna a interface `WorkflowTool.variables` assimétrica para qualquer futuro consumidor que inspecione o campo diretamente.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fbuilder%2Fsrc%2Ffeatures%2Fmcp%2Fservices%2FgetWorkflowTools.ts%0ALine%3A%20111-118%0A%0AComment%3A%0AConsist%C3%AAncia%20entre%20os%20dois%20caminhos%20de%20retorno%3A%20o%20caminho%20principal%20sempre%20entrega%20%60required%3A%20true%20%7C%20false%60%2C%20mas%20o%20fallback%20entrega%20%60required%3A%20undefined%60.%20Funcionalmente%20equivalente%20gra%C3%A7as%20ao%20%60!%3D%3D%20false%60%20em%20%60transformToMCPTool%60%2C%20por%C3%A9m%20torna%20a%20interface%20%60WorkflowTool.variables%60%20assim%C3%A9trica%20para%20qualquer%20futuro%20consumidor%20que%20inspecione%20o%20campo%20diretamente.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28variables.length%20%3D%3D%3D%200%29%20%7B%0A%20%20%20%20%20%20%20%20variables%20%3D%20typebotVariables%0A%20%20%20%20%20%20%20%20%20%20.filter%28%28v%29%20%3D%3E%20v.name%20%26%26%20v.description%29%0A%20%20%20%20%20%20%20%20%20%20.map%28%28v%29%20%3D%3E%20%28%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20name%3A%20v.name%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20description%3A%20v.description%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20required%3A%20true%20as%20const%2C%0A%20%20%20%20%20%20%20%20%20%20%7D%29%29%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudhumans%2Ftypebot.io&pr=216&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fbuilder%2Fsrc%2Ffeatures%2Fmcp%2Fservices%2FgetWorkflowTools.ts%0ALine%3A%20111-118%0A%0AComment%3A%0AConsist%C3%AAncia%20entre%20os%20dois%20caminhos%20de%20retorno%3A%20o%20caminho%20principal%20sempre%20entrega%20%60required%3A%20true%20%7C%20false%60%2C%20mas%20o%20fallback%20entrega%20%60required%3A%20undefined%60.%20Funcionalmente%20equivalente%20gra%C3%A7as%20ao%20%60!%3D%3D%20false%60%20em%20%60transformToMCPTool%60%2C%20por%C3%A9m%20torna%20a%20interface%20%60WorkflowTool.variables%60%20assim%C3%A9trica%20para%20qualquer%20futuro%20consumidor%20que%20inspecione%20o%20campo%20diretamente.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28variables.length%20%3D%3D%3D%200%29%20%7B%0A%20%20%20%20%20%20%20%20variables%20%3D%20typebotVariables%0A%20%20%20%20%20%20%20%20%20%20.filter%28%28v%29%20%3D%3E%20v.name%20%26%26%20v.description%29%0A%20%20%20%20%20%20%20%20%20%20.map%28%28v%29%20%3D%3E%20%28%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20name%3A%20v.name%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20description%3A%20v.description%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20required%3A%20true%20as%20const%2C%0A%20%20%20%20%20%20%20%20%20%20%7D%29%29%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=216&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fmcp%2Fservices%2FgetWorkflowTools.ts%3A111-118%0AConsist%C3%AAncia%20entre%20os%20dois%20caminhos%20de%20retorno%3A%20o%20caminho%20principal%20sempre%20entrega%20%60required%3A%20true%20%7C%20false%60%2C%20mas%20o%20fallback%20entrega%20%60required%3A%20undefined%60.%20Funcionalmente%20equivalente%20gra%C3%A7as%20ao%20%60!%3D%3D%20false%60%20em%20%60transformToMCPTool%60%2C%20por%C3%A9m%20torna%20a%20interface%20%60WorkflowTool.variables%60%20assim%C3%A9trica%20para%20qualquer%20futuro%20consumidor%20que%20inspecione%20o%20campo%20diretamente.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28variables.length%20%3D%3D%3D%200%29%20%7B%0A%20%20%20%20%20%20%20%20variables%20%3D%20typebotVariables%0A%20%20%20%20%20%20%20%20%20%20.filter%28%28v%29%20%3D%3E%20v.name%20%26%26%20v.description%29%0A%20%20%20%20%20%20%20%20%20%20.map%28%28v%29%20%3D%3E%20%28%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20name%3A%20v.name%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20description%3A%20v.description%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20required%3A%20true%20as%20const%2C%0A%20%20%20%20%20%20%20%20%20%20%7D%29%29%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=216&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fmcp%2Fservices%2FgetWorkflowTools.ts%3A111-118%0AConsist%C3%AAncia%20entre%20os%20dois%20caminhos%20de%20retorno%3A%20o%20caminho%20principal%20sempre%20entrega%20%60required%3A%20true%20%7C%20false%60%2C%20mas%20o%20fallback%20entrega%20%60required%3A%20undefined%60.%20Funcionalmente%20equivalente%20gra%C3%A7as%20ao%20%60!%3D%3D%20false%60%20em%20%60transformToMCPTool%60%2C%20por%C3%A9m%20torna%20a%20interface%20%60WorkflowTool.variables%60%20assim%C3%A9trica%20para%20qualquer%20futuro%20consumidor%20que%20inspecione%20o%20campo%20diretamente.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28variables.length%20%3D%3D%3D%200%29%20%7B%0A%20%20%20%20%20%20%20%20variables%20%3D%20typebotVariables%0A%20%20%20%20%20%20%20%20%20%20.filter%28%28v%29%20%3D%3E%20v.name%20%26%26%20v.description%29%0A%20%20%20%20%20%20%20%20%20%20.map%28%28v%29%20%3D%3E%20%28%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20name%3A%20v.name%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20description%3A%20v.description%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20required%3A%20true%20as%20const%2C%0A%20%20%20%20%20%20%20%20%20%20%7D%29%29%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&pr=216&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/builder/src/features/mcp/services/getWorkflowTools.ts:111-118
Consistência entre os dois caminhos de retorno: o caminho principal sempre entrega `required: true | false`, mas o fallback entrega `required: undefined`. Funcionalmente equivalente graças ao `!== false` em `transformToMCPTool`, porém torna a interface `WorkflowTool.variables` assimétrica para qualquer futuro consumidor que inspecione o campo diretamente.

```suggestion
      if (variables.length === 0) {
        variables = typebotVariables
          .filter((v) => v.name && v.description)
          .map((v) => ({
            name: v.name,
            description: v.description,
            required: true as const,
          }))
      }
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): respect optional Declare Varia..."](https://github.com/cloudhumans/typebot.io/commit/9119d26e9e0d6cbbc7694a01056f43d94188cad5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35442378)</sub>

<!-- /greptile_comment -->