### PR TITLE
docs: GCP OAuth External migration — plan + validation record

### DIFF
--- a/docs/superpowers/plans/2026-06-09-gcp-oauth-external-migration.md
+++ b/docs/superpowers/plans/2026-06-09-gcp-oauth-external-migration.md
@@ -1,0 +1,183 @@
+# GCP OAuth External Migration (Approach 3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Safely transition the Google OAuth integration to allow external emails (External + In Production) on the GCP Console while verifying that the `DISABLE_SIGNUP` security gate is active and correctly blocking unauthorized users.
+
+**Architecture:** 
+1. Validate the `DISABLE_SIGNUP` code path programmatically using a custom Prisma-connected test script.
+2. Modify the GCP OAuth configuration directly to External + In Production.
+3. Collect required Google assets (unlisted YouTube video, domain ownership, and public policy) and submit for sensitive scopes verification.
+
+**Tech Stack:** NextAuth.js, Prisma, GCP Console, TSX, dotenv-cli
+
+---
+
+### Task 1: Verify the DISABLE_SIGNUP Gate Programmatically
+
+**Files:**
+- Create: `docs/superpowers/scratch/verify-signup-block.ts`
+
+- [ ] **Step 1: Write the verification script**
+  Create the scratch script that initializes Prisma, mocks the `DISABLE_SIGNUP` environment variable, and calls the custom adapter to ensure it rejects unauthorized new sign-ups.
+
+  ```typescript
+  // docs/superpowers/scratch/verify-signup-block.ts
+  import { customAdapter } from '../../../apps/builder/src/features/auth/api/customAdapter'
+  import { PrismaClient } from '@typebot.io/prisma'
+
+  // Force environment variables for the test run
+  process.env.DISABLE_SIGNUP = 'true'
+  process.env.ADMIN_EMAIL = 'admin@example.com'
+
+  const prisma = new PrismaClient()
+  const adapter = customAdapter(prisma)
+
+  async function runVerification() {
+    console.log('--- Starting DISABLE_SIGNUP Verification ---')
+
+    // 1. Generate a random email that does not exist and has no invitations
+    const randomUnauthorizedEmail = `unauthorized-${Date.now()}@external-domain.com`
+
+    try {
+      console.log(`Testing signup block for unauthorized user: ${randomUnauthorizedEmail}`)
+      await adapter.createUser({
+        email: randomUnauthorizedEmail,
+        emailVerified: null,
+      })
+      console.error('❌ FAILURE: User creation succeeded but should have been blocked.')
+      process.exit(1)
+    } catch (err: any) {
+      if (err.message === 'New users are forbidden') {
+        console.log('✅ SUCCESS: Correctly blocked unauthorized new user sign-up.')
+      } else {
+        console.error(`❌ FAILURE: Block failed with unexpected error: ${err.message}`)
+        process.exit(1)
+      }
+    }
+
+    // 2. Create an invitation for a test email and verify signup is permitted
+    const invitedEmail = `invited-${Date.now()}@external-domain.com`
+    console.log(`Setting up invitation for email: ${invitedEmail}`)
+    
+    // Create a temporary workspace and invitation
+    const tempWorkspace = await prisma.workspace.create({
+      data: { name: 'Temp Test Workspace' }
+    })
+    const tempInvitation = await prisma.workspaceInvitation.create({
+      data: {
+        email: invitedEmail,
+        workspaceId: tempWorkspace.id,
+        role: 'member'
+      }
+    })
+
+    try {
+      console.log(`Testing allowed signup for invited user: ${invitedEmail}`)
+      const createdUser = await adapter.createUser({
+        email: invitedEmail,
+        emailVerified: null,
+      })
+      console.log(`✅ SUCCESS: User created successfully with ID: ${createdUser.id}`)
+
+      // Clean up created user, invitation, and workspace
+      await prisma.user.delete({ where: { id: createdUser.id } })
+      console.log('✅ Temporary user cleaned up.')
+    } catch (err: any) {
+      console.error(`❌ FAILURE: Allowed signup failed: ${err.message}`)
+      process.exit(1)
+    } finally {
+      await prisma.workspaceInvitation.delete({ where: { id: tempInvitation.id } })
+      await prisma.workspace.delete({ where: { id: tempWorkspace.id } })
+      console.log('✅ Temporary invitation and workspace cleaned up.')
+    }
+
+    console.log('--- All DISABLE_SIGNUP security checks passed! ---')
+    process.exit(0)
+  }
+
+  runVerification().catch((e) => {
+    console.error('Fatal test execution error:', e)
+    process.exit(1)
+  })
+  ```
+
+- [ ] **Step 2: Run the script to verify the security gate**
+  Run the script using `tsx` from `@typebot.io/prisma` workspace to ensure it runs correctly and outputs success.
+
+  Run:
+  ```bash
+  pnpm --filter @typebot.io/prisma exec tsx docs/superpowers/scratch/verify-signup-block.ts
+  ```
+  Expected output:
+  `--- All DISABLE_SIGNUP security checks passed! ---`
+
+- [ ] **Step 3: Delete the scratch script**
+  Remove the scratch script so we don't commit temporary testing code into the main repository.
+
+  Run:
+  ```bash
+  rm docs/superpowers/scratch/verify-signup-block.ts
+  ```
+
+- [ ] **Step 4: Commit**
+  Commit the progress stating the verification was completed successfully.
+
+  Run:
+  ```bash
+  git commit --allow-empty -m "test: verified DISABLE_SIGNUP logic with local DB script"
+  ```
+
+---
+
+### Task 2: GCP OAuth Consent Screen Transition (Console Steps)
+
+**Files:**
+- Modify: `.env` (verify configuration)
+
+- [ ] **Step 1: Check production environment variables**
+  Verify that the production environment configs (manifests or env variables) have `DISABLE_SIGNUP=true` explicitly set.
+
+- [ ] **Step 2: Transition GCP User Type to External**
+  1. Open the [Google Cloud Console](https://console.cloud.google.com/).
+  2. Navigate to **APIs & Services** > **OAuth Consent Screen**.
+  3. Click **Edit App**.
+  4. Change the User Type to **External**.
+  5. Fill in the App Name, User Support Email, and Developer Contact Information.
+  6. Save and Continue.
+
+- [ ] **Step 3: Push OAuth Consent Screen to In Production**
+  1. Under the OAuth Consent Screen dashboard, locate the **Publishing status**.
+  2. Click **Publish App**.
+  3. Accept the warning stating that the app will be available to any Google user (it will show the "Unverified App" screen until verified).
+
+---
+
+### Task 3: Setup Verification Assets
+
+- [ ] **Step 1: Verify Domain Ownership**
+  Ensure the domain used for authorization (e.g. `cloudhumans.com` or `cloudhumans.io`) is verified in the Google Search Console of the GCP account owner.
+
+- [ ] **Step 2: Host Privacy Policy and Public Homepage**
+  Verify that the public homepage and privacy policy are accessible on the verified domain:
+  - Homepage: Describing the integration/app purpose.
+  - Privacy Policy: Compliant with Google API Services User Data Policy, explaining how the `spreadsheets` and `drive.file` scope data is stored/processed.
+
+- [ ] **Step 3: Record Demo Video**
+  Record an unlisted YouTube video showing the authorization flow. The video must show:
+  1. The user initiating the OAuth flow from Typebot.
+  2. The Google OAuth Consent Screen showing the **Client ID** clearly in the browser URL bar.
+  3. The user completing authorization.
+  4. A demonstration of reading/writing to a Google Sheet block within a chatbot flow.
+
+---
+
+### Task 4: Submit Verification Request on GCP Console
+
+- [ ] **Step 1: Justification for Scopes**
+  In the GCP Consent Screen edit workflow, add justifications for:
+  - `https://www.googleapis.com/auth/spreadsheets`: "Users need to connect existing spreadsheets that were not created by the app to read and write row data in their custom chatbot workflows."
+  - `https://www.googleapis.com/auth/drive.file`: "Required to create new sheets or access files chosen specifically by the user."
+
+- [ ] **Step 2: Submit to Verification Center**
+  Provide the links to the demo video, privacy policy, and homepage, and submit for verification.

--- a/docs/superpowers/plans/2026-06-09-gcp-oauth-external-migration.md
+++ b/docs/superpowers/plans/2026-06-09-gcp-oauth-external-migration.md
@@ -33,12 +33,13 @@ Branch: `feat/gcp-oauth-external-migration`.
 
 These were established while validating locally and drive the task details below:
 
-- **The `DISABLE_SIGNUP` PR is env-only — no code change.** The gate is already implemented in two reinforcing places:
-  - `apps/builder/src/features/auth/api/customAdapter.ts:30` (adapter `createUser`)
-  - `apps/builder/src/pages/api/auth/[...nextauth].ts:326` (`signIn` callback → throws `sign-up-disabled`)
+- **The `DISABLE_SIGNUP` PR is env-only — no code change.** The gate exists in two spots, but **only the `signIn` callback is effective with our config** (`ADMIN_EMAIL` unset):
+  - `apps/builder/src/pages/api/auth/[...nextauth].ts:326` (`signIn` callback → throws `sign-up-disabled`). Uses `!env.ADMIN_EMAIL?.includes(email)`, which is `true` when `ADMIN_EMAIL` is unset → **gate fires**. ✅
+  - `apps/builder/src/features/auth/api/customAdapter.ts:30` (adapter `createUser`). Uses `env.ADMIN_EMAIL?.every(...)`, which short-circuits to `undefined` (falsy) when `ADMIN_EMAIL` is unset → **adapter check is a no-op**. ⚠️ So it is NOT a second line of defense in our config. It's also moot for interactive logins: the `signIn` callback throws first, before `createUser` is reached.
+  - Safe because no app code calls `adapter.createUser` outside the NextAuth `signIn`-gated flow (verified by grep); the only non-`signIn` user creation is embedded (`createCloudChatEmbeddedUser`), an intentional bypass. Latent upstream quirk worth noting: the adapter gate silently disables itself whenever `ADMIN_EMAIL` is empty.
   - Default is `false` (`packages/env/env.ts:71`). Migration only requires setting `DISABLE_SIGNUP=true` in the **production** environment.
   - ✅ **Confirmed:** neither `DISABLE_SIGNUP` nor `ADMIN_EMAIL` was set in the manifests (`cloudhumans/typebot.io-manifests`) → prod signup was OPEN by default. PR #80 adds `DISABLE_SIGNUP: 'true'` to the **base** builder ConfigMap (`deploy-k8s/base/typebot-builder-configmap.yaml`), inherited by both instances (`eddie` + `eddie2`).
-- **`ADMIN_EMAIL` is optional, not required.** It's an allowlist of emails that bypass the gate (self-provision without an invitation) — for bootstrap/admin accounts only. Left **unset** (most restrictive: everyone needs an invitation). The gate also applies to the **Cloud Hub Login** (`CUSTOM_OAUTH`/Cognito) direct builder login, not just Google — so new internal staff without an invitation are gated too (existing users and CloudChat embedded SSO are unaffected).
+- **`ADMIN_EMAIL` is optional, not required.** It's an allowlist of emails that bypass the gate (self-provision without an invitation) — for bootstrap/admin accounts only. Left **unset**, which makes the `signIn` callback the most restrictive (everyone needs an invitation); note the adapter check does NOT enforce in this state (see above). The gate also applies to the **Cloud Hub Login** (`CUSTOM_OAUTH`/Cognito) direct builder login, not just Google — so new internal staff without an invitation are gated too (existing users and CloudChat embedded SSO are unaffected).
 - **Embedded CloudChat users are NOT affected by `DISABLE_SIGNUP`.** They authenticate via the `cloudchat-embedded` CredentialsProvider → `cloudchatEmbeddedAuthorize` (verifies the Cognito JWT) → JIT `createCloudChatEmbeddedUser` (direct `p.user.create`, bypasses the adapter gate). It always forwards `createdAt`, so the `signIn` callback's `isNewUser` is `false` and that gate is skipped too. Trust boundary = verified Cognito JWT (`cloudChatAuthorization: true`). So `DISABLE_SIGNUP=true` only locks the **public Google OAuth signup** that External mode newly exposes; embedded SSO logins keep working.
 - **Availability — 7-day token expiry in Testing.** While the app's publishing status is **Testing**, refresh tokens for sensitive scopes expire in ~7 days (connections break weekly). This goes away only after **Production + verified**. This is a core reason the migration is needed.
 - **Going External + Publish does NOT disconnect existing users/tokens.** New authorizations see the "unverified app" warning screen until verification passes.
@@ -100,14 +101,14 @@ These were established while validating locally and drive the task details below
   Run with: `corepack pnpm@8.15.4 --filter @typebot.io/prisma exec tsx docs/superpowers/scratch/verify-signup-block.ts`
 
 - [x] **Step 5: Real Google-login E2E validation** (2026-06-10)
-  With `DISABLE_SIGNUP=true` in local `.env` and the builder restarted, signed in via Google with a fresh external account (`xandylm@gmail.com` — not admin, no invitation). Result: redirected to `/signin?error=sign-up-disabled`, and **0 `User` + 0 `Account` rows** were created (clean block; the `signIn` callback throws before the adapter creates anything).
+  With `DISABLE_SIGNUP=true` in local `.env` and the builder restarted, signed in via Google with a fresh external account (`xan***@gmail.com` — @alexandre-machado's personal Google account; not admin, no invitation). Result: redirected to `/signin?error=sign-up-disabled`, and **0 `User` + 0 `Account` rows** were created (clean block; the `signIn` callback throws before the adapter creates anything).
   > **Gotcha:** the gate only blocks **new** users (`isNewUser`). An account that already exists in the DB is not blocked. To re-test the block, use an account that has never signed in, or delete its `User` row first.
 
 ---
 
 ### Task 2: GCP OAuth Consent Screen Transition (Console Steps)
 
-- [x] **Step 1: Set production environment variable (the "DISABLE_SIGNUP PR")** — 🔄 PR open
+- [ ] **Step 1: Set production environment variable (the "DISABLE_SIGNUP PR")** — 🔄 PR open, not yet merged/deployed
   Env/config change, **not code** (see Key findings). PR [typebot.io-manifests#80](https://github.com/cloudhumans/typebot.io-manifests/pull/80) adds `DISABLE_SIGNUP: 'true'` to `deploy-k8s/base/typebot-builder-configmap.yaml`, inherited by both instances (`eddie` + `eddie2`). `ADMIN_EMAIL` intentionally left unset (most restrictive; all need invite).
   - [ ] Merge PR #80.
   - [ ] Confirm deploy: ArgoCD sync + builder pod restart (env is read at boot, not hot-reloaded).
@@ -153,9 +154,9 @@ These were established while validating locally and drive the task details below
 ### Task 4: Submit Verification Request on GCP Console
 
 - [ ] **Step 1: Justification for Scopes**
-  In the GCP Consent Screen "Data access" workflow, add justifications:
-  - `https://www.googleapis.com/auth/spreadsheets`: "Users need to connect existing spreadsheets that were not created by the app to read and write row data in their custom chatbot workflows."
-  - `https://www.googleapis.com/auth/drive.file`: "Required to create new sheets or access files chosen specifically by the user."
+  In the GCP Consent Screen "Data access" workflow, add justifications. Note: only `spreadsheets` is **sensitive** and drives verification; `drive.file` is non-sensitive. Justifications match the actual UX — selection is done via the **Google Drive Picker** (`GoogleSpreadsheetPicker.tsx`, loads `gapi`/`picker`), so the app only touches files the user explicitly picks.
+  - `https://www.googleapis.com/auth/spreadsheets` *(sensitive)*: "The Google Sheets block reads and writes cell/row data in the spreadsheet the user connects. The Sheets API has no per-file scope, so this broad scope is required to operate on the user-selected sheet."
+  - `https://www.googleapis.com/auth/drive.file` *(non-sensitive)*: "Used with the Google Drive Picker so the user explicitly selects which spreadsheet to connect, and to create new spreadsheets on the user's behalf. Grants per-file access only — never the user's full Drive."
 
 - [ ] **Step 2: Submit to Verification Center**
   Provide links to the demo video, privacy policy, and homepage, and submit for verification. After approval, the unverified-app warning disappears and sensitive-scope refresh tokens stop expiring at 7 days.

--- a/docs/superpowers/plans/2026-06-09-gcp-oauth-external-migration.md
+++ b/docs/superpowers/plans/2026-06-09-gcp-oauth-external-migration.md
@@ -18,11 +18,14 @@
 | Task | Status |
 |------|--------|
 | 1. Validate `DISABLE_SIGNUP` gate | ✅ Done — script + real Google-login E2E |
-| 2. GCP → External + In Production | ⏳ Pending (manual console) — **set prod env first** |
-| 3. Verification assets (domain, policy, video) | ⏳ Pending — Sheets read/write already validated locally |
-| 4. Submit verification request | ⏳ Pending |
+| 2. Set `DISABLE_SIGNUP=true` in prod env | 🔄 PR open — [typebot.io-manifests#80](https://github.com/cloudhumans/typebot.io-manifests/pull/80) (must merge + deploy before External) |
+| 3. Prep assets in parallel (Block A — can start now) | ⏳ Pending — domain verify · public homepage + privacy policy · consent-screen branding |
+| 4. GCP → External + In Production | ⏳ Pending (manual console) — after PR #80 lands |
+| 5. Demo video + submit verification | ⏳ Pending — Sheets read/write already validated locally |
 
 Branch: `feat/gcp-oauth-external-migration`.
+
+**Sequencing:** Block A (Task 3 — domain, homepage/privacy, branding) is independent of publishing status and can be done **now, in parallel**, with zero impact on the running Internal app. It's the slow part (Google review), so start early. Flipping to External (Task 4) is gated only on PR #80 being deployed.
 
 ---
 
@@ -33,15 +36,14 @@ These were established while validating locally and drive the task details below
 - **The `DISABLE_SIGNUP` PR is env-only — no code change.** The gate is already implemented in two reinforcing places:
   - `apps/builder/src/features/auth/api/customAdapter.ts:30` (adapter `createUser`)
   - `apps/builder/src/pages/api/auth/[...nextauth].ts:326` (`signIn` callback → throws `sign-up-disabled`)
-  - Default is `false` (`packages/env/env.ts:71`). Migration only requires setting `DISABLE_SIGNUP=true` (and a correct `ADMIN_EMAIL` allowlist) in the **production** environment.
-  - ⚠️ **Risk:** if the prod manifest omits `DISABLE_SIGNUP`, the default `false` means signup is OPEN the moment the app goes External.
+  - Default is `false` (`packages/env/env.ts:71`). Migration only requires setting `DISABLE_SIGNUP=true` in the **production** environment.
+  - ✅ **Confirmed:** neither `DISABLE_SIGNUP` nor `ADMIN_EMAIL` was set in the manifests (`cloudhumans/typebot.io-manifests`) → prod signup was OPEN by default. PR #80 adds `DISABLE_SIGNUP: 'true'` to the **base** builder ConfigMap (`deploy-k8s/base/typebot-builder-configmap.yaml`), inherited by both instances (`eddie` + `eddie2`).
+- **`ADMIN_EMAIL` is optional, not required.** It's an allowlist of emails that bypass the gate (self-provision without an invitation) — for bootstrap/admin accounts only. Left **unset** (most restrictive: everyone needs an invitation). The gate also applies to the **Cloud Hub Login** (`CUSTOM_OAUTH`/Cognito) direct builder login, not just Google — so new internal staff without an invitation are gated too (existing users and CloudChat embedded SSO are unaffected).
 - **Embedded CloudChat users are NOT affected by `DISABLE_SIGNUP`.** They authenticate via the `cloudchat-embedded` CredentialsProvider → `cloudchatEmbeddedAuthorize` (verifies the Cognito JWT) → JIT `createCloudChatEmbeddedUser` (direct `p.user.create`, bypasses the adapter gate). It always forwards `createdAt`, so the `signIn` callback's `isNewUser` is `false` and that gate is skipped too. Trust boundary = verified Cognito JWT (`cloudChatAuthorization: true`). So `DISABLE_SIGNUP=true` only locks the **public Google OAuth signup** that External mode newly exposes; embedded SSO logins keep working.
 - **Availability — 7-day token expiry in Testing.** While the app's publishing status is **Testing**, refresh tokens for sensitive scopes expire in ~7 days (connections break weekly). This goes away only after **Production + verified**. This is a core reason the migration is needed.
 - **Going External + Publish does NOT disconnect existing users/tokens.** New authorizations see the "unverified app" warning screen until verification passes.
 - **Scopes come from code, not the console.** `apps/builder/src/pages/api/credentials/google-sheets/consent-url.ts` requests `userinfo.email` + `spreadsheets` + `drive.file` (`access_type=offline`, `prompt=consent`). In **Testing** mode Google does not enforce scope pre-declaration/verification, so test users can grant them directly once the Sheets/Drive **APIs are enabled**. The console "Data access" scope list + justifications only become mandatory for the Production verification submission (Task 4).
-- **Two distinct redirect URIs** must be registered on the OAuth client:
-  - Login: `${NEXTAUTH_URL}/api/auth/callback/google`
-  - Sheets credential: `${NEXTAUTH_URL}/api/credentials/google-sheets/callback`
+- **Redirect URIs are already registered (no-op).** They are a property of the OAuth client, independent of publishing status. Since the app runs 100% in Internal today, the prod redirect URIs (login `${NEXTAUTH_URL}/api/auth/callback/google` and Sheets `${NEXTAUTH_URL}/api/credentials/google-sheets/callback`) are already in place. Going External does not change them — nothing to register.
 
 ---
 
@@ -105,17 +107,14 @@ These were established while validating locally and drive the task details below
 
 ### Task 2: GCP OAuth Consent Screen Transition (Console Steps)
 
-- [ ] **Step 1: Set production environment variables (the "DISABLE_SIGNUP PR")**
-  This is an **env/config change, not code** (see Key findings). In the production deployment of the typebot **builder** (manifest lives in the infra repo, not in composezao):
-  - Set `DISABLE_SIGNUP=true`
-  - Confirm `ADMIN_EMAIL` lists the emails that should bypass the gate
-  - Deploy/restart so the builder reloads env at boot (env is read at startup, not hot-reloaded)
-  - ⚠️ Do this **before** publishing the app as External, so external signup is locked the instant the consent screen opens up.
+- [x] **Step 1: Set production environment variable (the "DISABLE_SIGNUP PR")** — 🔄 PR open
+  Env/config change, **not code** (see Key findings). PR [typebot.io-manifests#80](https://github.com/cloudhumans/typebot.io-manifests/pull/80) adds `DISABLE_SIGNUP: 'true'` to `deploy-k8s/base/typebot-builder-configmap.yaml`, inherited by both instances (`eddie` + `eddie2`). `ADMIN_EMAIL` intentionally left unset (most restrictive; all need invite).
+  - [ ] Merge PR #80.
+  - [ ] Confirm deploy: ArgoCD sync + builder pod restart (env is read at boot, not hot-reloaded).
+  - ⚠️ Must be deployed **before** publishing the app as External, so external signup is locked the instant the consent screen opens up.
 
-- [ ] **Step 2: Register/confirm OAuth redirect URIs**
-  On the OAuth client, ensure both redirect URIs are present for the production host:
-  - `${NEXTAUTH_URL}/api/auth/callback/google`
-  - `${NEXTAUTH_URL}/api/credentials/google-sheets/callback`
+- [x] **Step 2: OAuth redirect URIs — no action needed**
+  Redirect URIs belong to the OAuth client and are independent of publishing status. The app runs in Internal today, so the prod URIs (`${NEXTAUTH_URL}/api/auth/callback/google` and `${NEXTAUTH_URL}/api/credentials/google-sheets/callback`) are already registered. Going External does not change them.
 
 - [ ] **Step 3: Transition GCP User Type to External**
   1. Open the [Google Cloud Console](https://console.cloud.google.com/).

--- a/docs/superpowers/plans/2026-06-09-gcp-oauth-external-migration.md
+++ b/docs/superpowers/plans/2026-06-09-gcp-oauth-external-migration.md
@@ -4,29 +4,62 @@
 
 **Goal:** Safely transition the Google OAuth integration to allow external emails (External + In Production) on the GCP Console while verifying that the `DISABLE_SIGNUP` security gate is active and correctly blocking unauthorized users.
 
-**Architecture:** 
-1. Validate the `DISABLE_SIGNUP` code path programmatically using a custom Prisma-connected test script.
-2. Modify the GCP OAuth configuration directly to External + In Production.
-3. Collect required Google assets (unlisted YouTube video, domain ownership, and public policy) and submit for sensitive scopes verification.
+**Architecture:**
+1. Validate the `DISABLE_SIGNUP` code path (programmatically + real Google-login E2E).
+2. Modify the GCP OAuth configuration to External + In Production.
+3. Collect required Google assets (unlisted YouTube video, domain ownership, public policy) and submit for sensitive-scope verification.
 
-**Tech Stack:** NextAuth.js, Prisma, GCP Console, TSX, dotenv-cli
+**Tech Stack:** NextAuth.js, Prisma, GCP Console, TSX
 
 ---
 
-### Task 1: Verify the DISABLE_SIGNUP Gate Programmatically
+## Status (updated 2026-06-10)
 
-**Files:**
-- Create: `docs/superpowers/scratch/verify-signup-block.ts`
+| Task | Status |
+|------|--------|
+| 1. Validate `DISABLE_SIGNUP` gate | ✅ Done — script + real Google-login E2E |
+| 2. GCP → External + In Production | ⏳ Pending (manual console) — **set prod env first** |
+| 3. Verification assets (domain, policy, video) | ⏳ Pending — Sheets read/write already validated locally |
+| 4. Submit verification request | ⏳ Pending |
 
-- [ ] **Step 1: Write the verification script**
-  Create the scratch script that initializes Prisma, mocks the `DISABLE_SIGNUP` environment variable, and calls the custom adapter to ensure it rejects unauthorized new sign-ups.
+Branch: `feat/gcp-oauth-external-migration`.
 
+---
+
+## Key findings (security & availability)
+
+These were established while validating locally and drive the task details below:
+
+- **The `DISABLE_SIGNUP` PR is env-only — no code change.** The gate is already implemented in two reinforcing places:
+  - `apps/builder/src/features/auth/api/customAdapter.ts:30` (adapter `createUser`)
+  - `apps/builder/src/pages/api/auth/[...nextauth].ts:326` (`signIn` callback → throws `sign-up-disabled`)
+  - Default is `false` (`packages/env/env.ts:71`). Migration only requires setting `DISABLE_SIGNUP=true` (and a correct `ADMIN_EMAIL` allowlist) in the **production** environment.
+  - ⚠️ **Risk:** if the prod manifest omits `DISABLE_SIGNUP`, the default `false` means signup is OPEN the moment the app goes External.
+- **Embedded CloudChat users are NOT affected by `DISABLE_SIGNUP`.** They authenticate via the `cloudchat-embedded` CredentialsProvider → `cloudchatEmbeddedAuthorize` (verifies the Cognito JWT) → JIT `createCloudChatEmbeddedUser` (direct `p.user.create`, bypasses the adapter gate). It always forwards `createdAt`, so the `signIn` callback's `isNewUser` is `false` and that gate is skipped too. Trust boundary = verified Cognito JWT (`cloudChatAuthorization: true`). So `DISABLE_SIGNUP=true` only locks the **public Google OAuth signup** that External mode newly exposes; embedded SSO logins keep working.
+- **Availability — 7-day token expiry in Testing.** While the app's publishing status is **Testing**, refresh tokens for sensitive scopes expire in ~7 days (connections break weekly). This goes away only after **Production + verified**. This is a core reason the migration is needed.
+- **Going External + Publish does NOT disconnect existing users/tokens.** New authorizations see the "unverified app" warning screen until verification passes.
+- **Scopes come from code, not the console.** `apps/builder/src/pages/api/credentials/google-sheets/consent-url.ts` requests `userinfo.email` + `spreadsheets` + `drive.file` (`access_type=offline`, `prompt=consent`). In **Testing** mode Google does not enforce scope pre-declaration/verification, so test users can grant them directly once the Sheets/Drive **APIs are enabled**. The console "Data access" scope list + justifications only become mandatory for the Production verification submission (Task 4).
+- **Two distinct redirect URIs** must be registered on the OAuth client:
+  - Login: `${NEXTAUTH_URL}/api/auth/callback/google`
+  - Sheets credential: `${NEXTAUTH_URL}/api/credentials/google-sheets/callback`
+
+---
+
+### Task 1: Validate the `DISABLE_SIGNUP` Gate ✅ DONE
+
+**Outcome:** Gate confirmed to block uninvited external users and allow invited/admin ones, both at the adapter level and through the real Google-login flow. Committed on branch (`test: verified DISABLE_SIGNUP logic with local DB script`).
+
+- [x] **Step 1–4: Programmatic verification (adapter level)**
+  A throwaway Prisma script (`docs/superpowers/scratch/verify-signup-block.ts`, since deleted) called `customAdapter.createUser` with `DISABLE_SIGNUP=true`:
+  - Unauthorized new email → threw `New users are forbidden` ✅
+  - Invited email (via a temp `workspaceInvitation`) → created successfully, then cleaned up ✅
+
+  Reference script (for re-running if needed):
   ```typescript
   // docs/superpowers/scratch/verify-signup-block.ts
   import { customAdapter } from '../../../apps/builder/src/features/auth/api/customAdapter'
   import { PrismaClient } from '@typebot.io/prisma'
 
-  // Force environment variables for the test run
   process.env.DISABLE_SIGNUP = 'true'
   process.env.ADMIN_EMAIL = 'admin@example.com'
 
@@ -34,150 +67,96 @@
   const adapter = customAdapter(prisma)
 
   async function runVerification() {
-    console.log('--- Starting DISABLE_SIGNUP Verification ---')
-
-    // 1. Generate a random email that does not exist and has no invitations
     const randomUnauthorizedEmail = `unauthorized-${Date.now()}@external-domain.com`
-
     try {
-      console.log(`Testing signup block for unauthorized user: ${randomUnauthorizedEmail}`)
-      await adapter.createUser({
-        email: randomUnauthorizedEmail,
-        emailVerified: null,
-      })
+      await adapter.createUser({ email: randomUnauthorizedEmail, emailVerified: null })
       console.error('❌ FAILURE: User creation succeeded but should have been blocked.')
       process.exit(1)
     } catch (err: any) {
-      if (err.message === 'New users are forbidden') {
-        console.log('✅ SUCCESS: Correctly blocked unauthorized new user sign-up.')
-      } else {
-        console.error(`❌ FAILURE: Block failed with unexpected error: ${err.message}`)
-        process.exit(1)
-      }
+      if (err.message !== 'New users are forbidden') { console.error(`❌ unexpected: ${err.message}`); process.exit(1) }
+      console.log('✅ Correctly blocked unauthorized new user sign-up.')
     }
 
-    // 2. Create an invitation for a test email and verify signup is permitted
     const invitedEmail = `invited-${Date.now()}@external-domain.com`
-    console.log(`Setting up invitation for email: ${invitedEmail}`)
-    
-    // Create a temporary workspace and invitation
-    const tempWorkspace = await prisma.workspace.create({
-      data: { name: 'Temp Test Workspace' }
-    })
+    const tempWorkspace = await prisma.workspace.create({ data: { name: 'Temp Test Workspace' } })
     const tempInvitation = await prisma.workspaceInvitation.create({
-      data: {
-        email: invitedEmail,
-        workspaceId: tempWorkspace.id,
-        role: 'member'
-      }
+      data: { email: invitedEmail, workspaceId: tempWorkspace.id, role: 'member' },
     })
-
     try {
-      console.log(`Testing allowed signup for invited user: ${invitedEmail}`)
-      const createdUser = await adapter.createUser({
-        email: invitedEmail,
-        emailVerified: null,
-      })
-      console.log(`✅ SUCCESS: User created successfully with ID: ${createdUser.id}`)
-
-      // Clean up created user, invitation, and workspace
+      const createdUser = await adapter.createUser({ email: invitedEmail, emailVerified: null })
+      console.log(`✅ Created invited user ${createdUser.id}`)
       await prisma.user.delete({ where: { id: createdUser.id } })
-      console.log('✅ Temporary user cleaned up.')
-    } catch (err: any) {
-      console.error(`❌ FAILURE: Allowed signup failed: ${err.message}`)
-      process.exit(1)
     } finally {
       await prisma.workspaceInvitation.delete({ where: { id: tempInvitation.id } })
       await prisma.workspace.delete({ where: { id: tempWorkspace.id } })
-      console.log('✅ Temporary invitation and workspace cleaned up.')
     }
-
     console.log('--- All DISABLE_SIGNUP security checks passed! ---')
     process.exit(0)
   }
-
-  runVerification().catch((e) => {
-    console.error('Fatal test execution error:', e)
-    process.exit(1)
-  })
+  runVerification().catch((e) => { console.error(e); process.exit(1) })
   ```
+  Run with: `corepack pnpm@8.15.4 --filter @typebot.io/prisma exec tsx docs/superpowers/scratch/verify-signup-block.ts`
 
-- [ ] **Step 2: Run the script to verify the security gate**
-  Run the script using `tsx` from `@typebot.io/prisma` workspace to ensure it runs correctly and outputs success.
-
-  Run:
-  ```bash
-  pnpm --filter @typebot.io/prisma exec tsx docs/superpowers/scratch/verify-signup-block.ts
-  ```
-  Expected output:
-  `--- All DISABLE_SIGNUP security checks passed! ---`
-
-- [ ] **Step 3: Delete the scratch script**
-  Remove the scratch script so we don't commit temporary testing code into the main repository.
-
-  Run:
-  ```bash
-  rm docs/superpowers/scratch/verify-signup-block.ts
-  ```
-
-- [ ] **Step 4: Commit**
-  Commit the progress stating the verification was completed successfully.
-
-  Run:
-  ```bash
-  git commit --allow-empty -m "test: verified DISABLE_SIGNUP logic with local DB script"
-  ```
+- [x] **Step 5: Real Google-login E2E validation** (2026-06-10)
+  With `DISABLE_SIGNUP=true` in local `.env` and the builder restarted, signed in via Google with a fresh external account (`xandylm@gmail.com` — not admin, no invitation). Result: redirected to `/signin?error=sign-up-disabled`, and **0 `User` + 0 `Account` rows** were created (clean block; the `signIn` callback throws before the adapter creates anything).
+  > **Gotcha:** the gate only blocks **new** users (`isNewUser`). An account that already exists in the DB is not blocked. To re-test the block, use an account that has never signed in, or delete its `User` row first.
 
 ---
 
 ### Task 2: GCP OAuth Consent Screen Transition (Console Steps)
 
-**Files:**
-- Modify: `.env` (verify configuration)
+- [ ] **Step 1: Set production environment variables (the "DISABLE_SIGNUP PR")**
+  This is an **env/config change, not code** (see Key findings). In the production deployment of the typebot **builder** (manifest lives in the infra repo, not in composezao):
+  - Set `DISABLE_SIGNUP=true`
+  - Confirm `ADMIN_EMAIL` lists the emails that should bypass the gate
+  - Deploy/restart so the builder reloads env at boot (env is read at startup, not hot-reloaded)
+  - ⚠️ Do this **before** publishing the app as External, so external signup is locked the instant the consent screen opens up.
 
-- [ ] **Step 1: Check production environment variables**
-  Verify that the production environment configs (manifests or env variables) have `DISABLE_SIGNUP=true` explicitly set.
+- [ ] **Step 2: Register/confirm OAuth redirect URIs**
+  On the OAuth client, ensure both redirect URIs are present for the production host:
+  - `${NEXTAUTH_URL}/api/auth/callback/google`
+  - `${NEXTAUTH_URL}/api/credentials/google-sheets/callback`
 
-- [ ] **Step 2: Transition GCP User Type to External**
+- [ ] **Step 3: Transition GCP User Type to External**
   1. Open the [Google Cloud Console](https://console.cloud.google.com/).
-  2. Navigate to **APIs & Services** > **OAuth Consent Screen**.
-  3. Click **Edit App**.
-  4. Change the User Type to **External**.
-  5. Fill in the App Name, User Support Email, and Developer Contact Information.
-  6. Save and Continue.
+  2. **APIs & Services** > **OAuth Consent Screen** > **Edit App**.
+  3. Set User Type to **External**.
+  4. Fill in App Name, User Support Email, Developer Contact Information.
+  5. Save and Continue.
 
-- [ ] **Step 3: Push OAuth Consent Screen to In Production**
-  1. Under the OAuth Consent Screen dashboard, locate the **Publishing status**.
+- [ ] **Step 4: Push OAuth Consent Screen to In Production**
+  1. Under the OAuth Consent Screen dashboard, locate **Publishing status**.
   2. Click **Publish App**.
-  3. Accept the warning stating that the app will be available to any Google user (it will show the "Unverified App" screen until verified).
+  3. Accept the warning that the app becomes available to any Google user (shows "Unverified App" until verified). Existing users/tokens are not disconnected.
 
 ---
 
 ### Task 3: Setup Verification Assets
 
 - [ ] **Step 1: Verify Domain Ownership**
-  Ensure the domain used for authorization (e.g. `cloudhumans.com` or `cloudhumans.io`) is verified in the Google Search Console of the GCP account owner.
+  Ensure the domain used for authorization (e.g. `cloudhumans.com` or `cloudhumans.io`) is verified in the Google Search Console of the GCP account owner. Note: the builder runs on `eddie.us-east-1.prd.cloudhumans.io` (`.io`) while the brand domain is likely `cloudhumans.com` — both (or a standardized homepage + privacy + redirect on one domain) must be verified. This is usually the highest-friction step.
 
 - [ ] **Step 2: Host Privacy Policy and Public Homepage**
-  Verify that the public homepage and privacy policy are accessible on the verified domain:
-  - Homepage: Describing the integration/app purpose.
-  - Privacy Policy: Compliant with Google API Services User Data Policy, explaining how the `spreadsheets` and `drive.file` scope data is stored/processed.
+  On the verified domain, publicly accessible (no login):
+  - Homepage: describes the integration/app purpose.
+  - Privacy Policy: compliant with the Google API Services User Data Policy (incl. Limited Use), explaining how `spreadsheets` and `drive.file` scope data is accessed/stored/processed.
 
 - [ ] **Step 3: Record Demo Video**
-  Record an unlisted YouTube video showing the authorization flow. The video must show:
+  Unlisted YouTube video showing the authorization flow. Must show:
   1. The user initiating the OAuth flow from Typebot.
-  2. The Google OAuth Consent Screen showing the **Client ID** clearly in the browser URL bar.
+  2. The Google OAuth Consent Screen with the **Client ID** clearly visible in the browser URL bar.
   3. The user completing authorization.
-  4. A demonstration of reading/writing to a Google Sheet block within a chatbot flow.
+  4. Reading/writing to a Google Sheet block within a chatbot flow.
+  > **Already validated locally (2026-06-10):** the consent flow requests `spreadsheets` + `drive.file` and read/write to a real sheet works — this is the dry run for the video.
 
 ---
 
 ### Task 4: Submit Verification Request on GCP Console
 
 - [ ] **Step 1: Justification for Scopes**
-  In the GCP Consent Screen edit workflow, add justifications for:
+  In the GCP Consent Screen "Data access" workflow, add justifications:
   - `https://www.googleapis.com/auth/spreadsheets`: "Users need to connect existing spreadsheets that were not created by the app to read and write row data in their custom chatbot workflows."
   - `https://www.googleapis.com/auth/drive.file`: "Required to create new sheets or access files chosen specifically by the user."
 
 - [ ] **Step 2: Submit to Verification Center**
-  Provide the links to the demo video, privacy policy, and homepage, and submit for verification.
+  Provide links to the demo video, privacy policy, and homepage, and submit for verification. After approval, the unverified-app warning disappears and sensitive-scope refresh tokens stop expiring at 7 days.

--- a/docs/superpowers/plans/2026-06-09-gcp-oauth-external-migration.md
+++ b/docs/superpowers/plans/2026-06-09-gcp-oauth-external-migration.md
@@ -18,7 +18,7 @@
 | Task | Status |
 |------|--------|
 | 1. Validate `DISABLE_SIGNUP` gate | ✅ Done — script + real Google-login E2E |
-| 2. Set `DISABLE_SIGNUP=true` in prod env | 🔄 PR open — [typebot.io-manifests#80](https://github.com/cloudhumans/typebot.io-manifests/pull/80) (must merge + deploy before External) |
+| 2. Set `DISABLE_SIGNUP=true` in prod env | ✅ Merged — [typebot.io-manifests#80](https://github.com/cloudhumans/typebot.io-manifests/pull/80) · confirm ArgoCD deploy before External |
 | 3. Prep assets in parallel (Block A — can start now) | ⏳ Pending — domain verify · public homepage + privacy policy · consent-screen branding |
 | 4. GCP → External + In Production | ⏳ Pending (manual console) — after PR #80 lands |
 | 5. Demo video + submit verification | ⏳ Pending — Sheets read/write already validated locally |
@@ -108,10 +108,10 @@ These were established while validating locally and drive the task details below
 
 ### Task 2: GCP OAuth Consent Screen Transition (Console Steps)
 
-- [ ] **Step 1: Set production environment variable (the "DISABLE_SIGNUP PR")** — 🔄 PR open, not yet merged/deployed
+- [ ] **Step 1: Set production environment variable (the "DISABLE_SIGNUP PR")** — 🔄 merged, deploy pending
   Env/config change, **not code** (see Key findings). PR [typebot.io-manifests#80](https://github.com/cloudhumans/typebot.io-manifests/pull/80) adds `DISABLE_SIGNUP: 'true'` to `deploy-k8s/base/typebot-builder-configmap.yaml`, inherited by both instances (`eddie` + `eddie2`). `ADMIN_EMAIL` intentionally left unset (most restrictive; all need invite).
-  - [ ] Merge PR #80.
-  - [ ] Confirm deploy: ArgoCD sync + builder pod restart (env is read at boot, not hot-reloaded).
+  - [x] Merge PR #80. ✅ (2026-06-11)
+  - [ ] Confirm deploy: ArgoCD sync + builder pod restart (env is read at boot, not hot-reloaded), then verify `DISABLE_SIGNUP=true` is live in the running pod.
   - ⚠️ Must be deployed **before** publishing the app as External, so external signup is locked the instant the consent screen opens up.
 
 - [x] **Step 2: OAuth redirect URIs — no action needed**


### PR DESCRIPTION
## O que é

### request do fabris
https://www.loom.com/share/e19a9da649804caa9b8bbea6844d13f5

Branch de **planejamento/registro** da migração do app Google OAuth do Typebot para **External + In Production** (liberar e-mails externos + Google Sheets em produção). Docs-only — nenhuma mudança de código de runtime.

Plano: `docs/superpowers/plans/2026-06-09-gcp-oauth-external-migration.md`

## Evolução registrada
- ✅ **Gate `DISABLE_SIGNUP` validado** — script (nível adapter) + **E2E real via login Google** (`xandylm@gmail.com` externo → `/signin?error=sign-up-disabled`, 0 linhas criadas).
- ✅ **Scopes de Sheets validados localmente** — `spreadsheets` + `drive.file`, leitura/escrita em planilha real funcionando.
- 🔄 **PR de produção do `DISABLE_SIGNUP`** aberto: cloudhumans/typebot.io-manifests#80 (ConfigMap base, ambas instâncias; `ADMIN_EMAIL` não setado = exige convite). Confirmado que o cadastro em prod estava **aberto** por default.

## Findings de segurança & disponibilidade (no plano)
- `DISABLE_SIGNUP` é **env-only**, sem código (gate já implementado em `customAdapter` + callback `signIn`).
- **Embedded CloudChat (Cognito) não é afetado** — bypassa o gate via JIT provisioning. A trava cobre o cadastro público Google **e** o login Cloud Hub/Cognito direto.
- **Disponibilidade:** em modo Testing os tokens de scope sensível expiram em ~7 dias → só resolve com Produção + verificado.
- Redirect URIs = **no-op** (já registrados; independem do publishing status).
- Re-sequenciamento: Bloco A (domínio, homepage/política, branding) pode começar **já**, em paralelo; virar External depende só do deploy do #80.

## Scope sensível a defender na verificação
`https://www.googleapis.com/auth/spreadsheets` — usuários conectam planilhas existentes (não criadas pelo app) para ler/gravar linhas nos fluxos. (`drive.file` e `userinfo.email` são não-sensíveis.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

PR exclusivamente de documentação — nenhuma linha de código de runtime foi alterada. Seguro para merge.

A mudança adiciona apenas um arquivo Markdown de planejamento. O plano documenta corretamente o sequenciamento crítico (deploy do `DISABLE_SIGNUP` antes de abrir o External) e as limitações conhecidas do adapter. Não há alteração em lógica de autenticação, configurações de produção ou qualquer código executável neste PR.

Nenhum arquivo requer atenção especial — é um único documento de planejamento sem impacto em runtime.

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([✅ Task 1: Validar gate DISABLE_SIGNUP\nscript adapter + E2E Google login]) --> B

    B[Task 2 — Step 1: Deploy PR #80\nDISABLE_SIGNUP=true em produção\nArgoCD sync + restart do pod]

    C[Task 3 — Block A: Ativos em paralelo\nDomínio · Homepage · Privacy Policy\nVideo demo Sheets]

    B --> D[Task 2 — Steps 3–4:\nGCP Console → External\nPublish App → In Production]
    C --> E

    D --> E[Task 4: Submeter verificação\nJustificativas de scope\nSpreadsheets + drive.file\nLink demo video + política]

    E --> F([✅ Verificação aprovada pelo Google\nTokens não expiram mais em 7 dias])

    A -.->|Pode iniciar agora,\nsem bloquear| C
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fsuperpowers%2Fplans%2F2026-06-09-gcp-oauth-external-migration.md%3A66-67%0A**Script%20de%20refer%C3%AAncia%20testa%20configura%C3%A7%C3%A3o%20diferente%20da%20produ%C3%A7%C3%A3o**%0A%0AO%20script%20define%20%60ADMIN_EMAIL%20%3D%20'admin%40example.com'%60%2C%20mas%20o%20pr%C3%B3prio%20documento%20afirma%20que%20em%20produ%C3%A7%C3%A3o%20o%20%60ADMIN_EMAIL%60%20%C3%A9%20intencionalmente%20deixado%20em%20branco.%20Isso%20significa%20que%20o%20bloqueio%20do%20%60adapter.createUser%60%20observado%20no%20teste%20%28%60New%20users%20are%20forbidden%60%29%20vem%20da%20checagem%20de%20%60ADMIN_EMAIL%60%20no%20adapter%2C%20n%C3%A3o%20do%20%60DISABLE_SIGNUP%60%20isoladamente.%20Com%20%60ADMIN_EMAIL%60%20sem%20valor%20%28como%20em%20produ%C3%A7%C3%A3o%29%2C%20o%20trecho%20do%20adapter%20%C3%A9%20inoperante%20%E2%80%94%20conclus%C3%A3o%20j%C3%A1%20documentada%20no%20bloco%20de%20Key%20Findings.%20O%20risco%20%C3%A9%20que%20algu%C3%A9m%20leia%20o%20log%20%60%22---%20All%20DISABLE_SIGNUP%20security%20checks%20passed!%20---%22%60%20e%20conclua%20que%20o%20adapter%20bloqueia%20de%20forma%20independente%20do%20%60ADMIN_EMAIL%60%2C%20o%20que%20n%C3%A3o%20%C3%A9%20verdade%20na%20config%20de%20produ%C3%A7%C3%A3o.%20Adicionar%20um%20coment%C3%A1rio%20inline%20no%20script%20esclarecendo%20esse%20comportamento%20evitaria%20essa%20leitura%20equivocada.%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=222&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fsuperpowers%2Fplans%2F2026-06-09-gcp-oauth-external-migration.md%3A66-67%0A**Script%20de%20refer%C3%AAncia%20testa%20configura%C3%A7%C3%A3o%20diferente%20da%20produ%C3%A7%C3%A3o**%0A%0AO%20script%20define%20%60ADMIN_EMAIL%20%3D%20'admin%40example.com'%60%2C%20mas%20o%20pr%C3%B3prio%20documento%20afirma%20que%20em%20produ%C3%A7%C3%A3o%20o%20%60ADMIN_EMAIL%60%20%C3%A9%20intencionalmente%20deixado%20em%20branco.%20Isso%20significa%20que%20o%20bloqueio%20do%20%60adapter.createUser%60%20observado%20no%20teste%20%28%60New%20users%20are%20forbidden%60%29%20vem%20da%20checagem%20de%20%60ADMIN_EMAIL%60%20no%20adapter%2C%20n%C3%A3o%20do%20%60DISABLE_SIGNUP%60%20isoladamente.%20Com%20%60ADMIN_EMAIL%60%20sem%20valor%20%28como%20em%20produ%C3%A7%C3%A3o%29%2C%20o%20trecho%20do%20adapter%20%C3%A9%20inoperante%20%E2%80%94%20conclus%C3%A3o%20j%C3%A1%20documentada%20no%20bloco%20de%20Key%20Findings.%20O%20risco%20%C3%A9%20que%20algu%C3%A9m%20leia%20o%20log%20%60%22---%20All%20DISABLE_SIGNUP%20security%20checks%20passed!%20---%22%60%20e%20conclua%20que%20o%20adapter%20bloqueia%20de%20forma%20independente%20do%20%60ADMIN_EMAIL%60%2C%20o%20que%20n%C3%A3o%20%C3%A9%20verdade%20na%20config%20de%20produ%C3%A7%C3%A3o.%20Adicionar%20um%20coment%C3%A1rio%20inline%20no%20script%20esclarecendo%20esse%20comportamento%20evitaria%20essa%20leitura%20equivocada.%0A%0A&pr=222&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
docs/superpowers/plans/2026-06-09-gcp-oauth-external-migration.md:66-67
**Script de referência testa configuração diferente da produção**

O script define `ADMIN_EMAIL = 'admin@example.com'`, mas o próprio documento afirma que em produção o `ADMIN_EMAIL` é intencionalmente deixado em branco. Isso significa que o bloqueio do `adapter.createUser` observado no teste (`New users are forbidden`) vem da checagem de `ADMIN_EMAIL` no adapter, não do `DISABLE_SIGNUP` isoladamente. Com `ADMIN_EMAIL` sem valor (como em produção), o trecho do adapter é inoperante — conclusão já documentada no bloco de Key Findings. O risco é que alguém leia o log `"--- All DISABLE_SIGNUP security checks passed! ---"` e conclua que o adapter bloqueia de forma independente do `ADMIN_EMAIL`, o que não é verdade na config de produção. Adicionar um comentário inline no script esclarecendo esse comportamento evitaria essa leitura equivocada.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["docs: DISABLE\_SIGNUP prod PR merged — up..."](https://github.com/cloudhumans/typebot.io/commit/36d334c56142b83ec8b5d299e5df467f0ac9e1c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36820383)</sub>

<!-- /greptile_comment -->