### PR TITLE
fix(server): pin KEEP_ALIVE_TIMEOUT so typebot never closes idle MCP sockets first

### DIFF
--- a/scripts/builder-entrypoint.sh
+++ b/scripts/builder-entrypoint.sh
@@ -4,4 +4,11 @@ cd apps/builder;
 node  -e "const { configureRuntimeEnv } = require('next-runtime-env/build/configure'); configureRuntimeEnv();"
 cd ../..;
 
-HOSTNAME=0.0.0.0 PORT=3000 node apps/builder/server.js;
+# Keep idle HTTP keep-alive sockets open longer than any upstream client / LB
+# idle pool. Next standalone reads KEEP_ALIVE_TIMEOUT and applies it to
+# server.keepAliveTimeout; left unset, Node defaults to 5000ms, which makes the
+# server the first party to close idle sockets. When a low-frequency caller
+# (e.g. the MCP proxy reaching the /api/mcp endpoint) reuses a socket the server
+# already closed, the client sees "Server disconnected without sending a
+# response". Closing only happens between requests, never on an in-flight one.
+KEEP_ALIVE_TIMEOUT=${KEEP_ALIVE_TIMEOUT:-65000} HOSTNAME=0.0.0.0 PORT=3000 node apps/builder/server.js;

--- a/scripts/viewer-entrypoint.sh
+++ b/scripts/viewer-entrypoint.sh
@@ -4,4 +4,10 @@ cd apps/viewer;
 node  -e "const { configureRuntimeEnv } = require('next-runtime-env/build/configure'); configureRuntimeEnv();"
 cd ../..;
 
-HOSTNAME=0.0.0.0 PORT=3001 node apps/viewer/server.js;
+# Keep idle HTTP keep-alive sockets open longer than any upstream client / LB
+# idle pool. Next standalone reads KEEP_ALIVE_TIMEOUT and applies it to
+# server.keepAliveTimeout; left unset, Node defaults to 5000ms, which makes the
+# server the first party to close idle sockets, triggering "Server disconnected
+# without sending a response" on the caller when it reuses a dead socket.
+# Closing only happens between requests, never on an in-flight one.
+KEEP_ALIVE_TIMEOUT=${KEEP_ALIVE_TIMEOUT:-65000} HOSTNAME=0.0.0.0 PORT=3001 node apps/viewer/server.js;


### PR DESCRIPTION
## Família do incidente (2026-06-08/09)

claudia-agentic chama tools do typebot via MCP e recebe **Cloudflare 520/502**. A cadeia é:

`claudia-agentic` → `Cloudflare (mcp.cloudhumans.com)` → `mcp (FastMCP proxy, httpx)` → `Kong 3.9` → `typebot (Next standalone, host eddie*)`

> A Cloudflare está só na frente do **mcp** (`mcp.cloudhumans.com` → `server: cloudflare`) — por isso a falha de origem vira **520** pro chamador. Os hosts do typebot `eddie.us-east-1.prd...` (builder) / `eddieeyes*` (viewer) são servidos **direto pelo Kong** (`server: kong/3.9.2`, sem Cloudflare) — não são o nome do Kong.

Três causas independentes → três PRs (este + [mcp#29](https://github.com/cloudhumans/mcp/pull/29) + [mcp-manifests#73](https://github.com/cloudhumans/mcp-manifests/pull/73)). **Este PR cobre a perna `Kong → typebot`.**

## Causa (perna Kong → typebot): corrida de reuso de keep-alive idle

O typebot roda Next standalone (`node server.js`) com `server.keepAliveTimeout` no **default do Node = 5s** (env `KEEP_ALIVE_TIMEOUT` não setada). O Kong tem `upstream_keepalive_idle_timeout = 60s` (confirmado no cluster: **Kong 3.9**, sem override — `ingress.class: kong`, hosts `eddie*`).

Como o Node (5s) fecha o socket idle **antes** do Kong (60s), o Kong mantém no pool um socket que o typebot já fechou e, na próxima request, **reusa esse socket morto** → o typebot responde com RST → **502** no handshake (`initialize`/`tools/list`), que o FastMCP traduz como o enganoso `Unknown tool`.

É a mesma família da corrida do `getegorize` 520 (um hop acima, coberta pelo [mcp#29](https://github.com/cloudhumans/mcp/pull/29)).

**Prova:** typebot **saudável** em 7/8 dos 502 observados (sem restart); 502 rápido (~262ms) com backend vivo = reuso de keep-alive, não pod morto (pod morto daria 503/504 ou connection-refused).

## Fix

`KEEP_ALIVE_TIMEOUT=65000` (override) nos entrypoints do builder e do viewer → o servidor segura o idle por 65s, **acima dos 60s do Kong**. Assim **o Kong sempre fecha o idle primeiro** e nunca reusa um socket que o typebot já matou.

`65000` é o valor recomendado pra um proxy com idle de 60s (app keep-alive 5–10s acima). Refs: [Madhur Ahuja — Configuring AWS ALB Timeouts (out/2025)](https://www.madhur.co.in/blog/2025/10/01/configuring-aws-alb-timeout.html), [AWS re:Post](https://repost.aws/questions/QUqP4BHC9iQ0uIB69M7QrjSg/502-errors-with-application-load-balancer-idle-timeout-apache2-keep-alive-timeout). Não há motivo pra mexer no número.

**Invariante respeitada — nunca cortar request em andamento:** `keepAliveTimeout` só age no gap **idle entre** requests; jamais afeta uma chamada em voo. Tools lentas (`categorize`) não são afetadas.

> Nota sobre `headersTimeout`: segue no default do Node. No Node ≥18 ele é **per-request** e não conflita com keepAlive de 65s (a regra antiga `headersTimeout > keepAliveTimeout` valia pro Node <13, onde contava o idle do keepalive). O Next standalone não expõe `headersTimeout` por env — só seria relevante num custom server (follow-up).

## Plano de teste
- `bash -n` nos dois entrypoints OK.
- Sem mudança de código de app; lint/format OK.
- Não aplicado em prod. Recomendado: deploy + monitorar a call horária do `categorize` pela ausência de `RemoteProtocolError` / `Unknown tool`.

## PRs irmãos (mesma família, pernas diferentes)
- [mcp#29](https://github.com/cloudhumans/mcp/pull/29) — `keepalive_expiry=0` na perna `mcp → Kong` (520 do `getegorize`).
- [mcp-manifests#73](https://github.com/cloudhumans/mcp-manifests/pull/73) — probe-kill (Causa 2) + drain no rollout (Causa 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as mcp (httpx proxy)
    participant K as Kong 3.9 (idle 60s)
    participant S as typebot server.js

    Note over C,S: Antes do fix — Node keepAliveTimeout = 5s (padrão)
    C->>K: "POST /api/mcp (request T=0)"
    K->>S: encaminha
    S-->>K: 200 OK
    K-->>C: 200 OK
    Note over S: socket Kong↔Node idle ~5s → servidor fecha
    Note over K: socket ainda aberto no pool do Kong
    C->>K: POST /api/mcp (T+1h)
    K->>S: reutiliza socket morto
    S--xK: RST / disconnect
    K--xC: 502 (perna Kong→Node) / RemoteProtocolError se a perna mcp→Kong também reusa socket morto

    Note over C,S: Depois do fix — Node keepAliveTimeout = 65s

    C->>K: "POST /api/mcp (request T=0)"
    K->>S: encaminha
    S-->>K: 200 OK
    K-->>C: 200 OK
    Note over K: socket idle 60s → Kong fecha primeiro (Node segura até 65s)
    Note over K: pool do Kong descarta o socket no FIN
    C->>K: POST /api/mcp (T+1h, abre nova conexão)
    K->>S: nova conexão
    S-->>K: 200 OK
    K-->>C: 200 OK
```

<sub>Reviews (1): Last reviewed commit: ["fix(server): set KEEP\_ALIVE\_TIMEOUT so t..."](https://github.com/cloudhumans/typebot.io/commit/4ba60084599373d2c48ea3adf6e06afad1c14beb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36334513)</sub>

<!-- /greptile_comment -->
