### PR TITLE
fix(google-sheets): stop serializing full query (JWT) into OAuth state (502 on Connect in embedded mode)

### DIFF
--- a/apps/builder/src/pages/api/credentials/google-sheets/consent-url.ts
+++ b/apps/builder/src/pages/api/credentials/google-sheets/consent-url.ts
@@ -15,11 +15,29 @@ const handler = (req: NextApiRequest, res: NextApiResponse) => {
       env.GOOGLE_CLIENT_SECRET,
       `${env.NEXTAUTH_URL}/api/credentials/google-sheets/callback`
     )
+    // Only persist the fields the callback actually reads. Crucially, strip the
+    // query string off redirectUrl (the callback does `redirectUrl.split('?')[0]`
+    // anyway): in embedded mode it carries a multi-KB Cognito JWT that, once
+    // base64-encoded into `state`, blows the OAuth redirect's `Location` header
+    // past the ingress header limit → 502. Keeping `state` minimal also stops the
+    // JWT from leaking into Google's URL and logs.
+    const { typebotId, blockId, workspaceId, redirectUrl } = req.query
+    const state = Buffer.from(
+      JSON.stringify({
+        typebotId,
+        blockId,
+        workspaceId,
+        redirectUrl:
+          typeof redirectUrl === 'string'
+            ? redirectUrl.split('?')[0]
+            : redirectUrl,
+      })
+    ).toString('base64')
     const url = oauth2Client.generateAuthUrl({
       access_type: 'offline',
       scope: googleSheetsScopes,
       prompt: 'consent',
-      state: Buffer.from(JSON.stringify(req.query)).toString('base64'),
+      state,
     })
     res.status(301).redirect(url)
   }

--- a/apps/builder/src/pages/api/credentials/google-sheets/consent-url.ts
+++ b/apps/builder/src/pages/api/credentials/google-sheets/consent-url.ts
@@ -21,16 +21,17 @@ const handler = (req: NextApiRequest, res: NextApiResponse) => {
     // base64-encoded into `state`, blows the OAuth redirect's `Location` header
     // past the ingress header limit → 502. Keeping `state` minimal also stops the
     // JWT from leaking into Google's URL and logs.
-    const { typebotId, blockId, workspaceId, redirectUrl } = req.query
+    // req.query values are `string | string[] | undefined`; normalize to a single
+    // string so `state` never carries arrays/undefined that the callback (which
+    // treats these as strings, e.g. `redirectUrl.split`) can't handle.
+    const firstValue = (value: string | string[] | undefined) =>
+      Array.isArray(value) ? value[0] : value
     const state = Buffer.from(
       JSON.stringify({
-        typebotId,
-        blockId,
-        workspaceId,
-        redirectUrl:
-          typeof redirectUrl === 'string'
-            ? redirectUrl.split('?')[0]
-            : redirectUrl,
+        typebotId: firstValue(req.query.typebotId),
+        blockId: firstValue(req.query.blockId),
+        workspaceId: firstValue(req.query.workspaceId),
+        redirectUrl: firstValue(req.query.redirectUrl)?.split('?')[0],
       })
     ).toString('base64')
     const url = oauth2Client.generateAuthUrl({


### PR DESCRIPTION
## Problem

Connecting a Google account from the **embedded** Sheets editor (typebot inside CloudChat, served from `eddie.*`) fails with a **502** from the eddie ingress (Kong):

> An invalid response was received from the upstream server.

### Root cause
`apps/builder/src/pages/api/credentials/google-sheets/consent-url.ts` base64-encoded the **entire `req.query`** into the OAuth `state`:

```ts
state: Buffer.from(JSON.stringify(req.query)).toString('base64')
```

In embedded mode the connect button passes `redirectUrl = window.location.href` (`GoogleSheetsConnectModal.tsx`), and that URL carries the multi-KB **Cognito JWT** (`?embedded=true&jwt=…`). So `state` — and therefore the 301 redirect's `Location` header pointing at Google — blew past the ingress header-size limit → Kong returned a 502 and the connect flow never reached Google.

Standalone Typebot was unaffected because there `redirectUrl` is a short URL with no JWT. This is an integration seam: upstream's "serialize the whole query into state" assumption met CloudHumans' "embedded auth travels as a JWT in the URL" assumption.

## Fix
Persist only the fields the callback actually reads (`typebotId`, `blockId`, `workspaceId`, `redirectUrl`), and strip the query string off `redirectUrl`. The callback already does `redirectUrl.split('?')[0]`, so the **return behavior is unchanged** — the JWT was dead weight in the round-trip.

Bonus: this also stops the Cognito ID token (email, groups, tenant, projects, account map) from leaking into Google's URL / browser history / logs. The OAuth `state` should be opaque, not an app-context blob carrying a session token.

## Verification
- Live padding sweep on the deployed endpoint: `Location` ≤ ~2.8 KB → **307 OK**; ≥ ~3 KB → **502**.
- With the real JWT: `state` ~2.4 KB → `Location` ~3.0 KB → **502**. After the fix: `state` ~0.3 KB → `Location` ~0.9 KB → **307**.
- `prettier --check` clean; `tsc --noEmit` shows no errors in this file (only pre-existing vitest test-file noise).
- Callback decode after fix yields exactly the 4 expected fields with `redirectUrl` already at its base path.

> Note: this can only be fully validated against the eddie ingress in production (the 502 is produced by Kong's response-header limit, not by the Next.js dev server).

## Related (not fixed here)
The **re-pick spreadsheet** flow still 403s in embedded mode because the Google Picker / `accounts.google.com` AccountChooser cannot render inside the cross-site iframe. Tracked separately — likely fixed by opening the picker/consent in a top-level popup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

A mudança é segura para merge — ela restringe o que vai no OAuth state a exatamente os 4 campos que o callback já consumia, sem alterar nenhuma outra lógica.

A correção é cirúrgica: remove dados desnecessários do state sem mudar o comportamento do callback, que já extraía apenas esses 4 campos. O helper firstValue trata corretamente os tipos do req.query. A remoção antecipada do query string do redirectUrl é redundante com o que o callback faz, mas inócua.

Nenhum arquivo requer atenção especial além do arquivo alterado, que está correto.

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser as Browser (embedded)
    participant ConsentURL as /api/credentials/google-sheets/consent-url
    participant Google as Google OAuth
    participant Callback as /api/credentials/google-sheets/callback

    Note over Browser,Callback: Antes da correção
    Browser->>ConsentURL: "GET ?typebotId=…&blockId=…&workspaceId=…&redirectUrl=…&jwt=MULTI_KB_TOKEN"
    ConsentURL->>ConsentURL: "state = base64(JSON.stringify(req.query)) ~2.4 KB state → ~3.0 KB Location header"
    ConsentURL-->>Browser: 502 (Kong ingress header limit exceeded)

    Note over Browser,Callback: Depois da correção
    Browser->>ConsentURL: "GET ?typebotId=…&blockId=…&workspaceId=…&redirectUrl=…&jwt=MULTI_KB_TOKEN"
    ConsentURL->>ConsentURL: "state = base64(JSON.stringify({typebotId, blockId, workspaceId, redirectUrl})) ~0.3 KB state → ~0.9 KB Location header"
    ConsentURL-->>Browser: 301 → Google OAuth consent screen
    Google-->>Callback: "GET ?code=…&state=…"
    Callback->>Callback: "Decode state → { typebotId, blockId, workspaceId, redirectUrl }"
    Callback->>Callback: Store credentials, update typebot
    Callback-->>Browser: "Redirect to redirectUrl?blockId=…"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser as Browser (embedded)
    participant ConsentURL as /api/credentials/google-sheets/consent-url
    participant Google as Google OAuth
    participant Callback as /api/credentials/google-sheets/callback

    Note over Browser,Callback: Antes da correção
    Browser->>ConsentURL: "GET ?typebotId=…&blockId=…&workspaceId=…&redirectUrl=…&jwt=MULTI_KB_TOKEN"
    ConsentURL->>ConsentURL: "state = base64(JSON.stringify(req.query)) ~2.4 KB state → ~3.0 KB Location header"
    ConsentURL-->>Browser: 502 (Kong ingress header limit exceeded)

    Note over Browser,Callback: Depois da correção
    Browser->>ConsentURL: "GET ?typebotId=…&blockId=…&workspaceId=…&redirectUrl=…&jwt=MULTI_KB_TOKEN"
    ConsentURL->>ConsentURL: "state = base64(JSON.stringify({typebotId, blockId, workspaceId, redirectUrl})) ~0.3 KB state → ~0.9 KB Location header"
    ConsentURL-->>Browser: 301 → Google OAuth consent screen
    Google-->>Callback: "GET ?code=…&state=…"
    Callback->>Callback: "Decode state → { typebotId, blockId, workspaceId, redirectUrl }"
    Callback->>Callback: Store credentials, update typebot
    Callback-->>Browser: "Redirect to redirectUrl?blockId=…"
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(google-sheets): normalize query para..."](https://github.com/cloudhumans/typebot.io/commit/5c666f01e68a364b64b1652ed3d7341cb12be681) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37962171)</sub>

<!-- /greptile_comment -->