### PR TITLE
fix(mcp): propagate real error message in /api/mcp JSON-RPC catch-all

### DIFF
--- a/apps/builder/src/pages/api/mcp.ts
+++ b/apps/builder/src/pages/api/mcp.ts
@@ -262,13 +262,18 @@ export default async function handler(
         error: error instanceof Error ? error.message : String(error),
         stack: error instanceof Error ? error.stack : undefined,
       })
-      // Don't leak internal error details to the client; the full error and
-      // stack are captured in the server-side log above.
+      // Propagate the real error message: errors raised during tool execution
+      // (e.g. `Missing required variable "X" for TOOL workflow` thrown by
+      // executeDeclareVariables) are addressed to the calling agent, which
+      // needs the message to self-correct. Masking everything as a generic
+      // "Internal error" defeated that "fail loudly" contract and blinded
+      // message-based observability filters. Full error + stack stay in the
+      // server-side log above.
       return res.status(200).json({
         jsonrpc: '2.0',
         error: {
           code: -32603,
-          message: 'Internal error',
+          message: error instanceof Error ? error.message : 'Internal error',
         },
         id: req.body?.id ?? null,
       })

--- a/apps/viewer/src/pages/api/mcp.ts
+++ b/apps/viewer/src/pages/api/mcp.ts
@@ -262,13 +262,18 @@ export default async function handler(
         error: error instanceof Error ? error.message : String(error),
         stack: error instanceof Error ? error.stack : undefined,
       })
-      // Don't leak internal error details to the client; the full error and
-      // stack are captured in the server-side log above.
+      // Propagate the real error message: errors raised during tool execution
+      // (e.g. `Missing required variable "X" for TOOL workflow` thrown by
+      // executeDeclareVariables) are addressed to the calling agent, which
+      // needs the message to self-correct. Masking everything as a generic
+      // "Internal error" defeated that "fail loudly" contract and blinded
+      // message-based observability filters. Full error + stack stay in the
+      // server-side log above.
       return res.status(200).json({
         jsonrpc: '2.0',
         error: {
           code: -32603,
-          message: 'Internal error',
+          message: error instanceof Error ? error.message : 'Internal error',
         },
         id: req.body?.id ?? null,
       })


### PR DESCRIPTION
## Problem

Since #221, the `/api/mcp` handlers (builder and viewer) mask every exception in the POST catch-all as a generic JSON-RPC error:

```json
{ "error": { "code": -32603, "message": "Internal error" } }
```

The masking was introduced by the hardening commit squashed into #221 (`ef72fd6f`), which replaced the original `error instanceof Error ? error.message : 'Internal error'` with the fixed `'Internal error'` string in both apps.

This defeats the explicit "fail loudly" contract of `executeDeclareVariables` in the bot-engine, which throws `Missing required variable "X" for TOOL workflow` precisely so the calling agent learns which required variable arrived empty. With the masking:

- The LLM calling the tool via MCP only sees "Internal error" and cannot self-correct (it doesn't know which variable is missing).
- Observability filters keyed on the error message are blind.

## Evidence (production, 2026-06-12)

Viewer logs show `Error in startChat` / `MCP request failed` with `Missing required variable "userID" for TOOL workflow` (tool `verificar_se_gerente`, tenant arquivei) and `Missing required variable "Email"` (tool `get_company_data`, tenant zapsign) in the same second the MCP client received only `-32603 Internal error`.

## Fix

Conscious partial revert of the `ef72fd6f` masking line, in both `apps/builder/src/pages/api/mcp.ts` and `apps/viewer/src/pages/api/mcp.ts` (kept in parity):

```ts
message: error instanceof Error ? error.message : 'Internal error',
```

The rest of the #221 hardening is untouched: JSON-RPC envelope validation (-32600), tenant header/query normalization, and server-side logging of the full error + stack.

## Verification (local — CI has no PR gate)

- `tsc --noEmit`: viewer clean; builder failures are all pre-existing in test files (missing vitest types, tRPC `createCaller`, duplicated playwright versions) — none in the touched files.
- `pnpm lint` / `pnpm format:check` (turbo, via pre-commit hook): all green.
- `vitest run` on `executeDeclareVariables.test.ts` (5 tests, incl. the throw of `Missing required variable`) + `packages/mcp-tools` (6 tests): 11/11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>

A mudança é cirúrgica e bem justificada: restaura o comportamento original de "falha ruidosa" para erros de variáveis obrigatórias, sem alterar a estrutura do endpoint nem o restante do hardening do #221.

O catch-all propaga agora a mensagem de qualquer exceção ao chamador, não apenas as geradas pelo `executeDeclareVariables`. Erros de infraestrutura (banco de dados, rede) podem vazar detalhes internos para agentes MCP externos via CORS `*`. O risco é real mas de impacto limitado, dado que o endpoint já era público e as mensagens de erro são de baixo valor para um atacante.

Ambos os arquivos alterados (`apps/viewer/src/pages/api/mcp.ts` e `apps/builder/src/pages/api/mcp.ts`) merecem atenção quanto ao escopo do catch-all; os demais arquivos não foram modificados.

<details open><summary><h3>Security Review</h3></summary>

- **Potencial exposição de mensagens internas de infraestrutura** (`apps/viewer/src/pages/api/mcp.ts`, `apps/builder/src/pages/api/mcp.ts`): o catch-all propaga `error.message` de qualquer exceção para o cliente via JSON-RPC. Embora o caso de uso intencional seja o erro `Missing required variable "X"` (benigno), falhas de banco de dados (Prisma), timeouts ou erros de rede podem conter strings sensíveis (ex.: hosts, nomes de tabela). O endpoint tem CORS `*`, tornando-o acessível a qualquer agente MCP.
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Agent as LLM Agent (MCP Client)
    participant MCP as /api/mcp (viewer/builder)
    participant EW as executeWorkflow
    participant SC as startChat
    participant DV as executeDeclareVariables

    Agent->>MCP: "POST tools/call { name, arguments }"
    MCP->>EW: "executeWorkflow({ publicId, prefilledVariables })"
    EW->>SC: startChat(...)
    SC->>DV: executeDeclareVariables(state, block)

    alt Variável obrigatória ausente
        DV-->>SC: throw Error('Missing required variable "X" for TOOL workflow')
        SC-->>EW: propagates error
        EW-->>MCP: propagates error
        Note over MCP: catch (error)
        MCP-->>Agent: "{ error: { code: -32603, message: 'Missing required variable "X"...' } }"
        Note over Agent: Agent can self-correct ✅
    else Erro de infraestrutura (DB, rede, etc.)
        SC-->>MCP: throw Error('DB connection failed at host:5432')
        Note over MCP: catch (error)
        MCP-->>Agent: "{ error: { code: -32603, message: 'DB connection failed at host:5432' } }"
        Note over Agent: Mensagem interna exposta ⚠️
    else Execução bem-sucedida
        DV-->>SC: "{ outgoingEdgeId }"
        SC-->>EW: result
        EW-->>MCP: result
        MCP-->>Agent: "{ result: { content: [{ type: 'text', text: output }] } }"
    end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/viewer/src/pages/api/mcp.ts`, line 257-279 ([link](https://github.com/cloudhumans/typebot.io/blob/0ce42913301a2c7553116e16cde5b61fa97c262a/apps/viewer/src/pages/api/mcp.ts#L257-L279)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Vazamento potencial de detalhes internos em erros de infraestrutura**

   O bloco `catch` agora repassa a mensagem de qualquer exceção ao cliente MCP, não apenas as geradas pelo `executeDeclareVariables`. Erros de banco de dados (Prisma), falhas de rede ou timeouts internos podem incluir informações como nomes de tabelas, strings de conexão parciais ou caminhos internos. Como o endpoint tem CORS `*` e qualquer agente MCP pode consumi-lo, um erro de infraestrutura deixaria esses detalhes visíveis para o chamador.

   Vale avaliar um filtro mais seletivo — por exemplo, propagar somente instâncias de um tipo de erro "seguro para o agente" (ex.: `ToolExecutionError`) e manter o fallback genérico para os demais.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/viewer/src/pages/api/mcp.ts
   Line: 257-279

   Comment:
   **Vazamento potencial de detalhes internos em erros de infraestrutura**

   O bloco `catch` agora repassa a mensagem de qualquer exceção ao cliente MCP, não apenas as geradas pelo `executeDeclareVariables`. Erros de banco de dados (Prisma), falhas de rede ou timeouts internos podem incluir informações como nomes de tabelas, strings de conexão parciais ou caminhos internos. Como o endpoint tem CORS `*` e qualquer agente MCP pode consumi-lo, um erro de infraestrutura deixaria esses detalhes visíveis para o chamador.

   Vale avaliar um filtro mais seletivo — por exemplo, propagar somente instâncias de um tipo de erro "seguro para o agente" (ex.: `ToolExecutionError`) e manter o fallback genérico para os demais.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fviewer%2Fsrc%2Fpages%2Fapi%2Fmcp.ts%0ALine%3A%20257-279%0A%0AComment%3A%0A**Vazamento%20potencial%20de%20detalhes%20internos%20em%20erros%20de%20infraestrutura**%0A%0AO%20bloco%20%60catch%60%20agora%20repassa%20a%20mensagem%20de%20qualquer%20exce%C3%A7%C3%A3o%20ao%20cliente%20MCP%2C%20n%C3%A3o%20apenas%20as%20geradas%20pelo%20%60executeDeclareVariables%60.%20Erros%20de%20banco%20de%20dados%20%28Prisma%29%2C%20falhas%20de%20rede%20ou%20timeouts%20internos%20podem%20incluir%20informa%C3%A7%C3%B5es%20como%20nomes%20de%20tabelas%2C%20strings%20de%20conex%C3%A3o%20parciais%20ou%20caminhos%20internos.%20Como%20o%20endpoint%20tem%20CORS%20%60*%60%20e%20qualquer%20agente%20MCP%20pode%20consumi-lo%2C%20um%20erro%20de%20infraestrutura%20deixaria%20esses%20detalhes%20vis%C3%ADveis%20para%20o%20chamador.%0A%0AVale%20avaliar%20um%20filtro%20mais%20seletivo%20%E2%80%94%20por%20exemplo%2C%20propagar%20somente%20inst%C3%A2ncias%20de%20um%20tipo%20de%20erro%20%22seguro%20para%20o%20agente%22%20%28ex.%3A%20%60ToolExecutionError%60%29%20e%20manter%20o%20fallback%20gen%C3%A9rico%20para%20os%20demais.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudhumans%2Ftypebot.io&pr=224&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fviewer%2Fsrc%2Fpages%2Fapi%2Fmcp.ts%0ALine%3A%20257-279%0A%0AComment%3A%0A**Vazamento%20potencial%20de%20detalhes%20internos%20em%20erros%20de%20infraestrutura**%0A%0AO%20bloco%20%60catch%60%20agora%20repassa%20a%20mensagem%20de%20qualquer%20exce%C3%A7%C3%A3o%20ao%20cliente%20MCP%2C%20n%C3%A3o%20apenas%20as%20geradas%20pelo%20%60executeDeclareVariables%60.%20Erros%20de%20banco%20de%20dados%20%28Prisma%29%2C%20falhas%20de%20rede%20ou%20timeouts%20internos%20podem%20incluir%20informa%C3%A7%C3%B5es%20como%20nomes%20de%20tabelas%2C%20strings%20de%20conex%C3%A3o%20parciais%20ou%20caminhos%20internos.%20Como%20o%20endpoint%20tem%20CORS%20%60*%60%20e%20qualquer%20agente%20MCP%20pode%20consumi-lo%2C%20um%20erro%20de%20infraestrutura%20deixaria%20esses%20detalhes%20vis%C3%ADveis%20para%20o%20chamador.%0A%0AVale%20avaliar%20um%20filtro%20mais%20seletivo%20%E2%80%94%20por%20exemplo%2C%20propagar%20somente%20inst%C3%A2ncias%20de%20um%20tipo%20de%20erro%20%22seguro%20para%20o%20agente%22%20%28ex.%3A%20%60ToolExecutionError%60%29%20e%20manter%20o%20fallback%20gen%C3%A9rico%20para%20os%20demais.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=224&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fviewer%2Fsrc%2Fpages%2Fapi%2Fmcp.ts%3A257-279%0A**Vazamento%20potencial%20de%20detalhes%20internos%20em%20erros%20de%20infraestrutura**%0A%0AO%20bloco%20%60catch%60%20agora%20repassa%20a%20mensagem%20de%20qualquer%20exce%C3%A7%C3%A3o%20ao%20cliente%20MCP%2C%20n%C3%A3o%20apenas%20as%20geradas%20pelo%20%60executeDeclareVariables%60.%20Erros%20de%20banco%20de%20dados%20%28Prisma%29%2C%20falhas%20de%20rede%20ou%20timeouts%20internos%20podem%20incluir%20informa%C3%A7%C3%B5es%20como%20nomes%20de%20tabelas%2C%20strings%20de%20conex%C3%A3o%20parciais%20ou%20caminhos%20internos.%20Como%20o%20endpoint%20tem%20CORS%20%60*%60%20e%20qualquer%20agente%20MCP%20pode%20consumi-lo%2C%20um%20erro%20de%20infraestrutura%20deixaria%20esses%20detalhes%20vis%C3%ADveis%20para%20o%20chamador.%0A%0AVale%20avaliar%20um%20filtro%20mais%20seletivo%20%E2%80%94%20por%20exemplo%2C%20propagar%20somente%20inst%C3%A2ncias%20de%20um%20tipo%20de%20erro%20%22seguro%20para%20o%20agente%22%20%28ex.%3A%20%60ToolExecutionError%60%29%20e%20manter%20o%20fallback%20gen%C3%A9rico%20para%20os%20demais.%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=224&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fviewer%2Fsrc%2Fpages%2Fapi%2Fmcp.ts%3A257-279%0A**Vazamento%20potencial%20de%20detalhes%20internos%20em%20erros%20de%20infraestrutura**%0A%0AO%20bloco%20%60catch%60%20agora%20repassa%20a%20mensagem%20de%20qualquer%20exce%C3%A7%C3%A3o%20ao%20cliente%20MCP%2C%20n%C3%A3o%20apenas%20as%20geradas%20pelo%20%60executeDeclareVariables%60.%20Erros%20de%20banco%20de%20dados%20%28Prisma%29%2C%20falhas%20de%20rede%20ou%20timeouts%20internos%20podem%20incluir%20informa%C3%A7%C3%B5es%20como%20nomes%20de%20tabelas%2C%20strings%20de%20conex%C3%A3o%20parciais%20ou%20caminhos%20internos.%20Como%20o%20endpoint%20tem%20CORS%20%60*%60%20e%20qualquer%20agente%20MCP%20pode%20consumi-lo%2C%20um%20erro%20de%20infraestrutura%20deixaria%20esses%20detalhes%20vis%C3%ADveis%20para%20o%20chamador.%0A%0AVale%20avaliar%20um%20filtro%20mais%20seletivo%20%E2%80%94%20por%20exemplo%2C%20propagar%20somente%20inst%C3%A2ncias%20de%20um%20tipo%20de%20erro%20%22seguro%20para%20o%20agente%22%20%28ex.%3A%20%60ToolExecutionError%60%29%20e%20manter%20o%20fallback%20gen%C3%A9rico%20para%20os%20demais.%0A%0A&pr=224&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/viewer/src/pages/api/mcp.ts:257-279
**Vazamento potencial de detalhes internos em erros de infraestrutura**

O bloco `catch` agora repassa a mensagem de qualquer exceção ao cliente MCP, não apenas as geradas pelo `executeDeclareVariables`. Erros de banco de dados (Prisma), falhas de rede ou timeouts internos podem incluir informações como nomes de tabelas, strings de conexão parciais ou caminhos internos. Como o endpoint tem CORS `*` e qualquer agente MCP pode consumi-lo, um erro de infraestrutura deixaria esses detalhes visíveis para o chamador.

Vale avaliar um filtro mais seletivo — por exemplo, propagar somente instâncias de um tipo de erro "seguro para o agente" (ex.: `ToolExecutionError`) e manter o fallback genérico para os demais.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): propagate real error message i..."](https://github.com/cloudhumans/typebot.io/commit/0ce42913301a2c7553116e16cde5b61fa97c262a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37236941)</sub>

<!-- /greptile_comment -->