### PR TITLE
🐛bug: add default api token to jit-provisioned users

### DIFF
--- a/apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.test.ts
+++ b/apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.test.ts
@@ -66,6 +66,7 @@ describe('createCloudChatEmbeddedUser', () => {
         emailVerified: verifiedAt,
         image: undefined,
         onboardingCategories: [],
+        apiTokens: { create: { name: 'Default', token: expect.any(String) } },
       },
     })
     expect(user.email).toBe('maria@cliente.com')
@@ -82,16 +83,19 @@ describe('createCloudChatEmbeddedUser', () => {
         emailVerified: undefined,
         image: undefined,
         onboardingCategories: [],
+        apiTokens: { create: { name: 'Default', token: expect.any(String) } },
       },
     })
   })
 
-  it('does not create workspace, MemberInWorkspace or apiToken (no nested relations)', async () => {
+  it('creates a Default apiToken (preview auth) but no workspace or include', async () => {
     const p = buildPrismaMock()
     await createCloudChatEmbeddedUser({ p, email: 'no-side@local.test' })
 
     const callArg = p.user.create.mock.calls[0][0]
-    expect(callArg.data).not.toHaveProperty('apiTokens')
+    expect(callArg.data.apiTokens).toEqual({
+      create: { name: 'Default', token: expect.any(String) },
+    })
     expect(callArg.data).not.toHaveProperty('workspaces')
     expect(callArg).not.toHaveProperty('include')
   })

--- a/apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.test.ts
+++ b/apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.test.ts
@@ -96,6 +96,7 @@ describe('createCloudChatEmbeddedUser', () => {
     expect(callArg.data.apiTokens).toEqual({
       create: { name: 'Default', token: expect.any(String) },
     })
+    expect(callArg.data.apiTokens.create.token).toHaveLength(24)
     expect(callArg.data).not.toHaveProperty('workspaces')
     expect(callArg).not.toHaveProperty('include')
   })

--- a/apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.ts
+++ b/apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.ts
@@ -1,5 +1,5 @@
 import { PrismaClient, User } from '@typebot.io/prisma'
-import { generateId } from '@typebot.io/lib'
+import { randomBytes } from 'crypto'
 import { trackEvents } from '@typebot.io/telemetry/trackEvents'
 import logger from '@/helpers/logger'
 
@@ -25,7 +25,9 @@ export const createCloudChatEmbeddedUser = async ({
       emailVerified: emailVerified ?? undefined,
       image: image ?? undefined,
       onboardingCategories: [],
-      apiTokens: { create: { name: 'Default', token: generateId(24) } },
+      apiTokens: {
+        create: { name: 'Default', token: randomBytes(18).toString('base64url') },
+      },
     },
   })
 

--- a/apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.ts
+++ b/apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.ts
@@ -1,4 +1,5 @@
 import { PrismaClient, User } from '@typebot.io/prisma'
+import { generateId } from '@typebot.io/lib'
 import { trackEvents } from '@typebot.io/telemetry/trackEvents'
 import logger from '@/helpers/logger'
 
@@ -24,6 +25,7 @@ export const createCloudChatEmbeddedUser = async ({
       emailVerified: emailVerified ?? undefined,
       image: image ?? undefined,
       onboardingCategories: [],
+      apiTokens: { create: { name: 'Default', token: generateId(24) } },
     },
   })
 

--- a/apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.ts
+++ b/apps/builder/src/features/auth/helpers/createCloudChatEmbeddedUser.ts
@@ -1,5 +1,5 @@
 import { PrismaClient, User } from '@typebot.io/prisma'
-import { randomBytes } from 'crypto'
+import { generateId } from '@typebot.io/lib'
 import { trackEvents } from '@typebot.io/telemetry/trackEvents'
 import logger from '@/helpers/logger'
 
@@ -25,9 +25,7 @@ export const createCloudChatEmbeddedUser = async ({
       emailVerified: emailVerified ?? undefined,
       image: image ?? undefined,
       onboardingCategories: [],
-      apiTokens: {
-        create: { name: 'Default', token: randomBytes(18).toString('base64url') },
-      },
+      apiTokens: { create: { name: 'Default', token: generateId(24) } },
     },
   })
 


### PR DESCRIPTION
Usuários provisionados via JIT (login embedded no CloudChat e o caminho de API `?apiGateway=true` que o claudia-app usa pra listar workspaces) nasciam sem `ApiToken` Default. Isso quebra o botão "Test" do builder: o preview autentica contra o viewer por `Bearer` (token buscado em `/api/users/{id}/api-tokens`) e, sem token, o `startChatPreview` retorna 401 UNAUTHORIZED. O signup OAuth já criava esse token; o JIT não.

O fix cria o token Default no `createCloudChatEmbeddedUser`, cobrindo os dois fluxos JIT (ambos convergem nele: `cloudchatEmbeddedAuthorize` e `getAuthenticatedUser` via API gateway). Resolve o 401 na origem, sem depender de backfill recorrente.

Validado em produção: usuário sem token → 401 no Test; com token → funciona.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

A mudança é segura para merge: resolve um 401 real em produção adicionando a criação do token Default de forma atômica com o usuário JIT, sem alterar fluxos existentes.

O nested write `apiTokens: { create: ... }` é atômico com `user.create` — se a criação do usuário falhar, o token também não é criado. O fluxo OAuth preexistente não é afetado. Os testes cobrem todos os cenários relevantes: criação com todos os campos, sem campos opcionais, ausência de workspaces/include, propagação de erros do Prisma e resiliência do path de telemetria.

Nenhum arquivo requer atenção especial.

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Cliente (CloudChat / API Gateway)
    participant A as Auth Handler
    participant F as createCloudChatEmbeddedUser
    participant DB as Prisma / DB

    C->>A: Login request (email, name, …)
    A->>DB: Busca usuário por email
    alt Usuário não existe (JIT)
        A->>F: createCloudChatEmbeddedUser
        F->>DB: user.create com apiTokens nested write
        DB-->>F: User + ApiToken Default criados
        F-->>A: User
    else Usuário já existe
        DB-->>A: User existente
    end
    A-->>C: Sessão autenticada

    Note over C,DB: Botão Test do builder
    C->>A: GET /api/users/id/api-tokens
    A->>DB: Busca tokens do usuário
    DB-->>A: Bearer token Default
    A-->>C: Bearer token
    C->>C: startChatPreview com Authorization Bearer
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Cliente (CloudChat / API Gateway)
    participant A as Auth Handler
    participant F as createCloudChatEmbeddedUser
    participant DB as Prisma / DB

    C->>A: Login request (email, name, …)
    A->>DB: Busca usuário por email
    alt Usuário não existe (JIT)
        A->>F: createCloudChatEmbeddedUser
        F->>DB: user.create com apiTokens nested write
        DB-->>F: User + ApiToken Default criados
        F-->>A: User
    else Usuário já existe
        DB-->>A: User existente
    end
    A-->>C: Sessão autenticada

    Note over C,DB: Botão Test do builder
    C->>A: GET /api/users/id/api-tokens
    A->>DB: Busca tokens do usuário
    DB-->>A: Bearer token Default
    A-->>C: Bearer token
    C->>C: startChatPreview com Authorization Bearer
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["🔧maintenance: assert default token leng..."](https://github.com/cloudhumans/typebot.io/commit/f9154659244f574d20c504c7f04fda7343b68045) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38258753)</sub>

<!-- /greptile_comment -->