### PR TITLE
ci: add release-candidate deploy workflow for typebot-instance2

### DIFF
--- a/.github/workflows/typebot-rc-instance2.yaml
+++ b/.github/workflows/typebot-rc-instance2.yaml
@@ -1,0 +1,145 @@
+name: Typebot RC — Instance2
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  AWS_REGION: us-east-1
+  ECR_BUILDER_REPOSITORY: typebot-builder
+  ECR_VIEWER_REPOSITORY: typebot-viewer
+  ECR_REGISTRY: 585814034319.dkr.ecr.us-east-1.amazonaws.com
+  MANIFESTS_REPO: cloudhumans/typebot.io-manifests
+  INSTANCE2_OVERLAY: deploy-k8s/overlays/typebot-instance2
+
+jobs:
+  rc-instance2:
+    if: ${{ github.event.label.name == 'release-candidate' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App installation token
+        id: app-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ vars.CLOUDHUMANS_VERSION_BOT_APP_ID }}
+          private_key: ${{ secrets.CLOUDHUMANS_VERSION_BOT_PRIVATE_KEY }}
+
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Export RC tag (PR head SHA)
+        run: echo "RC_TAG=$(git rev-parse HEAD)" >> $GITHUB_ENV
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_CI_EKS_PRODUCTION_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_CI_EKS_PRODUCTION_SECRET }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push BUILDER image
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_BUILDER_REPOSITORY:$RC_TAG --build-arg SCOPE=builder .
+          docker push $ECR_REGISTRY/$ECR_BUILDER_REPOSITORY:$RC_TAG
+
+      - name: Build, tag, and push VIEWER image
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_VIEWER_REPOSITORY:$RC_TAG --build-arg SCOPE=viewer .
+          docker push $ECR_REGISTRY/$ECR_VIEWER_REPOSITORY:$RC_TAG
+
+      - name: Install kustomize
+        run: |
+          curl -sfLo kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.1.1/kustomize_v4.1.1_linux_amd64.tar.gz \
+            && tar -xvf kustomize.tar.gz && chmod u+x kustomize
+          echo "KUSTOMIZE_CMD=$PWD/kustomize" >> $GITHUB_ENV
+
+      - name: Checkout manifests repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.MANIFESTS_REPO }}
+          path: manifests
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Point instance2 overlay at RC images & open PR
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          cd manifests
+          git config user.name "CloudHumans Version Bot"
+          git config user.email "cloudhumans-bot@users.noreply.github.com"
+
+          # Override images ONLY in the instance2 overlay (overlay > base).
+          # Prod overlay (deploy-k8s/overlays/typebot) keeps the base tag, untouched.
+          #
+          # The match key MUST be the resolved ECR repo name, NOT the
+          # `typebot-builder-image` placeholder: base/kustomization.yaml already
+          # rewrites the placeholder to the ECR name, so by the time this overlay's
+          # transformer runs the image is `<registry>/typebot-builder` — matching the
+          # placeholder here would be a silent no-op.
+          pushd "$INSTANCE2_OVERLAY"
+          "$KUSTOMIZE_CMD" edit set image \
+            "$ECR_REGISTRY/$ECR_BUILDER_REPOSITORY=$ECR_REGISTRY/$ECR_BUILDER_REPOSITORY:$RC_TAG" \
+            "$ECR_REGISTRY/$ECR_VIEWER_REPOSITORY=$ECR_REGISTRY/$ECR_VIEWER_REPOSITORY:$RC_TAG"
+          popd
+
+          BRANCH_NAME="rc/typebot-instance2/$RC_TAG"
+          PR_TITLE="chore: deploy RC $RC_TAG to typebot-instance2"
+          PR_BODY=$(cat <<EOF
+          Automated RC deploy to typebot-instance2.
+
+          Source PR: ${{ github.repository }}#${{ github.event.pull_request.number }} (${{ github.event.pull_request.title }})
+          Image tag: $RC_TAG
+
+          Builder: https://eddie-instance-2.us-east-1.prd.cloudhumans.io
+          Viewer:  https://eddieeyes-instance-2.us-east-1.prd.cloudhumans.io
+
+          After merge, Sync the 'typebot-instance2' app in ArgoCD (manual sync by design).
+          EOF
+          )
+
+          git checkout -B "$BRANCH_NAME"
+          git add -A
+          git commit -m "$PR_TITLE [skip ci]" --allow-empty
+          git push origin "$BRANCH_NAME" --force
+
+          export GH_TOKEN="$GITHUB_TOKEN"
+          gh pr create --repo "$MANIFESTS_REPO" --title "$PR_TITLE" --body "$PR_BODY" --base main --head "$BRANCH_NAME"
+
+          PR_NUMBER=""
+          for i in {1..5}; do
+            PR_NUMBER=$(gh pr view --repo "$MANIFESTS_REPO" "$BRANCH_NAME" --json number --jq '.number' 2>/dev/null || true)
+            [ -n "$PR_NUMBER" ] && break
+            sleep 2
+          done
+          [ -z "$PR_NUMBER" ] && { echo "PR number not found" >&2; exit 1; }
+
+          if gh pr merge --repo "$MANIFESTS_REPO" "$PR_NUMBER" --squash --delete-branch --admin --subject "$PR_TITLE"; then
+            echo "Manifests PR #$PR_NUMBER merged."
+          else
+            echo "Auto-merge blocked; PR #$PR_NUMBER left open." >&2
+          fi
+
+      - name: Comment test URLs on the source PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body \
+          "RC \`$RC_TAG\` pushed to **typebot-instance2**.
+          - Builder: https://eddie-instance-2.us-east-1.prd.cloudhumans.io
+          - Viewer:  https://eddieeyes-instance-2.us-east-1.prd.cloudhumans.io
+
+          Sync the \`typebot-instance2\` app in ArgoCD to roll it out (manual sync by design)."

--- a/.github/workflows/typebot-rc-instance2.yaml
+++ b/.github/workflows/typebot-rc-instance2.yaml
@@ -76,6 +76,12 @@ jobs:
       - name: Point instance2 overlay at RC images & open PR
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Pass the PR title through the environment instead of interpolating
+          # `${{ github.event.pull_request.title }}` straight into the script.
+          # The heredoc below is unquoted, so a title like `$(curl … | bash)`
+          # would otherwise run as a command substitution on the runner — with
+          # prod AWS creds and the GitHub App token in scope.
+          PR_TITLE_SAFE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail
           cd manifests
@@ -101,7 +107,7 @@ jobs:
           PR_BODY=$(cat <<EOF
           Automated RC deploy to typebot-instance2.
 
-          Source PR: ${{ github.repository }}#${{ github.event.pull_request.number }} (${{ github.event.pull_request.title }})
+          Source PR: ${{ github.repository }}#${{ github.event.pull_request.number }} ($PR_TITLE_SAFE)
           Image tag: $RC_TAG
 
           Builder: https://eddie-instance-2.us-east-1.prd.cloudhumans.io

--- a/.github/workflows/typebot-rc-instance2.yaml
+++ b/.github/workflows/typebot-rc-instance2.yaml
@@ -31,12 +31,16 @@ jobs:
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          # Pin to the head SHA captured in the event payload, not the branch
+          # name: `github.head_ref` resolves to the branch tip at checkout time,
+          # so a push between labeling and the runner starting would build a
+          # different commit than the one that was labeled for testing.
+          ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Export RC tag (PR head SHA)
-        run: echo "RC_TAG=$(git rev-parse HEAD)" >> $GITHUB_ENV
+        run: echo "RC_TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## What

Adds `.github/workflows/typebot-rc-instance2.yaml` — a label-triggered GitHub Actions workflow that ships any PR branch to the **typebot-instance2** live test environment.

Trigger: add the `release-candidate` label to a PR. The job then:

- Builds **builder** and **viewer** images from the PR head, tagged with the head SHA, and pushes them to ECR (`585814034319.dkr.ecr.us-east-1.amazonaws.com`).
- Opens and auto-merges a PR in `cloudhumans/typebot.io-manifests` that points **only** the `typebot-instance2` overlay at the RC images — prod overlay (`overlays/typebot`) stays on the base tag, untouched.
- Comments the test URLs back on the source PR.

Uses a GitHub App installation token (`CLOUDHUMANS_VERSION_BOT`) for cross-repo writes.

## Why

Lets a reviewer smoke-test a PR's actual built images on a real cluster before merge, without touching prod. The kustomize override matches the **resolved ECR repo name** (not the `typebot-builder-image` placeholder) — base rewrites the placeholder first, so a placeholder-keyed overlay entry would silently no-op.

After the manifests PR merges, the `typebot-instance2` app must be **manually synced** in ArgoCD (child apps have no automated sync, by design).

- Builder: https://eddie-instance-2.us-east-1.prd.cloudhumans.io
- Viewer: https://eddieeyes-instance-2.us-east-1.prd.cloudhumans.io

## Test

- [ ] Add the `release-candidate` label to a test PR; confirm the workflow builds + pushes both images to ECR.
- [ ] Confirm the auto-merged manifests PR overrides only the instance2 overlay (prod tag unchanged).
- [ ] Manually sync `typebot-instance2` in ArgoCD; verify builder/viewer test hosts serve the RC build.
- [ ] Confirm the test-URL comment lands on the source PR.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

O workflow é seguro para merge — opera exclusivamente sobre o overlay de instance2, sem tocar no overlay de produção, e todos os acessos cross-repo passam pelo GitHub App token com escopo controlado.

As correções críticas apontadas nas revisões anteriores (checkout fixado ao SHA do evento, título do PR passado via variável de ambiente para evitar injeção de script) estão presentes no código. O único ponto restante é a ausência de um grupo de concorrência, que já é uma característica do workflow de produção existente e foi deliberadamente mantida por consistência.

Nenhum arquivo requer atenção especial — `.github/workflows/typebot-rc-instance2.yaml` está bem alinhado com o precedente `typebot-gitops.yaml`.

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    actor Dev as Desenvolvedor
    participant GH as GitHub Actions
    participant ECR as Amazon ECR
    participant MR as cloudhumans/typebot.io-manifests
    participant ArgoCD as ArgoCD (instance2)

    Dev->>GH: Adiciona label release-candidate ao PR
    GH->>GH: Gera token via GitHub App (CLOUDHUMANS_VERSION_BOT)
    GH->>GH: Checkout do head SHA do PR (git ref fixo)
    GH->>ECR: docker build + push typebot-builder:RC_TAG
    GH->>ECR: docker build + push typebot-viewer:RC_TAG
    GH->>MR: Checkout do repo de manifests
    GH->>MR: kustomize edit set image (overlay typebot-instance2 apenas)
    GH->>MR: git push rc/typebot-instance2/RC_TAG --force
    GH->>MR: gh pr create
    GH->>MR: gh pr merge --squash --admin
    GH->>Dev: Comenta URLs de teste no PR original
    Dev->>ArgoCD: Sync manual do app typebot-instance2
    ArgoCD->>ECR: Pull das imagens RC_TAG
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    actor Dev as Desenvolvedor
    participant GH as GitHub Actions
    participant ECR as Amazon ECR
    participant MR as cloudhumans/typebot.io-manifests
    participant ArgoCD as ArgoCD (instance2)

    Dev->>GH: Adiciona label release-candidate ao PR
    GH->>GH: Gera token via GitHub App (CLOUDHUMANS_VERSION_BOT)
    GH->>GH: Checkout do head SHA do PR (git ref fixo)
    GH->>ECR: docker build + push typebot-builder:RC_TAG
    GH->>ECR: docker build + push typebot-viewer:RC_TAG
    GH->>MR: Checkout do repo de manifests
    GH->>MR: kustomize edit set image (overlay typebot-instance2 apenas)
    GH->>MR: git push rc/typebot-instance2/RC_TAG --force
    GH->>MR: gh pr create
    GH->>MR: gh pr merge --squash --admin
    GH->>Dev: Comenta URLs de teste no PR original
    Dev->>ArgoCD: Sync manual do app typebot-instance2
    ArgoCD->>ECR: Pull das imagens RC_TAG
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): pin RC checkout to PR head SHA ..."](https://github.com/cloudhumans/typebot.io/commit/6c481550916ecba3cd1f8c382fd03504a68b7f0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40536488)</sub>

<!-- /greptile_comment -->