### PR TITLE
fix(validation): clear lingering secondary-flow alert icon on group nodes

### DIFF
--- a/apps/builder/src/features/editor/components/BoardMenuButton.tsx
+++ b/apps/builder/src/features/editor/components/BoardMenuButton.tsx
@@ -126,28 +126,15 @@ const ValidationErrorsButton = () => {
     return () => clearTimeout(timeoutRef.current)
   }, [isValidating])
 
-  const { typebot } = useTypebot()
-
   const getTotalErrorCount = () => {
     if (!validationErrors) return 0
 
-    const isSecondaryFlow = typebot?.isSecondaryFlow ?? false
-
     // The red badge reflects blocking errors only; 'warning' items (e.g.
     // deprecated credentials) are surfaced in the drawer / group icon instead.
-    const blockingErrors = validationErrors.errors.filter(
+    // Secondary-flow-only errors are already suppressed at validation time.
+    return validationErrors.errors.filter(
       (error) => (error.severity ?? 'error') === 'error'
-    )
-
-    if (isSecondaryFlow) {
-      return blockingErrors.filter(
-        (error) =>
-          error.type !== 'missingTextBeforeClaudia' &&
-          error.type !== 'missingClaudiaInFlowBranches'
-      ).length
-    }
-
-    return blockingErrors.length
+    ).length
   }
 
   const totalErrors = getTotalErrorCount()

--- a/apps/builder/src/features/editor/hooks/useValidation.ts
+++ b/apps/builder/src/features/editor/hooks/useValidation.ts
@@ -22,6 +22,7 @@ export const useValidation = () => {
       settings: Settings | undefined
       workspaceId?: string
       whatsAppCredentialsId?: string | null
+      isSecondaryFlow?: boolean
     }): Promise<ValidationError | null> => {
       setIsValidating(true)
       try {

--- a/apps/builder/src/features/editor/providers/EditorProvider.tsx
+++ b/apps/builder/src/features/editor/providers/EditorProvider.tsx
@@ -27,6 +27,7 @@ type MinimalTypebot = Pick<
   | 'settings'
   | 'workspaceId'
   | 'whatsAppCredentialsId'
+  | 'isSecondaryFlow'
 >
 
 export enum RightPanel {
@@ -185,7 +186,7 @@ export const EditorProvider = ({ children }: { children: ReactNode }) => {
     const newVariablesValidationKey = JSON.stringify(typebot.variables)
     const newValidationKey = `${newGroupsValidationKey}-${newEdgesValidationKey}-${newSettingsValidationKey}-${newVariablesValidationKey}-${
       typebot.whatsAppCredentialsId ?? ''
-    }`
+    }-${typebot.isSecondaryFlow ?? false}`
 
     if (newValidationKey === validationKey) return
 
@@ -198,6 +199,7 @@ export const EditorProvider = ({ children }: { children: ReactNode }) => {
       settings: typebot.settings,
       workspaceId: typebot.workspaceId,
       whatsAppCredentialsId: typebot.whatsAppCredentialsId,
+      isSecondaryFlow: typebot.isSecondaryFlow,
     }
     queuedValidateTypebot(minimalTypebot)
   }, [
@@ -208,6 +210,7 @@ export const EditorProvider = ({ children }: { children: ReactNode }) => {
     typebot?.settings,
     typebot?.workspaceId,
     typebot?.whatsAppCredentialsId,
+    typebot?.isSecondaryFlow,
     queuedValidateTypebot,
   ])
 
@@ -222,6 +225,7 @@ export const EditorProvider = ({ children }: { children: ReactNode }) => {
       settings: typebot.settings,
       workspaceId: typebot.workspaceId,
       whatsAppCredentialsId: typebot.whatsAppCredentialsId,
+      isSecondaryFlow: typebot.isSecondaryFlow,
     })
   }, [typebot, queuedValidateTypebot])
 

--- a/apps/builder/src/features/preview/components/ValidationErrorsDrawer.tsx
+++ b/apps/builder/src/features/preview/components/ValidationErrorsDrawer.tsx
@@ -159,19 +159,10 @@ export const ValidationErrorsDrawer = ({ onClose }: Props) => {
 
     // Count blocking errors only; non-blocking warnings (e.g. deprecated
     // credentials) render in their own section but don't inflate the red count.
-    const blockingErrors = validationErrors.errors.filter(
+    // Secondary-flow-only errors are already suppressed at validation time.
+    return validationErrors.errors.filter(
       (error) => (error.severity ?? 'error') === 'error'
-    )
-
-    if (isSecondaryFlow) {
-      return blockingErrors.filter(
-        (error) =>
-          error.type !== 'missingTextBeforeClaudia' &&
-          error.type !== 'missingClaudiaInFlowBranches'
-      ).length
-    }
-
-    return blockingErrors.length
+    ).length
   }
 
   const navigateToGroup = (groupId: string) => {
@@ -339,15 +330,6 @@ export const ValidationErrorsDrawer = ({ onClose }: Props) => {
           ) : (
             <>
               {Object.entries(ERROR_CONFIGS).map(([errorType, config]) => {
-                if (
-                  isSecondaryFlow &&
-                  (errorType === 'missingTextBeforeClaudia' ||
-                    errorType === 'missingClaudiaInFlowBranches' ||
-                    errorType === 'missingWorkflowEndInFlowBranches')
-                ) {
-                  return null
-                }
-
                 const filteredErrors = errorsWithGroup.filter(
                   (error) => error.type === errorType
                 )


### PR DESCRIPTION
## Problem

Marking a flow as **secondary** suppressed the "missing ClaudIA / flow-branch" warnings in the validation drawer and the header badge, but the **alert icon stayed on the last block** (group node). Worse, because that lingering error is `error`-severity, it overrode the amber **deprecated-credential** warning on the same group.

## Root cause

The editor validated **without** passing `isSecondaryFlow`, so the secondary-flow-only errors (`missingClaudiaInFlowBranches`, `missingTextBeforeClaudia`, `missingWorkflowEndInFlowBranches`) were still generated. They were then filtered out **only at display time** in two places (the drawer and `BoardMenuButton`). `GroupNode` reads `validationErrors.errors` directly — with no such filter — so its icon never cleared. Three inconsistent suppression sites; the group icon was the one left out.

## Fix (suppress once, at the source)

- Thread `isSecondaryFlow` (already accepted by the `postTypebotValidation` procedure) from the editor into validation: `useValidation`'s input type + both `EditorProvider` validation calls, and re-validate when the flag toggles (added to the validation key + effect deps).
- Remove the now-dead secondary-flow display filters in `ValidationErrorsDrawer` and `BoardMenuButton`. With suppression at the source, every site (drawer, badge, **group icon**) consumes the same already-correct error list.

Result: in a secondary flow the icon clears, and a group whose only issue is a deprecated credential now correctly shows the amber warning icon.

## Verification

- `tsc` + monorepo `lint`/`format:check` clean.
- Ran the real `next build` — the type-check phase passes (the gate that's skipped on PRs and only runs on main merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# erro
<img width="2109" height="1307" alt="image" src="https://github.com/user-attachments/assets/14540e3f-9ab1-4dab-8002-1333db08d7d0" />

# correção
<img width="1280" height="796" alt="image" src="https://github.com/user-attachments/assets/38eb9458-e639-491f-86c6-925824a77034" />


<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

A mudança é cirúrgica e corrige um bug de exibição real sem alterar lógica de negócio ou persistência de dados.

Todas as quatro alterações são coerentes: a supressão de erros é movida para a origem (servidor), o flag agora é incluído na chave de validação e nas deps do efeito, e os filtros client-side redundantes são removidos de forma consistente. Nenhum caminho crítico de dados ou autenticação é tocado.

Nenhum arquivo exige atenção especial; as mudanças são pequenas e localizadas nos quatro arquivos alterados.

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as Usuário
    participant D as ValidationErrorsDrawer
    participant TP as TypebotProvider
    participant EP as EditorProvider
    participant UV as useValidation
    participant S as Servidor (postTypebotValidation)

    U->>D: Alterna toggle "Fluxo Secundário"
    D->>TP: "updateTypebot({ isSecondaryFlow: true, save: true })"
    TP-->>EP: typebot.isSecondaryFlow atualizado
    Note over EP: validationKey muda (inclui isSecondaryFlow)
    EP->>UV: "queuedValidateTypebot({ ..., isSecondaryFlow: true })"
    UV->>S: "mutateAsync({ typebot: { ..., isSecondaryFlow: true } })"
    S-->>UV: ValidationError (erros de fluxo secundário já suprimidos)
    UV-->>EP: setValidationErrors(resultado filtrado)
    EP-->>D: validationErrors atualizado
    EP-->>D: BoardMenuButton badge atualizado
    Note over D: GroupNode também lê validationErrors diretamente — ícone limpo
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as Usuário
    participant D as ValidationErrorsDrawer
    participant TP as TypebotProvider
    participant EP as EditorProvider
    participant UV as useValidation
    participant S as Servidor (postTypebotValidation)

    U->>D: Alterna toggle "Fluxo Secundário"
    D->>TP: "updateTypebot({ isSecondaryFlow: true, save: true })"
    TP-->>EP: typebot.isSecondaryFlow atualizado
    Note over EP: validationKey muda (inclui isSecondaryFlow)
    EP->>UV: "queuedValidateTypebot({ ..., isSecondaryFlow: true })"
    UV->>S: "mutateAsync({ typebot: { ..., isSecondaryFlow: true } })"
    S-->>UV: ValidationError (erros de fluxo secundário já suprimidos)
    UV-->>EP: setValidationErrors(resultado filtrado)
    EP-->>D: validationErrors atualizado
    EP-->>D: BoardMenuButton badge atualizado
    Note over D: GroupNode também lê validationErrors diretamente — ícone limpo
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(validation): suppress secondary-flow..."](https://github.com/cloudhumans/typebot.io/commit/fd131fa23f3a9c76cfbc2eb4eab31ef4d8a9bd40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40610861)</sub>

<!-- /greptile_comment -->