### PR TITLE
🔧maintenance: aumenta limites de visita por bloco

### DIFF
--- a/packages/env/env.ts
+++ b/packages/env/env.ts
@@ -82,14 +82,14 @@ const baseEnv = {
       .default('FREE'),
     DEBUG: boolean.optional().default('false'),
     CHAT_API_TIMEOUT: z.coerce.number().optional(),
-    MAX_BLOCK_VISITS_PER_SESSION: z.coerce.number().int().min(1).default(200),
+    MAX_BLOCK_VISITS_PER_SESSION: z.coerce.number().int().min(1).default(500),
     MAX_LLM_BLOCK_VISITS_PER_SESSION: z.coerce
       .number()
       .int()
       .min(1)
-      .default(10),
-    BLOCK_VISIT_WARN_THRESHOLD: z.coerce.number().int().min(1).default(20),
-    LLM_BLOCK_VISIT_WARN_THRESHOLD: z.coerce.number().int().min(1).default(5),
+      .default(100),
+    BLOCK_VISIT_WARN_THRESHOLD: z.coerce.number().int().min(1).default(100),
+    LLM_BLOCK_VISIT_WARN_THRESHOLD: z.coerce.number().int().min(1).default(10),
     BLOCK_VISIT_LIMIT_ENABLED: boolean.optional().default('true'),
     // Datadog logging configuration
     DD_LOGS_ENABLED: boolean.optional().default('false'),


### PR DESCRIPTION
Os limites default de visita por bloco estavam baixos demais e cortavam fluxos legítimos com muitos blocos (e fluxos agênticos com mais idas ao LLM), além de disparar warning cedo demais no Datadog.

Sobe os defaults em `packages/env/env.ts`:

- bloco comum: limite `200 → 500`, warn `20 → 100`
- bloco com LLM: limite `10 → 100`, warn `5 → 10`

São apenas defaults do schema de env — overrides via variável de ambiente seguem valendo.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Mudança segura para merge — altera apenas valores padrão de configuração, sem impacto em lógica de execução.

Apenas os defaults do Zod schema são alterados. A lógica em `enforceBlockVisitLimit.ts` permanece intacta. Os novos warn thresholds continuam abaixo dos respectivos limites (100 < 500 e 10 < 100), então o aviso sempre precede o encerramento da sessão. Ambientes com variáveis de ambiente explícitas não são afetados.

Nenhum arquivo requer atenção especial; a única mudança está nos defaults de `packages/env/env.ts`.

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Visita ao bloco] --> B{BLOCK_VISIT_LIMIT_ENABLED\ne willSkipBubble?}
    B -- Desativado / skip --> C[continue]
    B -- Ativo --> D[Incrementa visitCount]
    D --> E{isLlmBlock?}
    E -- Sim --> F[limit = 100\nwarnThreshold = 10]
    E -- Não --> G[limit = 500\nwarnThreshold = 100]
    F --> H{visitCount == warnThreshold\nou visitCount > limit?}
    G --> H
    H -- Não --> C
    H -- visitCount == warnThreshold --> I[logger.warn\ncontinue]
    H -- visitCount > limit --> J[logger.error\nterminate sessão]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["🔧maintenance: raise block visit limits ..."](https://github.com/cloudhumans/typebot.io/commit/1416fc6559b3c80b4a7afaaecaf0c5a0f15e576a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37038538)</sub>

<!-- /greptile_comment -->