### PR TITLE
fix(credentials): fixed scroll height for the in-use flow list

### DIFF
--- a/apps/builder/src/features/credentials/components/CredentialInUseModal.tsx
+++ b/apps/builder/src/features/credentials/components/CredentialInUseModal.tsx
@@ -105,7 +105,9 @@ export const CredentialInUseModal = ({
       isCentered
     >
       <ModalOverlay />
-      <ModalContent borderRadius="xl">
+      {/* Stop wheel from reaching the flow-editor canvas, which preventDefaults
+          it for zoom/pan and would otherwise block scrolling inside the modal. */}
+      <ModalContent borderRadius="xl" onWheel={(e) => e.stopPropagation()}>
         <ModalHeader pb={2}>
           <HStack spacing={4} align="flex-start">
             <Flex

--- a/apps/builder/src/features/credentials/components/CredentialInUseModal.tsx
+++ b/apps/builder/src/features/credentials/components/CredentialInUseModal.tsx
@@ -156,8 +156,7 @@ export const CredentialInUseModal = ({
           </Text>
 
           <Box
-            flex={1}
-            minH={0}
+            maxH="280px"
             overflowY="auto"
             bg={cardBg}
             border="1px solid"


### PR DESCRIPTION
## What

Gives the impacted-flows list in `CredentialInUseModal` a fixed scroll height (`maxH=280px`) instead of `flex={1}`.

## Root cause (confirmed against the running builder)

I ran the real app (auth + the actual modal, with a credential used by 5 flows) and inspected the DOM:

- `scrollBehavior="inside"` **does** cap the modal correctly (`.chakra-modal__content` gets `max-height: calc(100% - 7.5rem)`), and the body + list both have `overflow-y: auto`. The scroll plumbing was never broken.
- The list used `flex={1}`, so its height tracked the viewport:
  - **tall viewport (900px):** list got 298px and the 5 rows (298px) fit exactly → `scrollHeight == clientHeight` → **no scrollbar**. That's the "scroll doesn't work" report: there was nothing to overflow.
  - **short viewport (700px):** list shrank to 133px and scrolled fine.
  - On very short viewports it collapsed to ~33px (unusable).

## Fix

`maxH="280px"` (≈4 rows) + `overflowY="auto"`, dropping `flex={1}`. The list is now a consistent window that scrolls from the 5th flow onward regardless of viewport — matching the design mock. Verified at 900px: `clientHeight=278, scrollHeight=298 → scrolls`.

## Note (out of scope)

The credential **edit** modal (`RestApiCredentialsModal`) has no `scrollBehavior`, so it grows unbounded on short viewports. Happy to follow up if you want it capped too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Mudança cirúrgica de UI sem efeitos colaterais — segura para merge.

A alteração toca apenas o layout da lista de fluxos dentro do modal e a propagação de eventos de roda; não modifica lógica de negócio, chamadas de API ou estado global. O `stopPropagation` é aplicado ao contêiner do modal, limitando seu escopo, e a troca de `flex={1}` por `maxH="280px"` é direta e verificada contra o comportamento real do app.

Nenhum arquivo requer atenção especial.

<sub>Reviews (2): Last reviewed commit: ["fix(credentials): stop the flow-editor c..."](https://github.com/cloudhumans/typebot.io/commit/0bde407334371dbfa209c410cd9814e499326ba9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40916251)</sub>

<!-- /greptile_comment -->