### PR TITLE
fix(mcp): respect optional Declare Variables flag in tool JSON Schema (re-do of reverted #216)

### DIFF
--- a/apps/builder/src/features/mcp/helpers/transformToMCPTool.test.ts
+++ b/apps/builder/src/features/mcp/helpers/transformToMCPTool.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { transformToMCPTool } from './transformToMCPTool'
+import type { WorkflowTool } from '../types'
+
+const baseTool: WorkflowTool = {
+  id: 'tool-id',
+  name: 'My Tool',
+  tenant: 'acme',
+  description: 'A tool',
+  isPublished: true,
+  variables: [],
+  publicName: 'my-tool',
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+}
+
+describe('transformToMCPTool', () => {
+  it('keeps an optional variable (required: false) in properties but out of required', () => {
+    const result = transformToMCPTool({
+      ...baseTool,
+      variables: [
+        { name: 'valorContraproposta', description: 'desc', required: false },
+      ],
+    })
+
+    expect(result.inputSchema.properties).toHaveProperty('valorContraproposta')
+    expect(result.inputSchema.required).not.toContain('valorContraproposta')
+    expect(result.inputSchema.required).toEqual([])
+  })
+
+  it('keeps a variable with required: true in the required array', () => {
+    const result = transformToMCPTool({
+      ...baseTool,
+      variables: [{ name: 'orderId', description: 'desc', required: true }],
+    })
+
+    expect(result.inputSchema.properties).toHaveProperty('orderId')
+    expect(result.inputSchema.required).toContain('orderId')
+  })
+
+  it('treats a variable with no required flag as required (legacy default)', () => {
+    const result = transformToMCPTool({
+      ...baseTool,
+      variables: [{ name: 'legacyVar', description: 'desc' }],
+    })
+
+    expect(result.inputSchema.properties).toHaveProperty('legacyVar')
+    expect(result.inputSchema.required).toContain('legacyVar')
+  })
+
+  it('handles a mix of required and optional variables', () => {
+    const result = transformToMCPTool({
+      ...baseTool,
+      variables: [
+        { name: 'mandatory', description: 'm', required: true },
+        { name: 'optional', description: 'o', required: false },
+        { name: 'defaulted', description: 'd' },
+      ],
+    })
+
+    expect(Object.keys(result.inputSchema.properties)).toEqual([
+      'mandatory',
+      'optional',
+      'defaulted',
+    ])
+    expect(result.inputSchema.required).toEqual(['mandatory', 'defaulted'])
+  })
+})

--- a/apps/builder/src/features/mcp/helpers/transformToMCPTool.ts
+++ b/apps/builder/src/features/mcp/helpers/transformToMCPTool.ts
@@ -20,7 +20,11 @@ export function transformToMCPTool(tool: WorkflowTool) {
         type: 'string',
         description: v.description || `Input for ${v.name}`,
       }
-      required.push(v.name)
+      // Only mandatory inputs go into `required`. A variable declared as
+      // optional in the editor (`required: false`) stays in `properties` but
+      // out of `required`, so the agent may omit it instead of sending "".
+      // `undefined`/`true` keeps the legacy default of mandatory.
+      if (v.required !== false) required.push(v.name)
     }
   })
 

--- a/apps/builder/src/features/mcp/services/getWorkflowTools.test.ts
+++ b/apps/builder/src/features/mcp/services/getWorkflowTools.test.ts
@@ -1,0 +1,94 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { getWorkflowTools } from './getWorkflowTools'
+import prisma from '@typebot.io/lib/prisma'
+
+vi.mock('@typebot.io/lib/prisma', () => ({
+  default: {
+    typebot: {
+      findMany: vi.fn(),
+    },
+  },
+}))
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const findManyMock = (prisma as any).typebot.findMany as ReturnType<
+  typeof vi.fn
+>
+
+const makeToolTypebot = (
+  declaredVariables: Array<{
+    variableId: string
+    description?: string
+    required?: boolean
+  }>
+) => ({
+  id: 'typebot-1234567',
+  name: 'Solides Tool',
+  tenant: 'solides',
+  toolDescription: 'Send a counter proposal',
+  settings: { general: { type: 'TOOL' } },
+  variables: [
+    { id: 'v1', name: 'valorContraproposta', description: 'amount' },
+    { id: 'v2', name: 'orderId', description: 'order id' },
+  ],
+  publicId: 'solides-tool',
+  groups: [
+    {
+      blocks: [
+        {
+          type: 'Declare variables',
+          options: { variables: declaredVariables },
+        },
+      ],
+    },
+  ],
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+  publishedTypebot: { id: 'pub-1' },
+})
+
+describe('getWorkflowTools', () => {
+  beforeEach(() => {
+    findManyMock.mockReset()
+  })
+
+  it('propagates required: false from the Declare Variables block', async () => {
+    findManyMock.mockResolvedValue([
+      makeToolTypebot([
+        { variableId: 'v1', description: 'amount', required: false },
+        { variableId: 'v2', description: 'order id', required: true },
+      ]),
+    ])
+
+    const { tools } = await getWorkflowTools({ tenant: 'solides' })
+
+    expect(tools).toHaveLength(1)
+    const optional = tools[0].variables.find(
+      (v) => v.name === 'valorContraproposta'
+    )
+    const mandatory = tools[0].variables.find((v) => v.name === 'orderId')
+    expect(optional?.required).toBe(false)
+    expect(mandatory?.required).toBe(true)
+  })
+
+  it('defaults required to true when the flag is absent (legacy tools)', async () => {
+    findManyMock.mockResolvedValue([
+      makeToolTypebot([{ variableId: 'v1', description: 'amount' }]),
+    ])
+
+    const { tools } = await getWorkflowTools({ tenant: 'solides' })
+
+    const variable = tools[0].variables.find(
+      (v) => v.name === 'valorContraproposta'
+    )
+    expect(variable?.required).toBe(true)
+  })
+})

--- a/apps/builder/src/features/mcp/services/getWorkflowTools.ts
+++ b/apps/builder/src/features/mcp/services/getWorkflowTools.ts
@@ -90,23 +90,35 @@ export async function getWorkflowTools({
 
       let variables = declaredVariables
         .map((v) => {
-          const vObj = v as { variableId?: string; description?: string }
+          const vObj = v as {
+            variableId?: string
+            description?: string
+            required?: boolean
+          }
           const variable = typebotVariables.find(
             (tv) => tv.id === vObj.variableId
           )
           return {
             name: variable?.name,
             description: vObj.description,
+            // `required` defaults to true in the Declare Variables schema, so
+            // an absent flag (legacy tools) keeps the variable mandatory.
+            required: vObj.required ?? true,
           }
         })
         .filter((v) => v.name)
 
       if (variables.length === 0) {
+        // Fallback when there is no Declare Variables block: bare typebot
+        // variables carry no optional flag, so they default to mandatory to
+        // match the schema default and keep the shape aligned with the
+        // primary branch (which now includes `required`).
         variables = typebotVariables
           .filter((v) => v.name && v.description)
           .map((v) => ({
             name: v.name,
             description: v.description,
+            required: true,
           }))
       }
 

--- a/apps/builder/src/features/mcp/types.ts
+++ b/apps/builder/src/features/mcp/types.ts
@@ -10,6 +10,7 @@ export interface WorkflowTool {
   variables: Array<{
     name?: string
     description?: string
+    required?: boolean
   }>
   publicName: string
   createdAt: Date

--- a/apps/builder/src/features/typebot/api/listTypebots.test.ts
+++ b/apps/builder/src/features/typebot/api/listTypebots.test.ts
@@ -45,8 +45,10 @@ describe('listTypebots', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    vi.mocked(prisma.workspace.findUnique).mockResolvedValue(mockWorkspace as any)
+    vi.mocked(prisma.workspace.findUnique).mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockWorkspace as any
+    )
     vi.mocked(getUserRoleInWorkspace).mockReturnValue(WorkspaceRole.ADMIN)
   })
 

--- a/apps/builder/src/features/typebot/api/listTypebots.ts
+++ b/apps/builder/src/features/typebot/api/listTypebots.ts
@@ -171,7 +171,9 @@ export const listTypebots = authenticatedProcedure
       return {
         typebots: typebots
           .map((typebot) => {
-            const parsedSettings = toolSettingsSchema.safeParse(typebot.settings)
+            const parsedSettings = toolSettingsSchema.safeParse(
+              typebot.settings
+            )
             const isTool =
               parsedSettings.success &&
               parsedSettings.data.general?.type === 'TOOL'


### PR DESCRIPTION
## Problema

Uma variável de input de um fluxo Typebot tipo TOOL marcada como **opcional** no editor (`required: false`, renderiza `(optional)`) ainda era emitida como **`required`** no JSON Schema da tool exposta via MCP. Isso força o agent agentic a sempre mandar a variável; sem valor, ele manda `""` e o fluxo quebra.

**Caso real (prod):** tenant `solides_financeiro_email`, variável `valorContraproposta` — quando não há contraproposta no contexto, a tool recebia `""` e retornava erro em vez de seguir o fluxo.

## Causa-raiz

O flag `required` existe no schema (`declareVariables/schema.ts` → `required: z.boolean().optional().default(true)`) e a UI lê certo (`isOptional = required === false`), mas o caminho que gera o schema MCP descartava o flag em dois pontos e depois marcava tudo como obrigatório:

1. **`getWorkflowTools.ts`** — o `.map` das variáveis declaradas fazia cast sem `required` e não o retornava → flag perdido.
2. **`WorkflowTool.variables`** (`types.ts`) — a interface nem tinha o campo `required`.
3. **`transformToMCPTool.ts`** — `required.push(v.name)` incondicional pra toda variável.

## Fix

- `getWorkflowTools.ts`: propaga `required: vObj.required ?? true` no branch principal **e** emite `required: true` no fallback (quando não há bloco "Declare variables") — mantendo o shape alinhado.
- `types.ts`: adiciona `required?: boolean` à interface.
- `transformToMCPTool.ts`: só empurra pro array `required` quando `required !== false`.

Semântica idêntica à do editor: `undefined`/`true` → obrigatória (default seguro p/ tools legadas), `false` → opcional.

## Relação com #216 / #217

Substitui o #216, que foi **revertido pelo #217 por quebrar o build da `main`**. A quebra foi um **erro de tipo** exatamente no branch de fallback do `getWorkflowTools.ts` (`required` faltando no objeto do fallback enquanto o branch principal já o exigia). Este PR corrige esse fallback.

Por que o #216 passou no PR mas quebrou na `main`: o check `build` fica **`skipping` em PRs** e só roda no push pra `main` — ou seja, **nenhum gate de type-check roda em PR**. Recomendação fortemente sugerida: rodar o `build` (ou ao menos `tsc --noEmit` / `next build` type-check) também em PR, mais lint/format/test, pra fechar essa lacuna.

## Verificação local

- `tsc --noEmit` (mesmo type-check que o `next build` roda) → **zero erros em qualquer arquivo-fonte não-teste**; o erro original `getWorkflowTools.ts(112)` que derrubou a `main` foi reproduzido e está resolvido.
- Pre-commit gate `pnpm lint && pnpm format:check` → **verde** nos 47 pacotes (provado pelo hook ao commitar).
- Observação honesta: o repo **não tem runner de vitest** (sem dependência, sem job de CI). As specs `*.test.ts` adicionadas seguem a convenção existente do repo, mas **não foram executadas** — a verificação foi via type-checker + gates, não execução de testes.

O primeiro commit (`style(typebot): prettier-format listTypebots files...`) é pré-requisito: a `origin/main` já falhava o pre-commit gate nos arquivos do #209 (formatação/comentário, sem mudança de lógica).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent
    participant MCPServer as MCP Server
    participant GWT as getWorkflowTools
    participant DB as Prisma DB
    participant Transform as transformToMCPTool

    Agent->>MCPServer: list_tools(tenant)
    MCPServer->>GWT: "getWorkflowTools({ tenant })"
    GWT->>DB: typebot.findMany(where: TOOL, published)
    DB-->>GWT: typebots[]

    loop Para cada typebot
        GWT->>GWT: extrai blocos Declare variables
        alt bloco encontrado
            GWT->>GWT: vObj.required ?? true
        else sem bloco (fallback)
            GWT->>GWT: required: true (legado)
        end
    end

    GWT-->>MCPServer: WorkflowTool[] com required?: boolean

    loop Para cada WorkflowTool
        MCPServer->>Transform: transformToMCPTool(tool)
        Transform->>Transform: "v.required !== false → push required[]"
        Note over Transform: vars opcionais ficam só em properties
        Transform-->>MCPServer: MCP JSON Schema corrigido
    end

    MCPServer-->>Agent: tools com inputSchema correto
    Agent->>MCPServer: tool_call (omite vars opcionais se não houver valor)
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/builder/src/features/mcp/helpers/transformToMCPTool.ts`, line 34-38 ([link](https://github.com/cloudhumans/typebot.io/blob/77a2f2a27e405264fd284d83b6666b334aadd50b/apps/builder/src/features/mcp/helpers/transformToMCPTool.ts#L34-L38)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Quando todas as variáveis são opcionais, `required` é retornado como `[]`. Alguns clientes MCP e validadores de JSON Schema mais rígidos podem se comportar de forma diferente entre `required: []` (array vazio explícito) e a ausência do campo. Omitir o campo quando vazio é semanticamente equivalente e mais limpo.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/builder/src/features/mcp/helpers/transformToMCPTool.ts
   Line: 34-38

   Comment:
   Quando todas as variáveis são opcionais, `required` é retornado como `[]`. Alguns clientes MCP e validadores de JSON Schema mais rígidos podem se comportar de forma diferente entre `required: []` (array vazio explícito) e a ausência do campo. Omitir o campo quando vazio é semanticamente equivalente e mais limpo.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fbuilder%2Fsrc%2Ffeatures%2Fmcp%2Fhelpers%2FtransformToMCPTool.ts%0ALine%3A%2034-38%0A%0AComment%3A%0AQuando%20todas%20as%20vari%C3%A1veis%20s%C3%A3o%20opcionais%2C%20%60required%60%20%C3%A9%20retornado%20como%20%60%5B%5D%60.%20Alguns%20clientes%20MCP%20e%20validadores%20de%20JSON%20Schema%20mais%20r%C3%ADgidos%20podem%20se%20comportar%20de%20forma%20diferente%20entre%20%60required%3A%20%5B%5D%60%20%28array%20vazio%20expl%C3%ADcito%29%20e%20a%20aus%C3%AAncia%20do%20campo.%20Omitir%20o%20campo%20quando%20vazio%20%C3%A9%20semanticamente%20equivalente%20e%20mais%20limpo.%0A%0A%60%60%60suggestion%0A%20%20%20%20inputSchema%3A%20%7B%0A%20%20%20%20%20%20type%3A%20'object'%20as%20const%2C%0A%20%20%20%20%20%20properties%2C%0A%20%20%20%20%20%20...%28required.length%20%3E%200%20%3F%20%7B%20required%20%7D%20%3A%20%7B%7D%29%2C%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudhumans%2Ftypebot.io&pr=218&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fbuilder%2Fsrc%2Ffeatures%2Fmcp%2Fhelpers%2FtransformToMCPTool.ts%0ALine%3A%2034-38%0A%0AComment%3A%0AQuando%20todas%20as%20vari%C3%A1veis%20s%C3%A3o%20opcionais%2C%20%60required%60%20%C3%A9%20retornado%20como%20%60%5B%5D%60.%20Alguns%20clientes%20MCP%20e%20validadores%20de%20JSON%20Schema%20mais%20r%C3%ADgidos%20podem%20se%20comportar%20de%20forma%20diferente%20entre%20%60required%3A%20%5B%5D%60%20%28array%20vazio%20expl%C3%ADcito%29%20e%20a%20aus%C3%AAncia%20do%20campo.%20Omitir%20o%20campo%20quando%20vazio%20%C3%A9%20semanticamente%20equivalente%20e%20mais%20limpo.%0A%0A%60%60%60suggestion%0A%20%20%20%20inputSchema%3A%20%7B%0A%20%20%20%20%20%20type%3A%20'object'%20as%20const%2C%0A%20%20%20%20%20%20properties%2C%0A%20%20%20%20%20%20...%28required.length%20%3E%200%20%3F%20%7B%20required%20%7D%20%3A%20%7B%7D%29%2C%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=218&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fmcp%2Fhelpers%2FtransformToMCPTool.ts%3A34-38%0AQuando%20todas%20as%20vari%C3%A1veis%20s%C3%A3o%20opcionais%2C%20%60required%60%20%C3%A9%20retornado%20como%20%60%5B%5D%60.%20Alguns%20clientes%20MCP%20e%20validadores%20de%20JSON%20Schema%20mais%20r%C3%ADgidos%20podem%20se%20comportar%20de%20forma%20diferente%20entre%20%60required%3A%20%5B%5D%60%20%28array%20vazio%20expl%C3%ADcito%29%20e%20a%20aus%C3%AAncia%20do%20campo.%20Omitir%20o%20campo%20quando%20vazio%20%C3%A9%20semanticamente%20equivalente%20e%20mais%20limpo.%0A%0A%60%60%60suggestion%0A%20%20%20%20inputSchema%3A%20%7B%0A%20%20%20%20%20%20type%3A%20'object'%20as%20const%2C%0A%20%20%20%20%20%20properties%2C%0A%20%20%20%20%20%20...%28required.length%20%3E%200%20%3F%20%7B%20required%20%7D%20%3A%20%7B%7D%29%2C%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fmcp%2Fservices%2FgetWorkflowTools.test.ts%3A57-94%0A**Cobertura%20do%20caminho%20de%20fallback%20ausente**%0A%0AOs%20dois%20testes%20exercitam%20apenas%20o%20branch%20principal%20%28typebot%20com%20bloco%20%22Declare%20variables%22%29.%20O%20branch%20de%20fallback%20%E2%80%94%20quando%20%60variables.length%20%3D%3D%3D%200%60%20porque%20n%C3%A3o%20h%C3%A1%20nenhum%20bloco%20%22Declare%20variables%22%20%E2%80%94%20n%C3%A3o%20%C3%A9%20coberto%2C%20e%20foi%20exatamente%20esse%20trecho%20que%20causou%20o%20erro%20de%20tipo%20que%20derrubou%20a%20%60main%60%20no%20%23216.%20Um%20terceiro%20teste%20com%20um%20typebot%20cujo%20campo%20%60groups%60%20n%C3%A3o%20contenha%20nenhum%20bloco%20%60%22Declare%20variables%22%60%20garantiria%20que%20a%20corre%C3%A7%C3%A3o%20do%20fallback%20%28%60required%3A%20true%60%29%20se%20mant%C3%A9m%20regress%C3%A3o-free.%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=218&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fmcp%2Fhelpers%2FtransformToMCPTool.ts%3A34-38%0AQuando%20todas%20as%20vari%C3%A1veis%20s%C3%A3o%20opcionais%2C%20%60required%60%20%C3%A9%20retornado%20como%20%60%5B%5D%60.%20Alguns%20clientes%20MCP%20e%20validadores%20de%20JSON%20Schema%20mais%20r%C3%ADgidos%20podem%20se%20comportar%20de%20forma%20diferente%20entre%20%60required%3A%20%5B%5D%60%20%28array%20vazio%20expl%C3%ADcito%29%20e%20a%20aus%C3%AAncia%20do%20campo.%20Omitir%20o%20campo%20quando%20vazio%20%C3%A9%20semanticamente%20equivalente%20e%20mais%20limpo.%0A%0A%60%60%60suggestion%0A%20%20%20%20inputSchema%3A%20%7B%0A%20%20%20%20%20%20type%3A%20'object'%20as%20const%2C%0A%20%20%20%20%20%20properties%2C%0A%20%20%20%20%20%20...%28required.length%20%3E%200%20%3F%20%7B%20required%20%7D%20%3A%20%7B%7D%29%2C%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Fmcp%2Fservices%2FgetWorkflowTools.test.ts%3A57-94%0A**Cobertura%20do%20caminho%20de%20fallback%20ausente**%0A%0AOs%20dois%20testes%20exercitam%20apenas%20o%20branch%20principal%20%28typebot%20com%20bloco%20%22Declare%20variables%22%29.%20O%20branch%20de%20fallback%20%E2%80%94%20quando%20%60variables.length%20%3D%3D%3D%200%60%20porque%20n%C3%A3o%20h%C3%A1%20nenhum%20bloco%20%22Declare%20variables%22%20%E2%80%94%20n%C3%A3o%20%C3%A9%20coberto%2C%20e%20foi%20exatamente%20esse%20trecho%20que%20causou%20o%20erro%20de%20tipo%20que%20derrubou%20a%20%60main%60%20no%20%23216.%20Um%20terceiro%20teste%20com%20um%20typebot%20cujo%20campo%20%60groups%60%20n%C3%A3o%20contenha%20nenhum%20bloco%20%60%22Declare%20variables%22%60%20garantiria%20que%20a%20corre%C3%A7%C3%A3o%20do%20fallback%20%28%60required%3A%20true%60%29%20se%20mant%C3%A9m%20regress%C3%A3o-free.%0A%0A&pr=218&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/builder/src/features/mcp/helpers/transformToMCPTool.ts:34-38
Quando todas as variáveis são opcionais, `required` é retornado como `[]`. Alguns clientes MCP e validadores de JSON Schema mais rígidos podem se comportar de forma diferente entre `required: []` (array vazio explícito) e a ausência do campo. Omitir o campo quando vazio é semanticamente equivalente e mais limpo.

```suggestion
    inputSchema: {
      type: 'object' as const,
      properties,
      ...(required.length > 0 ? { required } : {}),
    },
```

### Issue 2 of 2
apps/builder/src/features/mcp/services/getWorkflowTools.test.ts:57-94
**Cobertura do caminho de fallback ausente**

Os dois testes exercitam apenas o branch principal (typebot com bloco "Declare variables"). O branch de fallback — quando `variables.length === 0` porque não há nenhum bloco "Declare variables" — não é coberto, e foi exatamente esse trecho que causou o erro de tipo que derrubou a `main` no #216. Um terceiro teste com um typebot cujo campo `groups` não contenha nenhum bloco `"Declare variables"` garantiria que a correção do fallback (`required: true`) se mantém regressão-free.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): respect optional Declare Varia..."](https://github.com/cloudhumans/typebot.io/commit/77a2f2a27e405264fd284d83b6666b334aadd50b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35453937)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->