### PR TITLE
chore: fix typo 'occured' -> 'occurred' in sign-in error toast

### DIFF
--- a/apps/builder/src/features/auth/components/SignInForm.tsx
+++ b/apps/builder/src/features/auth/components/SignInForm.tsx
@@ -117,7 +117,7 @@ export const SignInForm = ({
     } catch (e) {
       showToast({
         status: 'info',
-        description: 'An error occured while signing in',
+        description: 'An error occurred while signing in',
       })
     }
     setAuthLoading(false)


### PR DESCRIPTION
## O que muda

Corrige a grafia `occured` → `occurred` na mensagem de erro do toast de sign-in (`SignInForm.tsx`).

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Mudança de uma única linha, corrigindo apenas a grafia de uma string de interface — sem lógica, sem dependências, sem efeitos colaterais.

A alteração toca exclusivamente o texto estático de uma mensagem de toast no bloco `catch` do fluxo de sign-in. Nenhuma lógica de autenticação, estado ou roteamento foi modificada.

Nenhum arquivo requer atenção especial.

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as Usuário
    participant F as SignInForm
    participant A as Auth Provider

    U->>F: Submete formulário de login
    F->>A: Tenta autenticar
    A-->>F: Lança exceção
    F->>U: Toast: "An error occurred while signing in"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as Usuário
    participant F as SignInForm
    participant A as Auth Provider

    U->>F: Submete formulário de login
    F->>A: Tenta autenticar
    A-->>F: Lança exceção
    F->>U: Toast: "An error occurred while signing in"
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix typo &#39;occured&#39; -&gt; &#39;occurred&#39; ..."](https://github.com/cloudhumans/typebot.io/commit/f0be0ca572695aad661a90733ac9b64218938adf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40168855)</sub>

<!-- /greptile_comment -->