### PR TITLE
Revert "fix(google-sheets): stop serializing full query (JWT) into OAuth state (502 on Connect in embedded mode)"

### DIFF
--- a/apps/builder/src/pages/api/credentials/google-sheets/consent-url.ts
+++ b/apps/builder/src/pages/api/credentials/google-sheets/consent-url.ts
@@ -15,30 +15,11 @@ const handler = (req: NextApiRequest, res: NextApiResponse) => {
       env.GOOGLE_CLIENT_SECRET,
       `${env.NEXTAUTH_URL}/api/credentials/google-sheets/callback`
     )
-    // Only persist the fields the callback actually reads. Crucially, strip the
-    // query string off redirectUrl (the callback does `redirectUrl.split('?')[0]`
-    // anyway): in embedded mode it carries a multi-KB Cognito JWT that, once
-    // base64-encoded into `state`, blows the OAuth redirect's `Location` header
-    // past the ingress header limit → 502. Keeping `state` minimal also stops the
-    // JWT from leaking into Google's URL and logs.
-    // req.query values are `string | string[] | undefined`; normalize to a single
-    // string so `state` never carries arrays/undefined that the callback (which
-    // treats these as strings, e.g. `redirectUrl.split`) can't handle.
-    const firstValue = (value: string | string[] | undefined) =>
-      Array.isArray(value) ? value[0] : value
-    const state = Buffer.from(
-      JSON.stringify({
-        typebotId: firstValue(req.query.typebotId),
-        blockId: firstValue(req.query.blockId),
-        workspaceId: firstValue(req.query.workspaceId),
-        redirectUrl: firstValue(req.query.redirectUrl)?.split('?')[0],
-      })
-    ).toString('base64')
     const url = oauth2Client.generateAuthUrl({
       access_type: 'offline',
       scope: googleSheetsScopes,
       prompt: 'consent',
-      state,
+      state: Buffer.from(JSON.stringify(req.query)).toString('base64'),
     })
     res.status(301).redirect(url)
   }


### PR DESCRIPTION
Reverts cloudhumans/typebot.io#227

<!-- greptile_comment -->

<h3>Confidence Score: 2/5</h3>

O merge deste PR restaura um bug que interrompe completamente o fluxo de conexão com Google Sheets para usuários em modo incorporado.

A única alteração reverte uma correção cirúrgica e bem documentada. Em ambientes embedded com Cognito, o fluxo de OAuth do Google Sheets voltará a falhar com 502 para todos os usuários afetados. Há ainda o risco secundário de crash no callback e de vazamento de tokens em URLs de terceiros.

O único arquivo alterado, `consent-url.ts`, é o ponto crítico — a lógica de geração do `state` OAuth precisa ser revisada antes do merge.

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as Usuário (iframe)
    participant B as Builder API /consent-url
    participant G as Google OAuth
    participant C as Builder API /callback
    participant P as Proxy/Ingress

    U->>B: "GET /consent-url?redirectUrl=...&JWT=multi-KB"
    Note over B: req.query inclui JWT grande
    B->>P: "301 Location com state=base64-enorme"
    P-->>U: 502 Bad Gateway - header Location excede limite

    Note over B,G: Com o PR 227 (revertido)
    B->>G: "301 Location com state=base64-pequeno"
    G->>C: "GET /callback?state=base64-pequeno&code=..."
    C->>U: "302 redirectUrl?blockId=..."
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as Usuário (iframe)
    participant B as Builder API /consent-url
    participant G as Google OAuth
    participant C as Builder API /callback
    participant P as Proxy/Ingress

    U->>B: "GET /consent-url?redirectUrl=...&JWT=multi-KB"
    Note over B: req.query inclui JWT grande
    B->>P: "301 Location com state=base64-enorme"
    P-->>U: 502 Bad Gateway - header Location excede limite

    Note over B,G: Com o PR 227 (revertido)
    B->>G: "301 Location com state=base64-pequeno"
    G->>C: "GET /callback?state=base64-pequeno&code=..."
    C->>U: "302 redirectUrl?blockId=..."
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fbuilder%2Fsrc%2Fpages%2Fapi%2Fcredentials%2Fgoogle-sheets%2Fconsent-url.ts%3A19-23%0A**Re-introdu%C3%A7%C3%A3o%20do%20erro%20502%20em%20modo%20incorporado%20%28embedded%29**%0A%0AEste%20revert%20restaura%20a%20serializa%C3%A7%C3%A3o%20de%20%60req.query%60%20completo%20como%20%60state%60%20do%20OAuth.%20Em%20modo%20incorporado%20%28ex.%3A%20Typebot%20dentro%20de%20um%20iframe%20com%20autentica%C3%A7%C3%A3o%20Cognito%29%2C%20a%20query%20string%20pode%20conter%20um%20JWT%20de%20v%C3%A1rios%20KB.%20Ao%20codific%C3%A1-lo%20em%20base64%20no%20par%C3%A2metro%20%60state%60%2C%20o%20header%20%60Location%60%20do%20redirect%20301%20ultrapassa%20o%20limite%20de%20headers%20do%20ingress%2Fproxy%20%E2%86%92%20o%20servidor%20retorna%20502%20diretamente%20para%20o%20usu%C3%A1rio%2C%20quebrando%20o%20fluxo%20de%20conex%C3%A3o%20com%20o%20Google%20Sheets.%20Este%20era%20exatamente%20o%20problema%20corrigido%20no%20PR%20%23227.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fbuilder%2Fsrc%2Fpages%2Fapi%2Fcredentials%2Fgoogle-sheets%2Fconsent-url.ts%3A22%0A**Valores%20array%20de%20%60req.query%60%20podem%20causar%20crash%20no%20callback**%0A%0AO%20Next.js%20normaliza%20par%C3%A2metros%20repetidos%20na%20query%20string%20como%20%60string%5B%5D%60.%20Se%20%60redirectUrl%60%20%28ou%20qualquer%20outro%20campo%20lido%20no%20callback%29%20aparecer%20mais%20de%20uma%20vez%20na%20URL%2C%20o%20%60state%60%20conter%C3%A1%20um%20array.%20No%20callback%20%28%60callback.ts%3A97%60%29%2C%20%60redirectUrl.split%28'%3F'%29%5B0%5D%60%20%C3%A9%20chamado%20sem%20verifica%C3%A7%C3%A3o%20de%20tipo%20%E2%80%94%20se%20%60redirectUrl%60%20for%20um%20array%2C%20a%20chamada%20a%20%60.split%60%20lan%C3%A7a%20%60TypeError%3A%20redirectUrl.split%20is%20not%20a%20function%60%2C%20causando%20um%20erro%20500%20n%C3%A3o%20tratado.%20O%20PR%20%23227%20prevenia%20isso%20normalizando%20cada%20campo%20com%20%60firstValue%28%29%60.%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=228&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fbuilder%2Fsrc%2Fpages%2Fapi%2Fcredentials%2Fgoogle-sheets%2Fconsent-url.ts%3A19-23%0A**Re-introdu%C3%A7%C3%A3o%20do%20erro%20502%20em%20modo%20incorporado%20%28embedded%29**%0A%0AEste%20revert%20restaura%20a%20serializa%C3%A7%C3%A3o%20de%20%60req.query%60%20completo%20como%20%60state%60%20do%20OAuth.%20Em%20modo%20incorporado%20%28ex.%3A%20Typebot%20dentro%20de%20um%20iframe%20com%20autentica%C3%A7%C3%A3o%20Cognito%29%2C%20a%20query%20string%20pode%20conter%20um%20JWT%20de%20v%C3%A1rios%20KB.%20Ao%20codific%C3%A1-lo%20em%20base64%20no%20par%C3%A2metro%20%60state%60%2C%20o%20header%20%60Location%60%20do%20redirect%20301%20ultrapassa%20o%20limite%20de%20headers%20do%20ingress%2Fproxy%20%E2%86%92%20o%20servidor%20retorna%20502%20diretamente%20para%20o%20usu%C3%A1rio%2C%20quebrando%20o%20fluxo%20de%20conex%C3%A3o%20com%20o%20Google%20Sheets.%20Este%20era%20exatamente%20o%20problema%20corrigido%20no%20PR%20%23227.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fbuilder%2Fsrc%2Fpages%2Fapi%2Fcredentials%2Fgoogle-sheets%2Fconsent-url.ts%3A22%0A**Valores%20array%20de%20%60req.query%60%20podem%20causar%20crash%20no%20callback**%0A%0AO%20Next.js%20normaliza%20par%C3%A2metros%20repetidos%20na%20query%20string%20como%20%60string%5B%5D%60.%20Se%20%60redirectUrl%60%20%28ou%20qualquer%20outro%20campo%20lido%20no%20callback%29%20aparecer%20mais%20de%20uma%20vez%20na%20URL%2C%20o%20%60state%60%20conter%C3%A1%20um%20array.%20No%20callback%20%28%60callback.ts%3A97%60%29%2C%20%60redirectUrl.split%28'%3F'%29%5B0%5D%60%20%C3%A9%20chamado%20sem%20verifica%C3%A7%C3%A3o%20de%20tipo%20%E2%80%94%20se%20%60redirectUrl%60%20for%20um%20array%2C%20a%20chamada%20a%20%60.split%60%20lan%C3%A7a%20%60TypeError%3A%20redirectUrl.split%20is%20not%20a%20function%60%2C%20causando%20um%20erro%20500%20n%C3%A3o%20tratado.%20O%20PR%20%23227%20prevenia%20isso%20normalizando%20cada%20campo%20com%20%60firstValue%28%29%60.%0A%0A&pr=228&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/builder/src/pages/api/credentials/google-sheets/consent-url.ts:19-23
**Re-introdução do erro 502 em modo incorporado (embedded)**

Este revert restaura a serialização de `req.query` completo como `state` do OAuth. Em modo incorporado (ex.: Typebot dentro de um iframe com autenticação Cognito), a query string pode conter um JWT de vários KB. Ao codificá-lo em base64 no parâmetro `state`, o header `Location` do redirect 301 ultrapassa o limite de headers do ingress/proxy → o servidor retorna 502 diretamente para o usuário, quebrando o fluxo de conexão com o Google Sheets. Este era exatamente o problema corrigido no PR #227.

### Issue 2 of 2
apps/builder/src/pages/api/credentials/google-sheets/consent-url.ts:22
**Valores array de `req.query` podem causar crash no callback**

O Next.js normaliza parâmetros repetidos na query string como `string[]`. Se `redirectUrl` (ou qualquer outro campo lido no callback) aparecer mais de uma vez na URL, o `state` conterá um array. No callback (`callback.ts:97`), `redirectUrl.split('?')[0]` é chamado sem verificação de tipo — se `redirectUrl` for um array, a chamada a `.split` lança `TypeError: redirectUrl.split is not a function`, causando um erro 500 não tratado. O PR #227 prevenia isso normalizando cada campo com `firstValue()`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;fix(google-sheets): stop seriali..."](https://github.com/cloudhumans/typebot.io/commit/3ad0eeb37d9c2d050bd456a5b1fe61ff585fbc28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37990142)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->