### PR TITLE
fix(credentials): fix main build — add stable id when prefilling edit-modal rows

### DIFF
--- a/apps/builder/src/features/blocks/integrations/webhook/components/RestApiCredentialsModal.tsx
+++ b/apps/builder/src/features/blocks/integrations/webhook/components/RestApiCredentialsModal.tsx
@@ -23,6 +23,7 @@ import {
 } from '@chakra-ui/react'
 import { KeyValue } from '@typebot.io/schemas'
 import { isSafeBaseUrl } from '@typebot.io/schemas/features/blocks/integrations/webhook/urlHelpers'
+import { createId } from '@paralleldrive/cuid2'
 import React, { useEffect, useState } from 'react'
 import { HeadersInputs, QueryParamsInputs } from './KeyValueInputs'
 import { useTranslate } from '@tolgee/react'
@@ -105,8 +106,11 @@ export const RestApiCredentialsModal = ({
     if (!editingData) return
     setName(editingData.name)
     setBaseUrl(editingData.baseUrl)
-    setHeaders(editingData.headers)
-    setQueryParams(editingData.queryParams)
+    // TableList rows need a stable id; the masked credential arrives without one.
+    setHeaders(editingData.headers.map((h) => ({ id: createId(), ...h })))
+    setQueryParams(
+      editingData.queryParams.map((q) => ({ id: createId(), ...q }))
+    )
     setDeprecated(editingData.deprecatedAt !== null)
   }, [isOpen, isEditing, editingData])
 


### PR DESCRIPTION
## Why

`main`'s Docker build is red. `next build` (which runs ESLint **and** the type-check) fails:

```
./src/features/blocks/integrations/webhook/components/RestApiCredentialsModal.tsx:108
Type error: Argument of type '{ value: string; key: string }[]' is not assignable to
parameter of type 'SetStateAction<KeyValue[]>'. Property 'id' is missing … but required in KeyValue.
```

`getRestApiCredential` returns `{ key, value }[]`, but `TableList`'s `KeyValue` requires a stable `id`, so prefilling the edit modal with `setHeaders(editingData.headers)` / `setQueryParams(...)` is a type error.

This slipped through because the build-time type-check runs on **main merges only** (it's `skipping` on PR checks), and a stale local `@typebot.io/schemas` dist made `tsc` resolve a permissive `KeyValue` locally.

## Fix

Map the loaded rows through `createId()` on prefill so each row carries a stable id, exactly as `TableList` expects.

## Verification

- Rebuilt `@typebot.io/schemas` and re-ran `tsc` — clean.
- Ran the real `next build`: the **"Linting and checking validity of types"** phase now passes (advances to "Creating an optimized production build"). The only remaining local failure is an unrelated `date-fns/locale` module-resolution artifact of the local env, which resolves correctly in CI.
- Monorepo `lint` + `format:check` clean (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

A alteração é mínima e isolada: duas linhas de map() no prefill do modal de edição, sem tocar em lógica de persistência ou validação.

O fix resolve exatamente o erro reportado — o tRPC endpoint confirma que headers/queryParams nunca chegam undefined (o server usa ?? []), toDataEntries descarta os IDs antes do submit, e o TableList recebe o tipo correto. Não há lógica nova, sem risco de regressão em outros fluxos.

Nenhum arquivo requer atenção adicional — a mudança está contida em RestApiCredentialsModal.tsx e não afeta endpoints, schemas ou outros componentes.

<sub>Reviews (1): Last reviewed commit: ["fix(credentials): add stable id when pre..."](https://github.com/cloudhumans/typebot.io/commit/03c197ec9f5e2d3e5ec3eaafdab312908f0da03b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40599103)</sub>

<!-- /greptile_comment -->