### PR TITLE
fix(credentials): readable 'deprecate' box in dark mode

### DIFF
--- a/apps/builder/src/features/blocks/integrations/webhook/components/RestApiCredentialsModal.tsx
+++ b/apps/builder/src/features/blocks/integrations/webhook/components/RestApiCredentialsModal.tsx
@@ -20,6 +20,7 @@ import {
   Spinner,
   HStack,
   Switch,
+  useColorModeValue,
 } from '@chakra-ui/react'
 import { KeyValue } from '@typebot.io/schemas'
 import { isSafeBaseUrl } from '@typebot.io/schemas/features/blocks/integrations/webhook/urlHelpers'
@@ -183,6 +184,13 @@ export const RestApiCredentialsModal = ({
       handleClose()
     },
   })
+
+  // Warning-box palette, dark-mode-aware to match the validation drawer's
+  // amber sections (a fixed orange.50 bg is unreadable in dark mode).
+  const deprecateBoxBg = useColorModeValue('orange.50', 'orange.900')
+  const deprecateBoxBorder = useColorModeValue('orange.200', 'orange.700')
+  const deprecateTitleColor = useColorModeValue('orange.700', 'orange.200')
+  const deprecateSubColor = useColorModeValue('gray.600', 'gray.300')
 
   const isBaseUrlInvalid = baseUrl.trim() !== '' && !isSafeBaseUrl(baseUrl)
 
@@ -371,17 +379,21 @@ export const RestApiCredentialsModal = ({
                     justify="space-between"
                     p="3"
                     borderWidth="1px"
-                    borderColor="orange.200"
-                    bg="orange.50"
+                    borderColor={deprecateBoxBorder}
+                    bg={deprecateBoxBg}
                     rounded="md"
                   >
                     <Stack spacing="0">
-                      <Text fontWeight="medium" fontSize="sm">
+                      <Text
+                        fontWeight="medium"
+                        fontSize="sm"
+                        color={deprecateTitleColor}
+                      >
                         {t(
                           'blocks.integrations.httpRequest.credentialsModal.deprecateToggle.label'
                         )}
                       </Text>
-                      <Text fontSize="xs" color="gray.600">
+                      <Text fontSize="xs" color={deprecateSubColor}>
                         {t(
                           'blocks.integrations.httpRequest.credentialsModal.deprecateToggle.sub'
                         )}


### PR DESCRIPTION
## Problem

In dark mode, the **"Mark as deprecated"** box in the REST credential edit modal was unreadable: a fixed `orange.50` (light cream) background with no explicit text color, so the theme's light default text sat on a light background.

(see the reported screenshot — faint title on a cream box)

## Fix

Make the box dark-mode-aware with `useColorModeValue`, mirroring the validation drawer's amber warning sections (the established warning-box pattern):

| token | light | dark |
|---|---|---|
| bg | `orange.50` | `orange.900` |
| border | `orange.200` | `orange.700` |
| title | `orange.700` | `orange.200` |
| sub | `gray.600` | `gray.300` |

Keeps the amber "warning" semantics while staying legible in both themes.

## Verification
- `tsc` + monorepo `lint`/`format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Alteração cosmética de baixo risco, limitada a tokens de cor no modo escuro de um único componente.

A mudança substitui quatro valores de cor fixos por variáveis cientes do tema usando o hook padrão do Chakra UI. Não há lógica de negócio, estado ou efeitos colaterais envolvidos — apenas melhoria de acessibilidade visual.

Nenhum arquivo requer atenção especial.

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[RestApiCredentialsModal renderiza] --> B{isEditing?}
    B -- Não --> C[Caixa deprecate não exibida]
    B -- Sim --> D[Renderiza HStack da caixa deprecate]
    D --> E[useColorModeValue resolve tokens]
    E --> F{Modo atual}
    F -- Light --> G["bg=orange.50 | border=orange.200 | title=orange.700 | sub=gray.600"]
    F -- Dark --> H["bg=orange.900 | border=orange.700 | title=orange.200 | sub=gray.300"]
    G --> I[Caixa legível no modo claro]
    H --> J[Caixa legível no modo escuro]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[RestApiCredentialsModal renderiza] --> B{isEditing?}
    B -- Não --> C[Caixa deprecate não exibida]
    B -- Sim --> D[Renderiza HStack da caixa deprecate]
    D --> E[useColorModeValue resolve tokens]
    E --> F{Modo atual}
    F -- Light --> G["bg=orange.50 | border=orange.200 | title=orange.700 | sub=gray.600"]
    F -- Dark --> H["bg=orange.900 | border=orange.700 | title=orange.200 | sub=gray.300"]
    G --> I[Caixa legível no modo claro]
    H --> J[Caixa legível no modo escuro]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(credentials): make the &quot;deprecate&quot; b..."](https://github.com/cloudhumans/typebot.io/commit/1bacf389190e4d3cdbff9419e8f1a1d2e8e6a733) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40618436)</sub>

<!-- /greptile_comment -->