### PR TITLE
fix(bot-engine): keep webhook errors structured when upstream lies about Content-Type

### DIFF
--- a/packages/bot-engine/blocks/integrations/webhook/executeWebhookBlock.ts
+++ b/packages/bot-engine/blocks/integrations/webhook/executeWebhookBlock.ts
@@ -28,8 +28,8 @@ import {
 } from '@typebot.io/schemas/features/blocks/integrations/webhook/constants'
 import { env } from '@typebot.io/env'
 import { parseAnswers } from '@typebot.io/results/parseAnswers'
-import { JSONParse } from '@typebot.io/lib/JSONParse'
 import logger from '@typebot.io/lib/logger'
+import { parseResponseBody, safeJsonParse } from './parseResponseBody'
 
 type ParsedWebhook = ExecutableHttpRequest & {
   basicAuth: { username?: string; password?: string }
@@ -268,15 +268,13 @@ export const executeWebhook = async (
 
   try {
     const response = await ky(request.url, omit(request, 'url'))
-    const body = response.headers.get('content-type')?.includes('json')
-      ? await response.json()
-      : await response.text()
+    const body = await parseResponseBody(response)
     logs.push({
       status: 'success',
       description: webhookSuccessDescription,
       details: {
         statusCode: response.status,
-        response: typeof body === 'string' ? safeJsonParse(body).data : body,
+        response: body,
         request,
       },
     })
@@ -296,24 +294,16 @@ export const executeWebhook = async (
     return {
       response: {
         statusCode: response.status,
-        data: typeof body === 'string' ? safeJsonParse(body).data : body,
+        data: body,
       },
       logs,
       startTimeShouldBeUpdated: true,
     }
   } catch (error) {
     if (error instanceof HTTPError) {
-      const responseBody = error.response.headers
-        .get('content-type')
-        ?.includes('json')
-        ? await error.response.json()
-        : await error.response.text()
       const response = {
         statusCode: error.response.status,
-        data:
-          typeof responseBody === 'string'
-            ? safeJsonParse(responseBody).data
-            : responseBody,
+        data: await parseResponseBody(error.response),
       }
       logs.push({
         status: 'error',
@@ -434,15 +424,6 @@ export const convertKeyValueTableToObject = (
       [key]: value,
     }
   }, {})
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const safeJsonParse = (json: unknown): { data: any; isJson: boolean } => {
-  try {
-    return { data: JSONParse(json as string), isJson: true }
-  } catch (err) {
-    return { data: json, isJson: false }
-  }
 }
 
 const parseFormDataBody = (body: object) => {

--- a/packages/bot-engine/blocks/integrations/webhook/parseResponseBody.test.ts
+++ b/packages/bot-engine/blocks/integrations/webhook/parseResponseBody.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { parseResponseBody, safeJsonParse } from './parseResponseBody'
+
+describe('parseResponseBody', () => {
+  it('returns the raw text when Content-Type claims JSON but the body is plain text (AWS Lambda Function URL 502 quirk)', async () => {
+    // Incident 2026-06-12 (tenant zerezes): Lambda Function URL responded
+    // HTTP 502 with `Content-Type: application/json` and the plain-text body
+    // "Internal Server Error". Trusting the header and calling
+    // `response.json()` threw a SyntaxError that escaped the webhook error
+    // handling entirely.
+    const response = new Response('Internal Server Error', {
+      status: 502,
+      headers: { 'content-type': 'application/json' },
+    })
+
+    await expect(parseResponseBody(response)).resolves.toBe(
+      'Internal Server Error'
+    )
+  })
+
+  it('parses a valid JSON object body declared as JSON', async () => {
+    const response = new Response(JSON.stringify({ orderId: 123, ok: true }), {
+      headers: { 'content-type': 'application/json' },
+    })
+
+    await expect(parseResponseBody(response)).resolves.toEqual({
+      orderId: 123,
+      ok: true,
+    })
+  })
+
+  it('parses a valid JSON body even when Content-Type is not JSON (legacy behavior via safeJsonParse)', async () => {
+    const response = new Response('{"message":"hello"}', {
+      headers: { 'content-type': 'text/plain' },
+    })
+
+    await expect(parseResponseBody(response)).resolves.toEqual({
+      message: 'hello',
+    })
+  })
+
+  it('returns plain text bodies as-is', async () => {
+    const response = new Response('just some text', {
+      headers: { 'content-type': 'text/plain' },
+    })
+
+    await expect(parseResponseBody(response)).resolves.toBe('just some text')
+  })
+
+  it('unwraps a JSON-encoded string body to the string value', async () => {
+    const response = new Response('"hello"', {
+      headers: { 'content-type': 'application/json' },
+    })
+
+    await expect(parseResponseBody(response)).resolves.toBe('hello')
+  })
+
+  it('returns an empty string for an empty body instead of throwing', async () => {
+    const response = new Response('', {
+      status: 502,
+      headers: { 'content-type': 'application/json' },
+    })
+
+    await expect(parseResponseBody(response)).resolves.toBe('')
+  })
+
+  it('parses JSON arrays and scalars', async () => {
+    const response = new Response('[1,2,3]', {
+      headers: { 'content-type': 'application/json' },
+    })
+
+    await expect(parseResponseBody(response)).resolves.toEqual([1, 2, 3])
+  })
+})
+
+describe('safeJsonParse', () => {
+  it('parses valid JSON and flags it as JSON', () => {
+    expect(safeJsonParse('{"a":1}')).toEqual({ data: { a: 1 }, isJson: true })
+  })
+
+  it('falls back to the raw input when parsing fails', () => {
+    expect(safeJsonParse('Internal Server Error')).toEqual({
+      data: 'Internal Server Error',
+      isJson: false,
+    })
+  })
+})

--- a/packages/bot-engine/blocks/integrations/webhook/parseResponseBody.ts
+++ b/packages/bot-engine/blocks/integrations/webhook/parseResponseBody.ts
@@ -1,0 +1,34 @@
+import { JSONParse } from '@typebot.io/lib/JSONParse'
+
+/**
+ * Parses a JSON string, falling back to the raw input when parsing fails.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const safeJsonParse = (
+  json: unknown
+): { data: any; isJson: boolean } => {
+  try {
+    return { data: JSONParse(json as string), isJson: true }
+  } catch (err) {
+    return { data: json, isJson: false }
+  }
+}
+
+/**
+ * Reads an HTTP response body without trusting the Content-Type header.
+ *
+ * Some upstreams lie about their content type — e.g. AWS Lambda Function URLs
+ * respond to 502s with `Content-Type: application/json` and the plain-text
+ * body "Internal Server Error". Calling `response.json()` based on the header
+ * throws a SyntaxError that escapes the webhook error handling entirely.
+ *
+ * Instead we always read the body as text and attempt a safe JSON parse:
+ * valid JSON yields the parsed value, anything else yields the raw string.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const parseResponseBody = async (response: {
+  text: () => Promise<string>
+}): Promise<any> => {
+  const text = await response.text()
+  return safeJsonParse(text).data
+}


### PR DESCRIPTION
## Incident

Prod 2026-06-12 ~15:57Z, tenant **zerezes**: MCP tool calls (`get_order_status`, `get_order_by_last_order_name`) failed with `ToolException: ... Unexpected token I in JSON at position 0`.

Confirmed chain (LangSmith + Datadog APM trace 10814162541211834511):

1. The tenant's TOOL workflow POSTs via webhook block to an AWS Lambda Function URL.
2. The Lambda answered **HTTP 502 after ~10.7s** with the plain-text body `Internal Server Error` but with header `Content-Type: application/json` (known Lambda Function URL quirk on 502).
3. In `executeWebhookBlock.ts`, the `HTTPError` catch branch decided the parse strategy from the Content-Type header and called `await error.response.json()` unguarded. The `SyntaxError` thrown **inside the catch** escaped `executeWebhook` entirely (skipping the graceful fallback), bubbled through `startChat`, and was only caught by the `/api/mcp` handler — surfacing as an opaque JSON-RPC `-32603` with the raw parse error, useless to the agent.

The Datadog stack confirms it: `SyntaxError: Unexpected token I in JSON at position 0 at JSON.parse / parseJSONFromBytes (undici)` — i.e. fetch's `Response.json()`.

## Fix

New pure helper `parseResponseBody` that **never trusts the Content-Type header**: it always reads the body via `response.text()` and applies the existing `safeJsonParse` (valid JSON → parsed value; anything else → raw string). Applied to both call sites:

- **`HTTPError` catch branch (the incident):** now returns the normal structured error shape `{ response: { statusCode: 502, data: 'Internal Server Error' }, logs, startTimeShouldBeUpdated: true }` with the usual `Webhook returned an error.` log, so the agent receives a structured error it can recover from.
- **Success path (same latent bug):** a 2xx with a JSON Content-Type but non-JSON body used to throw and fall through to the generic catch as a fake 500 `Error from Typebot server`, losing the real status. Now it keeps the real status and the raw body.

For all previously-working cases the result is equivalent: JSON objects/arrays/scalars parse to the same values (including JSON-encoded strings unwrapping to the string), plain text stays a string — covered by tests.

`safeJsonParse` moved from `executeWebhookBlock.ts` to the new module unchanged (it was module-private; no other consumers).

## Validation (CI has no PR gate — validated locally)

- `vitest run` on `packages/bot-engine`: **14 passed** (9 new `parseResponseBody` tests incl. the Lambda 502 repro, 5 pre-existing)
- `tsc --noEmit` on `packages/bot-engine`: identical error baseline to `main` (27 pre-existing errors in untouched files, 0 in webhook files)
- `pnpm lint` + `pnpm format:check`: green (also enforced by the pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

A mudança é cirúrgica e bem contida: dois call sites de leitura de corpo substituídos por um helper testado, sem tocar em lógica de roteamento, variáveis ou persistência.

O helper introduzido tem implementação mínima e claramente correta — lê texto, tenta parse JSON seguro, nunca lança exceção de parse. Os 9 novos testes incluem o cenário exato do incidente e os casos limítrofes relevantes. A refatoração em executeWebhookBlock.ts é comportamentalmente equivalente para todos os casos previamente funcionais, e elimina o caminho de erro que escapava sem tratamento.

Nenhum arquivo requer atenção especial.

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Agent as Agent / MCP
    participant WH as executeWebhook
    participant KY as ky (HTTP client)
    participant Lambda as AWS Lambda
    participant PRB as parseResponseBody

    Agent->>WH: executa bloco webhook
    WH->>KY: HTTP POST /endpoint
    KY->>Lambda: POST
    Lambda-->>KY: 502 Content-Type: application/json
    KY-->>WH: throw HTTPError
    note over WH: catch (error instanceof HTTPError)
    WH->>PRB: parseResponseBody(error.response)
    PRB->>PRB: response.text() → "Internal Server Error"
    PRB->>PRB: "safeJsonParse → { data: "Internal Server Error", isJson: false }"
    PRB-->>WH: "Internal Server Error"
    WH-->>Agent: "{ statusCode: 502, data: "Internal Server Error" }"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(bot-engine): keep webhook errors str..."](https://github.com/cloudhumans/typebot.io/commit/c27147a3e17fdb11ee02fef806fbc91655a44420) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37280437)</sub>

<!-- /greptile_comment -->