### PR TITLE
fix(bot-engine): optional Declare Variables param no longer pauses TOOL-mode flow

### DIFF
--- a/packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.test.ts
+++ b/packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { executeDeclareVariables } from './executeDeclareVariables'
+import { DeclareVariablesBlock, SessionState } from '@typebot.io/schemas'
+import { LogicBlockType } from '@typebot.io/schemas/features/blocks/logic/constants'
+
+const makeState = (
+  variables: Array<{ id: string; name: string; value?: unknown }>
+): SessionState =>
+  ({
+    typebotsQueue: [
+      {
+        typebot: {
+          variables,
+        },
+      },
+    ],
+  } as unknown as SessionState)
+
+const makeBlock = (
+  declaredVariables: Array<{
+    variableId: string
+    description: string
+    required?: boolean
+  }>
+): DeclareVariablesBlock =>
+  ({
+    id: 'block-1',
+    type: LogicBlockType.DECLARE_VARIABLES,
+    outgoingEdgeId: 'edge-1',
+    options: { variables: declaredVariables },
+  } as unknown as DeclareVariablesBlock)
+
+describe('executeDeclareVariables', () => {
+  it('does not pause the flow for an optional (required: false) variable without a value', async () => {
+    const state = makeState([{ id: 'v1', name: 'optionalParam' }])
+    const block = makeBlock([
+      { variableId: 'v1', description: 'an optional param', required: false },
+    ])
+
+    const result = await executeDeclareVariables(state, block)
+
+    expect(result.input).toBeUndefined()
+    expect(result.outgoingEdgeId).toBe('edge-1')
+  })
+
+  it('still pauses the flow for a required variable without a value', async () => {
+    const state = makeState([{ id: 'v1', name: 'requiredParam' }])
+    const block = makeBlock([
+      { variableId: 'v1', description: 'a required param', required: true },
+    ])
+
+    const result = await executeDeclareVariables(state, block)
+
+    expect(result.input).toBeDefined()
+    expect(result.input?.options?.variableId).toBe('v1')
+  })
+
+  it('pauses the flow when the required flag is absent (legacy default = required)', async () => {
+    const state = makeState([{ id: 'v1', name: 'legacyParam' }])
+    const block = makeBlock([
+      { variableId: 'v1', description: 'a legacy param' },
+    ])
+
+    const result = await executeDeclareVariables(state, block)
+
+    expect(result.input).toBeDefined()
+  })
+
+  it('proceeds without input when the variable already has a value', async () => {
+    const state = makeState([{ id: 'v1', name: 'filled', value: 'hello' }])
+    const block = makeBlock([
+      { variableId: 'v1', description: 'already filled', required: true },
+    ])
+
+    const result = await executeDeclareVariables(state, block)
+
+    expect(result.input).toBeUndefined()
+    expect(result.outgoingEdgeId).toBe('edge-1')
+  })
+})

--- a/packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.test.ts
+++ b/packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.test.ts
@@ -4,13 +4,15 @@ import { DeclareVariablesBlock, SessionState } from '@typebot.io/schemas'
 import { LogicBlockType } from '@typebot.io/schemas/features/blocks/logic/constants'
 
 const makeState = (
-  variables: Array<{ id: string; name: string; value?: unknown }>
+  variables: Array<{ id: string; name: string; value?: unknown }>,
+  type: 'default' | 'TOOL' = 'default'
 ): SessionState =>
   ({
     typebotsQueue: [
       {
         typebot: {
           variables,
+          settings: { general: { type } },
         },
       },
     ],
@@ -31,64 +33,64 @@ const makeBlock = (
   } as unknown as DeclareVariablesBlock)
 
 describe('executeDeclareVariables', () => {
-  it('does not pause the flow for an optional (required: false) variable without a value', async () => {
-    const state = makeState([{ id: 'v1', name: 'optionalParam' }])
-    const block = makeBlock([
-      { variableId: 'v1', description: 'an optional param', required: false },
-    ])
+  describe('TOOL mode (headless — never pauses)', () => {
+    it('does not pause for an optional variable without a value', async () => {
+      const state = makeState([{ id: 'v1', name: 'optionalParam' }], 'TOOL')
+      const block = makeBlock([
+        { variableId: 'v1', description: 'an optional param', required: false },
+      ])
 
-    const result = await executeDeclareVariables(state, block)
+      const result = await executeDeclareVariables(state, block)
 
-    expect(result.input).toBeUndefined()
-    expect(result.outgoingEdgeId).toBe('edge-1')
+      expect(result.input).toBeUndefined()
+      expect(result.outgoingEdgeId).toBe('edge-1')
+    })
+
+    it('does not pause for a required variable without a value either', async () => {
+      // TOOL flows run headless: there is no human to answer an input block,
+      // so even a required variable must not block the run.
+      const state = makeState([{ id: 'v1', name: 'requiredParam' }], 'TOOL')
+      const block = makeBlock([
+        { variableId: 'v1', description: 'a required param', required: true },
+      ])
+
+      const result = await executeDeclareVariables(state, block)
+
+      expect(result.input).toBeUndefined()
+      expect(result.outgoingEdgeId).toBe('edge-1')
+    })
   })
 
-  it('still pauses the flow for a required variable without a value', async () => {
-    const state = makeState([{ id: 'v1', name: 'requiredParam' }])
-    const block = makeBlock([
-      { variableId: 'v1', description: 'a required param', required: true },
-    ])
+  describe('interactive (non-TOOL) mode — behavior preserved (blast radius zero)', () => {
+    it('still pauses for an empty variable (default settings type)', async () => {
+      const state = makeState([{ id: 'v1', name: 'someParam' }], 'default')
+      const block = makeBlock([
+        { variableId: 'v1', description: 'a param', required: false },
+      ])
 
-    const result = await executeDeclareVariables(state, block)
+      const result = await executeDeclareVariables(state, block)
 
-    expect(result.input).toBeDefined()
-    expect(result.input?.options?.variableId).toBe('v1')
+      expect(result.input).toBeDefined()
+      expect(result.input?.options?.variableId).toBe('v1')
+    })
+
+    it('still pauses for an empty variable when settings are absent (legacy session)', async () => {
+      const state = {
+        typebotsQueue: [{ typebot: { variables: [{ id: 'v1', name: 'p' }] } }],
+      } as unknown as SessionState
+      const block = makeBlock([{ variableId: 'v1', description: 'a param' }])
+
+      const result = await executeDeclareVariables(state, block)
+
+      expect(result.input).toBeDefined()
+    })
   })
 
-  it('pauses the flow when the required flag is absent (legacy default = required)', async () => {
-    const state = makeState([{ id: 'v1', name: 'legacyParam' }])
-    const block = makeBlock([
-      { variableId: 'v1', description: 'a legacy param' },
-    ])
-
-    const result = await executeDeclareVariables(state, block)
-
-    expect(result.input).toBeDefined()
-  })
-
-  it('skips a leading optional empty var and pauses on the required one (Bugbot misroute scenario)', async () => {
-    // [optional(empty), required(empty)] — the paused input must target the
-    // REQUIRED variable, not the optional one. This is the same selection that
-    // continueBotFlow relies on to save the reply to the correct variable; if
-    // they disagreed, the reply would be saved to the optional var and the
-    // required prompt would re-appear (misroute + duplicate prompt).
-    const state = makeState([
-      { id: 'v1', name: 'optionalParam' },
-      { id: 'v2', name: 'requiredParam' },
-    ])
-    const block = makeBlock([
-      { variableId: 'v1', description: 'an optional param', required: false },
-      { variableId: 'v2', description: 'a required param', required: true },
-    ])
-
-    const result = await executeDeclareVariables(state, block)
-
-    expect(result.input).toBeDefined()
-    expect(result.input?.options?.variableId).toBe('v2')
-  })
-
-  it('proceeds without input when the variable already has a value', async () => {
-    const state = makeState([{ id: 'v1', name: 'filled', value: 'hello' }])
+  it('proceeds without input when the variable already has a value (any mode)', async () => {
+    const state = makeState(
+      [{ id: 'v1', name: 'filled', value: 'hello' }],
+      'TOOL'
+    )
     const block = makeBlock([
       { variableId: 'v1', description: 'already filled', required: true },
     ])

--- a/packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.test.ts
+++ b/packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.test.ts
@@ -5,14 +5,14 @@ import { LogicBlockType } from '@typebot.io/schemas/features/blocks/logic/consta
 
 const makeState = (
   variables: Array<{ id: string; name: string; value?: unknown }>,
-  type: 'default' | 'TOOL' = 'default'
+  isToolWorkflow = false
 ): SessionState =>
   ({
     typebotsQueue: [
       {
         typebot: {
           variables,
-          settings: { general: { type } },
+          isToolWorkflow,
         },
       },
     ],
@@ -35,7 +35,7 @@ const makeBlock = (
 describe('executeDeclareVariables', () => {
   describe('TOOL mode (headless — never pauses)', () => {
     it('does not pause for an optional variable without a value', async () => {
-      const state = makeState([{ id: 'v1', name: 'optionalParam' }], 'TOOL')
+      const state = makeState([{ id: 'v1', name: 'optionalParam' }], true)
       const block = makeBlock([
         { variableId: 'v1', description: 'an optional param', required: false },
       ])
@@ -51,7 +51,7 @@ describe('executeDeclareVariables', () => {
       // arrive empty. Skipping it would silently produce an incomplete payload
       // ({{var}} === ""), so we fail loudly instead — surfaced as a JSON-RPC
       // error by the /api/mcp tools/call handler. This is NOT a pause.
-      const state = makeState([{ id: 'v1', name: 'requiredParam' }], 'TOOL')
+      const state = makeState([{ id: 'v1', name: 'requiredParam' }], true)
       const block = makeBlock([
         { variableId: 'v1', description: 'a required param', required: true },
       ])
@@ -63,8 +63,8 @@ describe('executeDeclareVariables', () => {
   })
 
   describe('interactive (non-TOOL) mode — behavior preserved (blast radius zero)', () => {
-    it('still pauses for an empty variable (default settings type)', async () => {
-      const state = makeState([{ id: 'v1', name: 'someParam' }], 'default')
+    it('still pauses for an empty variable (isToolWorkflow false)', async () => {
+      const state = makeState([{ id: 'v1', name: 'someParam' }], false)
       const block = makeBlock([
         { variableId: 'v1', description: 'a param', required: false },
       ])
@@ -75,7 +75,7 @@ describe('executeDeclareVariables', () => {
       expect(result.input?.options?.variableId).toBe('v1')
     })
 
-    it('still pauses for an empty variable when settings are absent (legacy session)', async () => {
+    it('still pauses for an empty variable when isToolWorkflow is absent (legacy session)', async () => {
       const state = {
         typebotsQueue: [{ typebot: { variables: [{ id: 'v1', name: 'p' }] } }],
       } as unknown as SessionState
@@ -90,7 +90,7 @@ describe('executeDeclareVariables', () => {
   it('proceeds without input when the variable already has a value (any mode)', async () => {
     const state = makeState(
       [{ id: 'v1', name: 'filled', value: 'hello' }],
-      'TOOL'
+      true
     )
     const block = makeBlock([
       { variableId: 'v1', description: 'already filled', required: true },

--- a/packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.test.ts
+++ b/packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.test.ts
@@ -46,18 +46,19 @@ describe('executeDeclareVariables', () => {
       expect(result.outgoingEdgeId).toBe('edge-1')
     })
 
-    it('does not pause for a required variable without a value either', async () => {
-      // TOOL flows run headless: there is no human to answer an input block,
-      // so even a required variable must not block the run.
+    it('throws for a required variable without a value (no silent skip)', async () => {
+      // The MCP route does not validate `required`, so a required variable can
+      // arrive empty. Skipping it would silently produce an incomplete payload
+      // ({{var}} === ""), so we fail loudly instead — surfaced as a JSON-RPC
+      // error by the /api/mcp tools/call handler. This is NOT a pause.
       const state = makeState([{ id: 'v1', name: 'requiredParam' }], 'TOOL')
       const block = makeBlock([
         { variableId: 'v1', description: 'a required param', required: true },
       ])
 
-      const result = await executeDeclareVariables(state, block)
-
-      expect(result.input).toBeUndefined()
-      expect(result.outgoingEdgeId).toBe('edge-1')
+      await expect(executeDeclareVariables(state, block)).rejects.toThrow(
+        /Missing required variable "requiredParam"/
+      )
     })
   })
 

--- a/packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.test.ts
+++ b/packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.test.ts
@@ -66,6 +66,27 @@ describe('executeDeclareVariables', () => {
     expect(result.input).toBeDefined()
   })
 
+  it('skips a leading optional empty var and pauses on the required one (Bugbot misroute scenario)', async () => {
+    // [optional(empty), required(empty)] — the paused input must target the
+    // REQUIRED variable, not the optional one. This is the same selection that
+    // continueBotFlow relies on to save the reply to the correct variable; if
+    // they disagreed, the reply would be saved to the optional var and the
+    // required prompt would re-appear (misroute + duplicate prompt).
+    const state = makeState([
+      { id: 'v1', name: 'optionalParam' },
+      { id: 'v2', name: 'requiredParam' },
+    ])
+    const block = makeBlock([
+      { variableId: 'v1', description: 'an optional param', required: false },
+      { variableId: 'v2', description: 'a required param', required: true },
+    ])
+
+    const result = await executeDeclareVariables(state, block)
+
+    expect(result.input).toBeDefined()
+    expect(result.input?.options?.variableId).toBe('v2')
+  })
+
   it('proceeds without input when the variable already has a value', async () => {
     const state = makeState([{ id: 'v1', name: 'filled', value: 'hello' }])
     const block = makeBlock([

--- a/packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.ts
+++ b/packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.ts
@@ -15,6 +15,9 @@ export const executeDeclareVariables = async (
     }
   }
 
+  const isToolMode =
+    state.typebotsQueue[0]?.typebot.settings?.general?.type === 'TOOL'
+
   // Find the first variable that doesn't have a value yet
   for (const declaredVar of variables) {
     const variable = state.typebotsQueue[0].typebot.variables.find(
@@ -32,12 +35,11 @@ export const executeDeclareVariables = async (
       continue
     }
 
-    // Optional declared variable left empty: skip it instead of pausing,
-    // honoring the `required:false` contract. Applies to any execution path —
-    // leaving the variable empty lets {{var}} resolve to "" and the flow runs
-    // through to the return block. `required` defaults to true in the schema,
-    // so required/legacy vars still block here.
-    if (declaredVar.required === false) {
+    // TOOL flows run headless (invoked by an agent, no human to answer inputs).
+    // Never pause to collect an unprovided variable — leave it empty so {{var}}
+    // resolves to "" and the run completes. Interactive (non-TOOL) flows keep
+    // the original collect-on-empty behavior untouched.
+    if (isToolMode) {
       continue
     }
 

--- a/packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.ts
+++ b/packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.ts
@@ -15,8 +15,7 @@ export const executeDeclareVariables = async (
     }
   }
 
-  const isToolMode =
-    state.typebotsQueue[0]?.typebot.settings?.general?.type === 'TOOL'
+  const isToolMode = state.typebotsQueue[0]?.typebot.isToolWorkflow === true
 
   // Find the first variable that doesn't have a value yet
   for (const declaredVar of variables) {

--- a/packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.ts
+++ b/packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.ts
@@ -35,12 +35,22 @@ export const executeDeclareVariables = async (
       continue
     }
 
-    // TOOL flows run headless (invoked by an agent, no human to answer inputs).
-    // Never pause to collect an unprovided variable — leave it empty so {{var}}
-    // resolves to "" and the run completes. Interactive (non-TOOL) flows keep
-    // the original collect-on-empty behavior untouched.
     if (isToolMode) {
-      continue
+      // TOOL flows are headless (agent-invoked, no human to answer inputs).
+      // Optional param not provided: leave it empty so {{var}} resolves to ""
+      // and the run completes.
+      if (declaredVar.required === false) {
+        continue
+      }
+      // Required param missing: the MCP route does not validate `required`, so a
+      // required variable can arrive empty. Skipping it would yield a
+      // "successful" result with an empty {{var}} (silent incomplete payload).
+      // Fail loudly so the agent gets a real error (surfaced as a JSON-RPC error
+      // by the /api/mcp tools/call handler) instead of garbage. This is NOT a
+      // pause/wait-for-input.
+      throw new Error(
+        `Missing required variable "${variable.name}" for TOOL workflow`
+      )
     }
 
     // This variable needs input - show a text input for it

--- a/packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.ts
+++ b/packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.ts
@@ -32,11 +32,11 @@ export const executeDeclareVariables = async (
       continue
     }
 
-    // Optional param not provided: don't pause the flow. TOOL-mode typebots run
-    // server-side via a single startChat (no continuation loop), so there is no
-    // human to answer an input block. Leaving the variable empty lets {{var}}
-    // resolve to "" and the flow runs through to the return block. `required`
-    // defaults to true in the schema, so legacy/required vars keep blocking.
+    // Optional declared variable left empty: skip it instead of pausing,
+    // honoring the `required:false` contract. Applies to any execution path —
+    // leaving the variable empty lets {{var}} resolve to "" and the flow runs
+    // through to the return block. `required` defaults to true in the schema,
+    // so required/legacy vars still block here.
     if (declaredVar.required === false) {
       continue
     }

--- a/packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.ts
+++ b/packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.ts
@@ -8,7 +8,7 @@ export const executeDeclareVariables = async (
   block: DeclareVariablesBlock
 ): Promise<ExecuteLogicResponse> => {
   const variables = block.options?.variables ?? []
-  
+
   if (variables.length === 0) {
     return {
       outgoingEdgeId: block.outgoingEdgeId,
@@ -20,17 +20,30 @@ export const executeDeclareVariables = async (
     const variable = state.typebotsQueue[0].typebot.variables.find(
       (v) => v.id === declaredVar.variableId
     )
-    
+
     if (!variable) continue
 
     // If the variable already has a value, skip it
-    if (variable.value !== undefined && variable.value !== null && variable.value !== '') {
+    if (
+      variable.value !== undefined &&
+      variable.value !== null &&
+      variable.value !== ''
+    ) {
+      continue
+    }
+
+    // Optional param not provided: don't pause the flow. TOOL-mode typebots run
+    // server-side via a single startChat (no continuation loop), so there is no
+    // human to answer an input block. Leaving the variable empty lets {{var}}
+    // resolve to "" and the flow runs through to the return block. `required`
+    // defaults to true in the schema, so legacy/required vars keep blocking.
+    if (declaredVar.required === false) {
       continue
     }
 
     // This variable needs input - show a text input for it
     const messages: ExecuteLogicResponse['messages'] = []
-    
+
     // Add description as a bubble if available
     if (declaredVar.description) {
       messages.push({

--- a/packages/bot-engine/continueBotFlow.ts
+++ b/packages/bot-engine/continueBotFlow.ts
@@ -194,13 +194,30 @@ export const continueBotFlow = async (
   let formattedReply: string | undefined
 
   // Handle Declare Variables block - find the first empty variable and save the reply
-  if (block.type === LogicBlockType.DECLARE_VARIABLES && reply && typeof reply === 'string') {
+  if (
+    block.type === LogicBlockType.DECLARE_VARIABLES &&
+    reply &&
+    typeof reply === 'string'
+  ) {
     const variables = (block as any).options?.variables ?? []
     for (const declaredVar of variables) {
       const variable = state.typebotsQueue[0].typebot.variables.find(
         (v) => v.id === declaredVar.variableId
       )
-      if (!variable || (variable.value !== undefined && variable.value !== null && variable.value !== '')) {
+      if (
+        !variable ||
+        (variable.value !== undefined &&
+          variable.value !== null &&
+          variable.value !== '')
+      ) {
+        continue
+      }
+      // Optional declared variable left empty: skip it instead of collecting,
+      // honoring the `required:false` contract. This must mirror
+      // executeDeclareVariables so both sides agree on which variable is being
+      // collected; otherwise the reply would be saved to the wrong variable.
+      // `required` defaults to true, so required/legacy vars are still collected.
+      if (declaredVar.required === false) {
         continue
       }
       // Found the variable we're collecting - save it
@@ -348,11 +365,11 @@ export const continueBotFlow = async (
 
 const processAndSaveAnswer =
   (state: SessionState, block: InputBlock) =>
-    async (reply: string | undefined): Promise<SessionState> => {
-      if (!reply) return state
-      let newState = await saveAnswerInDb(state, block)(reply)
-      return newState
-    }
+  async (reply: string | undefined): Promise<SessionState> => {
+    if (!reply) return state
+    let newState = await saveAnswerInDb(state, block)(reply)
+    return newState
+  }
 
 const saveVariableValueIfAny =
   (state: SessionState, block: InputBlock) =>
@@ -387,11 +404,11 @@ const parseRetryMessage =
   ): Promise<Pick<ContinueChatResponse, 'messages' | 'input'>> => {
     const retryMessage =
       block.options &&
-        'retryMessageContent' in block.options &&
-        block.options.retryMessageContent
+      'retryMessageContent' in block.options &&
+      block.options.retryMessageContent
         ? parseVariables(state.typebotsQueue[0].typebot.variables)(
-          block.options.retryMessageContent
-        )
+            block.options.retryMessageContent
+          )
         : parseDefaultRetryMessage(block)
     return {
       messages: [
@@ -401,13 +418,13 @@ const parseRetryMessage =
           content:
             textBubbleContentFormat === 'richText'
               ? {
-                type: 'richText',
-                richText: [{ type: 'p', children: [{ text: retryMessage }] }],
-              }
+                  type: 'richText',
+                  richText: [{ type: 'p', children: [{ text: retryMessage }] }],
+                }
               : {
-                type: 'markdown',
-                markdown: retryMessage,
-              },
+                  type: 'markdown',
+                  markdown: retryMessage,
+                },
         },
       ],
       input: await parseInput(state)(block),
@@ -427,41 +444,41 @@ const parseDefaultRetryMessage = (block: InputBlock): string => {
 
 const saveAnswerInDb =
   (state: SessionState, block: InputBlock) =>
-    async (reply: string): Promise<SessionState> => {
-      let newSessionState = state
-      await saveAnswer({
-        answer: {
-          blockId: block.id,
-          content: reply,
-        },
-        reply,
-        state,
-      })
+  async (reply: string): Promise<SessionState> => {
+    let newSessionState = state
+    await saveAnswer({
+      answer: {
+        blockId: block.id,
+        content: reply,
+      },
+      reply,
+      state,
+    })
 
-      newSessionState = {
-        ...saveVariableValueIfAny(newSessionState, block)(reply),
-        previewMetadata: state.typebotsQueue[0].resultId
-          ? newSessionState.previewMetadata
-          : {
+    newSessionState = {
+      ...saveVariableValueIfAny(newSessionState, block)(reply),
+      previewMetadata: state.typebotsQueue[0].resultId
+        ? newSessionState.previewMetadata
+        : {
             ...newSessionState.previewMetadata,
             answers: (newSessionState.previewMetadata?.answers ?? []).concat({
               blockId: block.id,
               content: reply,
             }),
           },
-      }
+    }
 
-      const key = block.options?.variableId
-        ? newSessionState.typebotsQueue[0].typebot.variables.find(
+    const key = block.options?.variableId
+      ? newSessionState.typebotsQueue[0].typebot.variables.find(
           (variable) => variable.id === block.options?.variableId
         )?.name
-        : parseGroupKey(block.id, { state: newSessionState })
+      : parseGroupKey(block.id, { state: newSessionState })
 
-      return setNewAnswerInState(newSessionState)({
-        key: key ?? block.id,
-        value: reply,
-      })
-    }
+    return setNewAnswerInState(newSessionState)({
+      key: key ?? block.id,
+      value: reply,
+    })
+  }
 
 const parseGroupKey = (blockId: string, { state }: { state: SessionState }) => {
   const group = state.typebotsQueue[0].typebot.groups.find((group) =>
@@ -493,9 +510,9 @@ const setNewAnswerInState =
       typebotsQueue: state.typebotsQueue.map((typebot, index) =>
         index === 0
           ? {
-            ...typebot,
-            answers: newAnswers,
-          }
+              ...typebot,
+              answers: newAnswers,
+            }
           : typebot
       ),
     } satisfies SessionState

--- a/packages/bot-engine/continueBotFlow.ts
+++ b/packages/bot-engine/continueBotFlow.ts
@@ -194,30 +194,13 @@ export const continueBotFlow = async (
   let formattedReply: string | undefined
 
   // Handle Declare Variables block - find the first empty variable and save the reply
-  if (
-    block.type === LogicBlockType.DECLARE_VARIABLES &&
-    reply &&
-    typeof reply === 'string'
-  ) {
+  if (block.type === LogicBlockType.DECLARE_VARIABLES && reply && typeof reply === 'string') {
     const variables = (block as any).options?.variables ?? []
     for (const declaredVar of variables) {
       const variable = state.typebotsQueue[0].typebot.variables.find(
         (v) => v.id === declaredVar.variableId
       )
-      if (
-        !variable ||
-        (variable.value !== undefined &&
-          variable.value !== null &&
-          variable.value !== '')
-      ) {
-        continue
-      }
-      // Optional declared variable left empty: skip it instead of collecting,
-      // honoring the `required:false` contract. This must mirror
-      // executeDeclareVariables so both sides agree on which variable is being
-      // collected; otherwise the reply would be saved to the wrong variable.
-      // `required` defaults to true, so required/legacy vars are still collected.
-      if (declaredVar.required === false) {
+      if (!variable || (variable.value !== undefined && variable.value !== null && variable.value !== '')) {
         continue
       }
       // Found the variable we're collecting - save it
@@ -365,11 +348,11 @@ export const continueBotFlow = async (
 
 const processAndSaveAnswer =
   (state: SessionState, block: InputBlock) =>
-  async (reply: string | undefined): Promise<SessionState> => {
-    if (!reply) return state
-    let newState = await saveAnswerInDb(state, block)(reply)
-    return newState
-  }
+    async (reply: string | undefined): Promise<SessionState> => {
+      if (!reply) return state
+      let newState = await saveAnswerInDb(state, block)(reply)
+      return newState
+    }
 
 const saveVariableValueIfAny =
   (state: SessionState, block: InputBlock) =>
@@ -404,11 +387,11 @@ const parseRetryMessage =
   ): Promise<Pick<ContinueChatResponse, 'messages' | 'input'>> => {
     const retryMessage =
       block.options &&
-      'retryMessageContent' in block.options &&
-      block.options.retryMessageContent
+        'retryMessageContent' in block.options &&
+        block.options.retryMessageContent
         ? parseVariables(state.typebotsQueue[0].typebot.variables)(
-            block.options.retryMessageContent
-          )
+          block.options.retryMessageContent
+        )
         : parseDefaultRetryMessage(block)
     return {
       messages: [
@@ -418,13 +401,13 @@ const parseRetryMessage =
           content:
             textBubbleContentFormat === 'richText'
               ? {
-                  type: 'richText',
-                  richText: [{ type: 'p', children: [{ text: retryMessage }] }],
-                }
+                type: 'richText',
+                richText: [{ type: 'p', children: [{ text: retryMessage }] }],
+              }
               : {
-                  type: 'markdown',
-                  markdown: retryMessage,
-                },
+                type: 'markdown',
+                markdown: retryMessage,
+              },
         },
       ],
       input: await parseInput(state)(block),
@@ -444,41 +427,41 @@ const parseDefaultRetryMessage = (block: InputBlock): string => {
 
 const saveAnswerInDb =
   (state: SessionState, block: InputBlock) =>
-  async (reply: string): Promise<SessionState> => {
-    let newSessionState = state
-    await saveAnswer({
-      answer: {
-        blockId: block.id,
-        content: reply,
-      },
-      reply,
-      state,
-    })
+    async (reply: string): Promise<SessionState> => {
+      let newSessionState = state
+      await saveAnswer({
+        answer: {
+          blockId: block.id,
+          content: reply,
+        },
+        reply,
+        state,
+      })
 
-    newSessionState = {
-      ...saveVariableValueIfAny(newSessionState, block)(reply),
-      previewMetadata: state.typebotsQueue[0].resultId
-        ? newSessionState.previewMetadata
-        : {
+      newSessionState = {
+        ...saveVariableValueIfAny(newSessionState, block)(reply),
+        previewMetadata: state.typebotsQueue[0].resultId
+          ? newSessionState.previewMetadata
+          : {
             ...newSessionState.previewMetadata,
             answers: (newSessionState.previewMetadata?.answers ?? []).concat({
               blockId: block.id,
               content: reply,
             }),
           },
-    }
+      }
 
-    const key = block.options?.variableId
-      ? newSessionState.typebotsQueue[0].typebot.variables.find(
+      const key = block.options?.variableId
+        ? newSessionState.typebotsQueue[0].typebot.variables.find(
           (variable) => variable.id === block.options?.variableId
         )?.name
-      : parseGroupKey(block.id, { state: newSessionState })
+        : parseGroupKey(block.id, { state: newSessionState })
 
-    return setNewAnswerInState(newSessionState)({
-      key: key ?? block.id,
-      value: reply,
-    })
-  }
+      return setNewAnswerInState(newSessionState)({
+        key: key ?? block.id,
+        value: reply,
+      })
+    }
 
 const parseGroupKey = (blockId: string, { state }: { state: SessionState }) => {
   const group = state.typebotsQueue[0].typebot.groups.find((group) =>
@@ -510,9 +493,9 @@ const setNewAnswerInState =
       typebotsQueue: state.typebotsQueue.map((typebot, index) =>
         index === 0
           ? {
-              ...typebot,
-              answers: newAnswers,
-            }
+            ...typebot,
+            answers: newAnswers,
+          }
           : typebot
       ),
     } satisfies SessionState

--- a/packages/bot-engine/startSession.ts
+++ b/packages/bot-engine/startSession.ts
@@ -536,7 +536,7 @@ const convertStartTypebotToTypebotInSession = (
         variables: startVariables,
         events: typebot.events,
         typebotId: typebot.id,
-        settings: typebot.settings,
+        isToolWorkflow: typebot.settings?.general?.type === 'TOOL',
       }
     : {
         version: typebot.version,
@@ -550,7 +550,7 @@ const convertStartTypebotToTypebotInSession = (
         variables: startVariables,
         events: typebot.events,
         typebotId: typebot.id,
-        settings: typebot.settings,
+        isToolWorkflow: typebot.settings?.general?.type === 'TOOL',
       }
 
 const extractVariableIdsUsedForTranscript = (

--- a/packages/bot-engine/startSession.ts
+++ b/packages/bot-engine/startSession.ts
@@ -536,6 +536,7 @@ const convertStartTypebotToTypebotInSession = (
         variables: startVariables,
         events: typebot.events,
         typebotId: typebot.id,
+        settings: typebot.settings,
       }
     : {
         version: typebot.version,
@@ -549,6 +550,7 @@ const convertStartTypebotToTypebotInSession = (
         variables: startVariables,
         events: typebot.events,
         typebotId: typebot.id,
+        settings: typebot.settings,
       }
 
 const extractVariableIdsUsedForTranscript = (

--- a/packages/bot-engine/tsconfig.json
+++ b/packages/bot-engine/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@typebot.io/tsconfig/base.json",
   "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
     "jsx": "preserve",
     "lib": ["ES2021"]

--- a/packages/schemas/features/chat/shared.ts
+++ b/packages/schemas/features/chat/shared.ts
@@ -10,6 +10,10 @@ const typebotInSessionStatePick = {
   edges: true,
   variables: true,
   typebotId: true,
+  // Carried so the engine can detect TOOL-mode flows at runtime
+  // (settings.general.type === 'TOOL'). Optional on the schema, so legacy
+  // serialized sessions without it stay backward compatible.
+  settings: true,
 } as const
 
 const typebotInSessionBaseSchema = z.preprocess(

--- a/packages/schemas/features/chat/shared.ts
+++ b/packages/schemas/features/chat/shared.ts
@@ -1,6 +1,7 @@
 import { z } from '../../zod'
 import { publicTypebotSchemaV5, publicTypebotSchemaV6 } from '../publicTypebot'
 import { preprocessTypebot } from '../typebot/helpers/preprocessTypebot'
+import { settingsSchema } from '../typebot/settings'
 
 const typebotInSessionStatePick = {
   version: true,
@@ -10,10 +11,6 @@ const typebotInSessionStatePick = {
   edges: true,
   variables: true,
   typebotId: true,
-  // Carried so the engine can detect TOOL-mode flows at runtime
-  // (settings.general.type === 'TOOL'). Optional on the schema, so legacy
-  // serialized sessions without it stay backward compatible.
-  settings: true,
 } as const
 
 const typebotInSessionBaseSchema = z.preprocess(
@@ -31,6 +28,10 @@ const sessionLoggingFieldsSchema = z.object({
   workspaceId: z.string().optional(),
   workspaceName: z.string().optional(),
   typebotHistoryId: z.string().optional(),
+  // Carried so the engine can detect TOOL-mode flows (settings.general.type
+  // === 'TOOL'). Optional for backward compatibility with existing serialized
+  // sessions created before this field was added.
+  settings: settingsSchema.optional(),
 })
 
 export const typebotInSessionStateSchema = typebotInSessionBaseSchema.and(

--- a/packages/schemas/features/chat/shared.ts
+++ b/packages/schemas/features/chat/shared.ts
@@ -20,8 +20,11 @@ const typebotInSessionBaseSchema = z.preprocess(
   ])
 )
 
-// Additional fields for logging context — optional for backward compatibility
-// with existing serialized sessions that lack these fields.
+// Optional fields merged onto the session typebot. Kept optional for backward
+// compatibility with sessions serialized before each field existed (getSession
+// parses stored state strictly, so a required field would break in-flight
+// sessions). Covers both diagnostic/logging context (name, workspaceId, ...)
+// and runtime-functional flags (isToolWorkflow, used to detect TOOL-mode flows).
 const sessionLoggingFieldsSchema = z.object({
   name: z.string().optional(),
   workspaceId: z.string().optional(),

--- a/packages/schemas/features/chat/shared.ts
+++ b/packages/schemas/features/chat/shared.ts
@@ -1,7 +1,6 @@
 import { z } from '../../zod'
 import { publicTypebotSchemaV5, publicTypebotSchemaV6 } from '../publicTypebot'
 import { preprocessTypebot } from '../typebot/helpers/preprocessTypebot'
-import { settingsSchema } from '../typebot/settings'
 
 const typebotInSessionStatePick = {
   version: true,
@@ -28,10 +27,11 @@ const sessionLoggingFieldsSchema = z.object({
   workspaceId: z.string().optional(),
   workspaceName: z.string().optional(),
   typebotHistoryId: z.string().optional(),
-  // Carried so the engine can detect TOOL-mode flows (settings.general.type
-  // === 'TOOL'). Optional for backward compatibility with existing serialized
-  // sessions created before this field was added.
-  settings: settingsSchema.optional(),
+  // Derived at session creation from settings.general.type === 'TOOL'. Carried
+  // (instead of the full settings object) so the engine can detect TOOL-mode
+  // flows without persisting unrelated config (customHeadCode, GTM, allowedOrigins).
+  // Optional for backward compatibility with sessions created before this field.
+  isToolWorkflow: z.boolean().optional(),
 })
 
 export const typebotInSessionStateSchema = typebotInSessionBaseSchema.and(

--- a/packages/schemas/features/chat/typebotInSessionState.test.ts
+++ b/packages/schemas/features/chat/typebotInSessionState.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from 'vitest'
 import { typebotInSessionStateSchema } from './shared'
 
 // Minimal valid v6 typebot-in-session object (the pick: version, id, groups,
-// events, edges, variables, typebotId). `settings` is intentionally NOT a pick
-// field — it is captured separately as an optional field, so legacy sessions
-// serialized before `settings` was carried must still parse.
+// events, edges, variables, typebotId). `isToolWorkflow` is NOT a pick field —
+// it is captured separately as an optional field, so legacy sessions serialized
+// before it was carried must still parse.
 const makeLegacyV6Typebot = () => ({
   version: '6' as const,
   id: 'typebot-1',
@@ -21,31 +21,32 @@ const makeLegacyV6Typebot = () => ({
   ],
 })
 
-describe('typebotInSessionStateSchema — settings back-compat', () => {
-  it('parses a legacy session typebot WITHOUT settings (no throw)', () => {
+describe('typebotInSessionStateSchema — isToolWorkflow back-compat', () => {
+  it('parses a legacy session typebot WITHOUT isToolWorkflow (no throw, resolves to non-TOOL)', () => {
     const result = typebotInSessionStateSchema.safeParse(makeLegacyV6Typebot())
 
     expect(result.success).toBe(true)
     if (result.success) {
-      // settings must be undefined, not a parse error — this is the exact
-      // failure mode that would 500 getSession (strict parse) on deploy if
-      // settings were carried as a REQUIRED pick field.
-      expect((result.data as { settings?: unknown }).settings).toBeUndefined()
+      // isToolWorkflow must be undefined, not a parse error — strict
+      // getSession() parse would 500 on every pre-deploy session if this were a
+      // REQUIRED field. undefined !== true → engine falls back to non-TOOL.
+      expect(
+        (result.data as { isToolWorkflow?: unknown }).isToolWorkflow
+      ).toBeUndefined()
     }
   })
 
-  it('parses a session typebot WITH settings and exposes the TOOL flag', () => {
+  it('parses a session typebot WITH isToolWorkflow: true', () => {
     const result = typebotInSessionStateSchema.safeParse({
       ...makeLegacyV6Typebot(),
-      settings: { general: { type: 'TOOL' } },
+      isToolWorkflow: true,
     })
 
     expect(result.success).toBe(true)
     if (result.success) {
-      const data = result.data as {
-        settings?: { general?: { type?: string } }
-      }
-      expect(data.settings?.general?.type).toBe('TOOL')
+      expect((result.data as { isToolWorkflow?: boolean }).isToolWorkflow).toBe(
+        true
+      )
     }
   })
 })

--- a/packages/schemas/features/chat/typebotInSessionState.test.ts
+++ b/packages/schemas/features/chat/typebotInSessionState.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { typebotInSessionStateSchema } from './shared'
+
+// Minimal valid v6 typebot-in-session object (the pick: version, id, groups,
+// events, edges, variables, typebotId). `settings` is intentionally NOT a pick
+// field — it is captured separately as an optional field, so legacy sessions
+// serialized before `settings` was carried must still parse.
+const makeLegacyV6Typebot = () => ({
+  version: '6' as const,
+  id: 'typebot-1',
+  typebotId: 'typebot-1',
+  groups: [],
+  edges: [],
+  variables: [],
+  events: [
+    {
+      id: 'start-event',
+      type: 'start',
+      graphCoordinates: { x: 0, y: 0 },
+    },
+  ],
+})
+
+describe('typebotInSessionStateSchema — settings back-compat', () => {
+  it('parses a legacy session typebot WITHOUT settings (no throw)', () => {
+    const result = typebotInSessionStateSchema.safeParse(makeLegacyV6Typebot())
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      // settings must be undefined, not a parse error — this is the exact
+      // failure mode that would 500 getSession (strict parse) on deploy if
+      // settings were carried as a REQUIRED pick field.
+      expect((result.data as { settings?: unknown }).settings).toBeUndefined()
+    }
+  })
+
+  it('parses a session typebot WITH settings and exposes the TOOL flag', () => {
+    const result = typebotInSessionStateSchema.safeParse({
+      ...makeLegacyV6Typebot(),
+      settings: { general: { type: 'TOOL' } },
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      const data = result.data as {
+        settings?: { general?: { type?: string } }
+      }
+      expect(data.settings?.general?.type).toBe('TOOL')
+    }
+  })
+})

--- a/packages/schemas/tsconfig.json
+++ b/packages/schemas/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@typebot.io/tsconfig/base.json",
   "include": ["**/*.ts"],
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
     "lib": ["ESNext"],
     "noEmit": true


### PR DESCRIPTION
## The bug

When a TOOL-type typebot (`settings.general.type = "TOOL"`) declares an **optional** parameter and the LLM agent **omits** it, the engine paused the flow and returned an input block instead of running through to the return block.

The tool then returned `status: success` but with the body of a paused input block (the `startChat` response shape: `sessionId` / `messages` / `input` / `resultId`) instead of the final JSON result the flow was supposed to build. Confirmed via LangSmith trace.

Omitting an optional param is correct agent behavior: `getWorkflowTools.ts` exposes optional params as `required: false` in the tool's JSON schema, so the LLM is free to leave them out.

## Root cause

TOOL-type typebots run **headless**: `executeWorkflow` invokes a single `startChat` with the agent-supplied params as prefilled variables — there is no human and no continuation loop. But `executeDeclareVariables` pauses on **any** declared variable without a value (emitting a description bubble + text input). When an optional param is omitted, the block pauses, and with no continuation, `startChat` returns the paused-input shape instead of the return-block JSON.

## The fix

Two parts:

1. **Gate the behavior on TOOL mode** (`executeDeclareVariables.ts`). A TOOL flow is headless, so it never pauses to collect an unprovided variable. Within the TOOL gate:
   - **Optional** (`required === false`) empty → skip it, leaving it empty (`{{var}}` resolves to `""`), and run to the return block.
   - **Required** empty → **throw** `Missing required variable "<name>" for TOOL workflow`. The `/api/mcp` `tools/call` handler passes `args` straight to `executeWorkflow` and does **not** validate the `required` array (that flag is only advertised in `tools/list`), so a required param can arrive empty. Silently skipping it would yield a "successful" result with an empty `{{var}}` (a silent, incomplete payload), so we fail loudly instead. The throw propagates `executeLogic → executeGroup → startBotFlow → startSession → startChat → executeWorkflow → tools/call` and is returned as a JSON-RPC error (`code: -32603`). It fires **before** `saveStateToDatabase`, so no half-saved session. This is **not** a pause/wait-for-input.

   Interactive (non-TOOL) flows keep the original collect-on-empty behavior **byte-for-byte**: everything is inside the `isToolMode` gate, and `continueBotFlow.ts` is unchanged vs `main` (0 diff).

2. **Carry a derived `isToolWorkflow` flag into the session state as OPTIONAL** (`shared.ts` + `startSession.ts`). Detecting TOOL mode at runtime only needs `settings.general.type`, so instead of persisting the whole `settings` object in every session (which would carry `customHeadCode`, GTM, `allowedOrigins`, `whatsApp`, etc. for no reason), the converter computes a lean boolean `isToolWorkflow = settings.general.type === 'TOOL'` at session creation. It is added as an **optional** field (in the `.and()`-ed object, **not** in the required `.pick()`) because `getSession` does a strict `sessionStateSchema.parse()`: a *required* field would throw a `ZodError` on every session serialized before this deploy (those have no `isToolWorkflow` key), breaking in-flight conversations. Optional → legacy sessions parse with `isToolWorkflow: undefined` (`!== true` → non-TOOL behavior). This follows the existing back-compat pattern of the colocated logging fields.

**Why TOOL-mode-scoped instead of honoring `required` per-variable in all modes:** interactive flows must not change behavior at all. The `required` flag is only advertised in `tools/list`; the `/api/mcp` `tools/call` route does **not** validate it before reaching the engine. So in TOOL mode the engine itself enforces the contract — skip empty **optionals**, and **fail explicitly** on a missing **required** variable rather than producing a silently incomplete result.

## Validation

- `continueBotFlow.ts`: **0 diff vs main** — interactive path untouched.
- **Back-compat proven** (`safeParse`): a legacy session state without `isToolWorkflow` parses (`success: true`) with `isToolWorkflow: undefined` (`!== true` → non-TOOL); with `isToolWorkflow: true` it parses to `true` — confirming the optional field never throws on pre-deploy sessions.
- **TOOL gate proven**: TOOL + empty optional → proceeds; TOOL + empty required → throws `Missing required variable ...`; non-TOOL + empty → still returns input; filled → proceeds.
- Only `executeDeclareVariables` reads `isToolWorkflow` from the session state, so populating it changes no other engine behavior.
- `tsc` (bot-engine + schemas): no new errors vs baseline. Pre-commit `turbo run lint` 7/7 green; `format:check` green. No `--no-verify`.
- Tests: `executeDeclareVariables` (TOOL skips empty optional; TOOL **throws** on empty required; non-TOOL still pauses; legacy without `isToolWorkflow` still pauses; filled proceeds) and a `typebotInSessionState` schema back-compat test. Note: this repo has no wired-up vitest runner, so colocated `.test.ts` are not executed in CI (same as the existing tests on `main`); `*.test.ts` are excluded from the package `tsconfig`s to keep `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant MCP as /api/mcp tools/call
    participant EW as executeWorkflow
    participant SC as startChat / startSession
    participant EDV as executeDeclareVariables

    MCP->>EW: args (parâmetros do agente)
    EW->>SC: "startChat({ prefilledVariables: args })"
    SC->>SC: convertStartTypebotToTypebotInSession
    SC->>EDV: executeDeclareVariables(state, block)

    alt "isToolWorkflow === true"
        alt "variável omitida e required === false"
            EDV-->>SC: continue (skip — fluxo prossegue)
        else "variável omitida e required !== false"
            EDV-->>SC: throw Error(Missing required variable)
            SC-->>EW: propagate error
            EW-->>MCP: JSON-RPC error (-32603)
        end
    else "isToolWorkflow !== true"
        EDV-->>SC: return input block (pausa — comportamento original)
    end

    SC-->>EW: messages + outgoingEdgeId (sem input block)
    EW-->>MCP: resultado JSON do bloco de retorno
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fbot-engine%2Fblocks%2Flogic%2FdeclareVariables%2FexecuteDeclareVariables.ts%3A38-43%0A**Vari%C3%A1vel%20com%20%60required%60%20implicitamente%20verdadeiro%20pode%20ser%20surpreendente**%0A%0AA%20guarda%20usa%20igualdade%20estrita%20%60%3D%3D%3D%20false%60%2C%20o%20que%20trata%20%60required%3A%20undefined%60%20como%20%22obrigat%C3%B3rio%22%20%28lan%C3%A7a%20erro%29.%20Em%20produ%C3%A7%C3%A3o%20isso%20%C3%A9%20correto%20porque%20o%20schema%20Zod%20aplica%20%60.default%28true%29%60%2C%20mas%20qualquer%20caminho%20que%20passe%20um%20bloco%20n%C3%A3o%20parseado%20pelo%20Zod%20%28ex.%3A%20fixtures%20de%20teste%20com%20%60as%20unknown%60%29%20receber%C3%A1%20o%20comportamento%20de%20%22throw%22%20mesmo%20sem%20%60required%3A%20true%60%20expl%C3%ADcito.%20Uma%20alternativa%20mais%20defensiva%20seria%20checar%20%60!%3D%3D%20true%60%2C%20que%20tornaria%20%60undefined%60%20equivalente%20a%20opcional%20%E2%80%94%20mas%20isso%20contradiz%20o%20default%20do%20schema.%20Um%20coment%C3%A1rio%20curto%20tornaria%20a%20inten%C3%A7%C3%A3o%20expl%C3%ADcita.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%2F%2F%20TOOL%20flows%20are%20headless%20%28agent-invoked%2C%20no%20human%20to%20answer%20inputs%29.%0A%20%20%20%20%20%20%2F%2F%20Optional%20param%20not%20provided%3A%20leave%20it%20empty%20so%20%7B%7Bvar%7D%7D%20resolves%20to%20%22%22%0A%20%20%20%20%20%20%2F%2F%20and%20the%20run%20completes.%0A%20%20%20%20%20%20%2F%2F%20Note%3A%20%60required%60%20defaults%20to%20%60true%60%20via%20the%20Zod%20schema%2C%20so%20%60undefined%60%0A%20%20%20%20%20%20%2F%2F%20is%20intentionally%20treated%20as%20required%20here%20%28same%20as%20%60true%60%29.%0A%20%20%20%20%20%20if%20%28declaredVar.required%20%3D%3D%3D%20false%29%20%7B%0A%20%20%20%20%20%20%20%20continue%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fbot-engine%2Fblocks%2Flogic%2FdeclareVariables%2FexecuteDeclareVariables.test.ts%3A44-58%0A**Caso%20de%20teste%20ausente%3A%20modo%20TOOL%20com%20%60required%60%20n%C3%A3o%20definido**%0A%0AOs%20testes%20de%20modo%20TOOL%20cobrem%20explicitamente%20%60required%3A%20false%60%20%28skip%29%20e%20%60required%3A%20true%60%20%28throw%29.%20Falta%20um%20caso%20em%20que%20%60required%60%20n%C3%A3o%20est%C3%A1%20definido%20no%20objeto%20bruto%20%28sem%20parsing%20Zod%29%2C%20que%20na%20implementa%C3%A7%C3%A3o%20tamb%C3%A9m%20lan%C3%A7a%20porque%20%60undefined%20%3D%3D%3D%20false%60%20%C3%A9%20%60false%60.%20Em%20produ%C3%A7%C3%A3o%20o%20Zod%20resolve%20com%20%60.default%28true%29%60%2C%20mas%20um%20teste%20expl%C3%ADcito%20documentaria%20e%20protegeria%20esse%20contrato%2C%20evitando%20regress%C3%B5es%20caso%20a%20guarda%20seja%20alterada%20futuramente.%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=219&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fbot-engine%2Fblocks%2Flogic%2FdeclareVariables%2FexecuteDeclareVariables.ts%3A38-43%0A**Vari%C3%A1vel%20com%20%60required%60%20implicitamente%20verdadeiro%20pode%20ser%20surpreendente**%0A%0AA%20guarda%20usa%20igualdade%20estrita%20%60%3D%3D%3D%20false%60%2C%20o%20que%20trata%20%60required%3A%20undefined%60%20como%20%22obrigat%C3%B3rio%22%20%28lan%C3%A7a%20erro%29.%20Em%20produ%C3%A7%C3%A3o%20isso%20%C3%A9%20correto%20porque%20o%20schema%20Zod%20aplica%20%60.default%28true%29%60%2C%20mas%20qualquer%20caminho%20que%20passe%20um%20bloco%20n%C3%A3o%20parseado%20pelo%20Zod%20%28ex.%3A%20fixtures%20de%20teste%20com%20%60as%20unknown%60%29%20receber%C3%A1%20o%20comportamento%20de%20%22throw%22%20mesmo%20sem%20%60required%3A%20true%60%20expl%C3%ADcito.%20Uma%20alternativa%20mais%20defensiva%20seria%20checar%20%60!%3D%3D%20true%60%2C%20que%20tornaria%20%60undefined%60%20equivalente%20a%20opcional%20%E2%80%94%20mas%20isso%20contradiz%20o%20default%20do%20schema.%20Um%20coment%C3%A1rio%20curto%20tornaria%20a%20inten%C3%A7%C3%A3o%20expl%C3%ADcita.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%2F%2F%20TOOL%20flows%20are%20headless%20%28agent-invoked%2C%20no%20human%20to%20answer%20inputs%29.%0A%20%20%20%20%20%20%2F%2F%20Optional%20param%20not%20provided%3A%20leave%20it%20empty%20so%20%7B%7Bvar%7D%7D%20resolves%20to%20%22%22%0A%20%20%20%20%20%20%2F%2F%20and%20the%20run%20completes.%0A%20%20%20%20%20%20%2F%2F%20Note%3A%20%60required%60%20defaults%20to%20%60true%60%20via%20the%20Zod%20schema%2C%20so%20%60undefined%60%0A%20%20%20%20%20%20%2F%2F%20is%20intentionally%20treated%20as%20required%20here%20%28same%20as%20%60true%60%29.%0A%20%20%20%20%20%20if%20%28declaredVar.required%20%3D%3D%3D%20false%29%20%7B%0A%20%20%20%20%20%20%20%20continue%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fbot-engine%2Fblocks%2Flogic%2FdeclareVariables%2FexecuteDeclareVariables.test.ts%3A44-58%0A**Caso%20de%20teste%20ausente%3A%20modo%20TOOL%20com%20%60required%60%20n%C3%A3o%20definido**%0A%0AOs%20testes%20de%20modo%20TOOL%20cobrem%20explicitamente%20%60required%3A%20false%60%20%28skip%29%20e%20%60required%3A%20true%60%20%28throw%29.%20Falta%20um%20caso%20em%20que%20%60required%60%20n%C3%A3o%20est%C3%A1%20definido%20no%20objeto%20bruto%20%28sem%20parsing%20Zod%29%2C%20que%20na%20implementa%C3%A7%C3%A3o%20tamb%C3%A9m%20lan%C3%A7a%20porque%20%60undefined%20%3D%3D%3D%20false%60%20%C3%A9%20%60false%60.%20Em%20produ%C3%A7%C3%A3o%20o%20Zod%20resolve%20com%20%60.default%28true%29%60%2C%20mas%20um%20teste%20expl%C3%ADcito%20documentaria%20e%20protegeria%20esse%20contrato%2C%20evitando%20regress%C3%B5es%20caso%20a%20guarda%20seja%20alterada%20futuramente.%0A%0A&pr=219&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.ts:38-43
**Variável com `required` implicitamente verdadeiro pode ser surpreendente**

A guarda usa igualdade estrita `=== false`, o que trata `required: undefined` como "obrigatório" (lança erro). Em produção isso é correto porque o schema Zod aplica `.default(true)`, mas qualquer caminho que passe um bloco não parseado pelo Zod (ex.: fixtures de teste com `as unknown`) receberá o comportamento de "throw" mesmo sem `required: true` explícito. Uma alternativa mais defensiva seria checar `!== true`, que tornaria `undefined` equivalente a opcional — mas isso contradiz o default do schema. Um comentário curto tornaria a intenção explícita.

```suggestion
      // TOOL flows are headless (agent-invoked, no human to answer inputs).
      // Optional param not provided: leave it empty so {{var}} resolves to ""
      // and the run completes.
      // Note: `required` defaults to `true` via the Zod schema, so `undefined`
      // is intentionally treated as required here (same as `true`).
      if (declaredVar.required === false) {
        continue
      }
```

### Issue 2 of 2
packages/bot-engine/blocks/logic/declareVariables/executeDeclareVariables.test.ts:44-58
**Caso de teste ausente: modo TOOL com `required` não definido**

Os testes de modo TOOL cobrem explicitamente `required: false` (skip) e `required: true` (throw). Falta um caso em que `required` não está definido no objeto bruto (sem parsing Zod), que na implementação também lança porque `undefined === false` é `false`. Em produção o Zod resolve com `.default(true)`, mas um teste explícito documentaria e protegeria esse contrato, evitando regressões caso a guarda seja alterada futuramente.

`````

</details>

<sub>Reviews (7): Last reviewed commit: ["docs(schemas): clarify sessionLoggingFie..."](https://github.com/cloudhumans/typebot.io/commit/d316fb85313b9f5e5f185ae7e7be62a7bbe06361) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35842006)</sub>

<!-- /greptile_comment -->