### PR TITLE
fix(credentials): pre-check usages before delete (no console 412)

### DIFF
--- a/apps/builder/src/features/blocks/integrations/webhook/components/RestApiCredentialsModal.tsx
+++ b/apps/builder/src/features/blocks/integrations/webhook/components/RestApiCredentialsModal.tsx
@@ -249,13 +249,43 @@ export const RestApiCredentialsModal = ({
     })
   }
 
-  const handleDelete = () => {
+  const handleDelete = async () => {
     if (!workspace || !editingCredentialsId) return
-    deleteMutation.mutate({
-      workspaceId: workspace.id,
-      credentialsId: editingCredentialsId,
-      currentTypebotId: typebot?.id,
-    })
+    setIsDeleting(true)
+    try {
+      // Read-only pre-check so an in-use credential opens the modal without a
+      // failed delete (412) in the console. Mirrors deleteCredentials' guard:
+      // a usage only from the current flow's draft block doesn't block.
+      const { usages } =
+        await trpcContext.credentials.getCredentialsUsages.fetch({
+          workspaceId: workspace.id,
+          credentialsId: editingCredentialsId,
+        })
+      const blockingUsages = usages.filter(
+        (u) =>
+          !(
+            u.source === 'Typebot' &&
+            u.via === 'block' &&
+            u.typebotId === typebot?.id
+          )
+      )
+      if (blockingUsages.length > 0) {
+        setIsDeleting(false)
+        setInUseModalState({ variant: 'delete', usages: blockingUsages })
+        return
+      }
+      // No blocking usage now: delete. The mutation re-checks atomically, so a
+      // usage that appears between this check and the delete still 412s and
+      // re-opens the modal via onError (keeping the user in the delete flow).
+      deleteMutation.mutate({
+        workspaceId: workspace.id,
+        credentialsId: editingCredentialsId,
+        currentTypebotId: typebot?.id,
+      })
+    } catch (error) {
+      setIsDeleting(false)
+      showToast({ description: (error as Error).message, status: 'error' })
+    }
   }
 
   const showLoader = isEditing && isLoadingCredential

--- a/apps/builder/src/features/blocks/integrations/webhook/components/RestApiCredentialsModal.tsx
+++ b/apps/builder/src/features/blocks/integrations/webhook/components/RestApiCredentialsModal.tsx
@@ -27,7 +27,7 @@ import {
 import { KeyValue } from '@typebot.io/schemas'
 import { isSafeBaseUrl } from '@typebot.io/schemas/features/blocks/integrations/webhook/urlHelpers'
 import { createId } from '@paralleldrive/cuid2'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { HeadersInputs, QueryParamsInputs } from './KeyValueInputs'
 import { useTranslate } from '@tolgee/react'
 import { MoreInfoTooltip } from '@/components/MoreInfoTooltip'
@@ -65,6 +65,13 @@ export const RestApiCredentialsModal = ({
   const { typebot } = useTypebot()
   const { showToast } = useToast()
   const isEditing = !!editingCredentialsId
+
+  // Tracks the latest open state so async work (the pre-delete usages check)
+  // can bail if the user closes the modal while it's in flight.
+  const isOpenRef = useRef(isOpen)
+  useEffect(() => {
+    isOpenRef.current = isOpen
+  }, [isOpen])
   const [name, setName] = useState('')
   const [baseUrl, setBaseUrl] = useState('')
   const [headers, setHeaders] = useState<KeyValue[]>([])
@@ -261,6 +268,12 @@ export const RestApiCredentialsModal = ({
           workspaceId: workspace.id,
           credentialsId: editingCredentialsId,
         })
+      // The user may have closed the modal while the check was in flight —
+      // don't reopen it or fire the delete against a dismissed modal.
+      if (!isOpenRef.current) {
+        setIsDeleting(false)
+        return
+      }
       const blockingUsages = usages.filter(
         (u) =>
           !(
@@ -284,7 +297,10 @@ export const RestApiCredentialsModal = ({
       })
     } catch (error) {
       setIsDeleting(false)
-      showToast({ description: (error as Error).message, status: 'error' })
+      showToast({
+        description: error instanceof Error ? error.message : String(error),
+        status: 'error',
+      })
     }
   }
 

--- a/apps/builder/src/features/credentials/api/getCredentialsUsages.ts
+++ b/apps/builder/src/features/credentials/api/getCredentialsUsages.ts
@@ -2,13 +2,17 @@ import prisma from '@typebot.io/lib/prisma'
 import { authenticatedProcedure } from '@/helpers/server/trpc'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
-import { isReadWorkspaceFobidden } from '@/features/workspace/helpers/isReadWorkspaceFobidden'
+import { isWriteWorkspaceForbidden } from '@/features/workspace/helpers/isWriteWorkspaceForbidden'
+import { isAdminWriteWorkspaceForbidden } from '@/features/workspace/helpers/isAdminWriteWorkspaceForbidden'
 import { findCredentialsUsages } from '@typebot.io/lib/credentials/findCredentialsUsages'
 
 // Read-only counterpart of the deleteCredentials in-use guard: lets the client
 // learn whether a credential is referenced *before* attempting a delete, so the
 // in-use modal can open without a failed (412) request polluting the console.
-// The mutation still re-checks atomically, so this is only a UX pre-check.
+// The mutation still re-checks atomically, so this is only a UX pre-check —
+// but it must match deleteCredentials' authorization (write access, plus the
+// admin gate for rest-api) so it never reveals usages to someone who couldn't
+// delete the credential anyway.
 export const getCredentialsUsages = authenticatedProcedure
   .input(
     z.object({
@@ -21,8 +25,21 @@ export const getCredentialsUsages = authenticatedProcedure
       where: { id: workspaceId },
       select: { id: true, members: true },
     })
-    if (!workspace || isReadWorkspaceFobidden(workspace, user))
+    if (!workspace || isWriteWorkspaceForbidden(workspace, user))
       throw new TRPCError({ code: 'NOT_FOUND', message: 'Workspace not found' })
+
+    const credential = await prisma.credentials.findFirst({
+      where: { id: credentialsId, workspaceId },
+      select: { type: true },
+    })
+    if (
+      credential?.type === 'rest-api' &&
+      isAdminWriteWorkspaceForbidden(workspace, user)
+    )
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Only workspace admins can manage this credential',
+      })
 
     const usages = await findCredentialsUsages(credentialsId, workspaceId)
     return { usages }

--- a/apps/builder/src/features/credentials/api/getCredentialsUsages.ts
+++ b/apps/builder/src/features/credentials/api/getCredentialsUsages.ts
@@ -1,0 +1,29 @@
+import prisma from '@typebot.io/lib/prisma'
+import { authenticatedProcedure } from '@/helpers/server/trpc'
+import { TRPCError } from '@trpc/server'
+import { z } from 'zod'
+import { isReadWorkspaceFobidden } from '@/features/workspace/helpers/isReadWorkspaceFobidden'
+import { findCredentialsUsages } from '@typebot.io/lib/credentials/findCredentialsUsages'
+
+// Read-only counterpart of the deleteCredentials in-use guard: lets the client
+// learn whether a credential is referenced *before* attempting a delete, so the
+// in-use modal can open without a failed (412) request polluting the console.
+// The mutation still re-checks atomically, so this is only a UX pre-check.
+export const getCredentialsUsages = authenticatedProcedure
+  .input(
+    z.object({
+      workspaceId: z.string(),
+      credentialsId: z.string(),
+    })
+  )
+  .query(async ({ input: { workspaceId, credentialsId }, ctx: { user } }) => {
+    const workspace = await prisma.workspace.findFirst({
+      where: { id: workspaceId },
+      select: { id: true, members: true },
+    })
+    if (!workspace || isReadWorkspaceFobidden(workspace, user))
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Workspace not found' })
+
+    const usages = await findCredentialsUsages(credentialsId, workspaceId)
+    return { usages }
+  })

--- a/apps/builder/src/features/credentials/api/router.ts
+++ b/apps/builder/src/features/credentials/api/router.ts
@@ -4,6 +4,7 @@ import { updateCredentials } from './updateCredentials'
 import { deleteCredentials } from './deleteCredentials'
 import { listCredentials } from './listCredentials'
 import { getRestApiCredential } from './getRestApiCredential'
+import { getCredentialsUsages } from './getCredentialsUsages'
 
 export const credentialsRouter = router({
   createCredentials,
@@ -11,4 +12,5 @@ export const credentialsRouter = router({
   listCredentials,
   deleteCredentials,
   getRestApiCredential,
+  getCredentialsUsages,
 })


### PR DESCRIPTION
## Problem

Clicking **Remove credential** on an in-use credential fired a no-force `credentials.deleteCredentials`, which the server rejects with **412 PRECONDITION_FAILED** to return the list of referencing flows. Chrome logs that failed request in the console on every open (`RestApiCredentialsModal.tsx:254 … 412`).

## Fix

Add a read-only `credentials.getCredentialsUsages` query (mirrors the delete guard's `findCredentialsUsages`, read-access checked). On **Remove credential**:

1. Pre-check usages with the query (a normal `200`, no failed request).
2. If the credential is referenced → open the in-use modal directly.
3. If not → run the no-force delete.

**Re-check is preserved:** the no-force delete still runs server-side inside its transaction, so a usage that appears *between* the pre-check and the delete still 412s and `onError` re-opens the in-use modal — the user stays in the deletion flow (with "Remove anyway"). The 412 path now only fires in that genuine race, not on every open.

## Verified on the running app (Playwright)

Clicking Remove on a credential used by 5 flows:
- network: only `200 credentials.getCredentialsUsages` (no `deleteCredentials`, no 412)
- in-use modal opens: ✅

## Scope note

Only the **delete** path is moved to the pre-check here. The **save**-while-published path (`updateCredentials` 412 → `variant: 'save'` modal) uses the same pattern and could get the same treatment in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

O PR é seguro para merge — adiciona apenas um endpoint read-only e refatora o fluxo de pré-check do cliente sem alterar a lógica de deleção do servidor.

A autorização do novo endpoint espelha exatamente o deleteCredentials (write + gate de admin para rest-api). O filtro client-side de blockingUsages é idêntico ao filtro server-side. A race condition é coberta pelo re-check atômico do servidor em transação RepeatableRead. Nenhuma regressão no caminho crítico de deleção.

Nenhum arquivo requer atenção especial.

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as Usuário
    participant C as RestApiCredentialsModal
    participant S as Server (tRPC)

    U->>C: Clica em "Remove credential"
    C->>C: setIsDeleting(true)
    C->>S: getCredentialsUsages.fetch() [200 OK]
    S-->>C: "{ usages }"
    
    alt Modal foi fechado durante o fetch
        C->>C: "isOpenRef.current === false → setIsDeleting(false), return"
    else Há blockingUsages
        C->>C: setIsDeleting(false)
        C->>U: Abre CredentialInUseModal (sem 412 no console)
        U->>C: Confirma "Remove anyway"
        C->>S: "deleteCredentials({ force: true })"
        S-->>C: 200 OK (deletado)
    else Sem blockingUsages
        C->>S: "deleteCredentials({ force: false })"
        alt Race condition: uso apareceu entre pré-check e delete
            S-->>C: 412 PRECONDITION_FAILED (onError)
            C->>U: Reabre CredentialInUseModal
        else Sem uso
            S-->>C: 200 OK
            C->>C: handleClose(), onDeleted()
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as Usuário
    participant C as RestApiCredentialsModal
    participant S as Server (tRPC)

    U->>C: Clica em "Remove credential"
    C->>C: setIsDeleting(true)
    C->>S: getCredentialsUsages.fetch() [200 OK]
    S-->>C: "{ usages }"
    
    alt Modal foi fechado durante o fetch
        C->>C: "isOpenRef.current === false → setIsDeleting(false), return"
    else Há blockingUsages
        C->>C: setIsDeleting(false)
        C->>U: Abre CredentialInUseModal (sem 412 no console)
        U->>C: Confirma "Remove anyway"
        C->>S: "deleteCredentials({ force: true })"
        S-->>C: 200 OK (deletado)
    else Sem blockingUsages
        C->>S: "deleteCredentials({ force: false })"
        alt Race condition: uso apareceu entre pré-check e delete
            S-->>C: 412 PRECONDITION_FAILED (onError)
            C->>U: Reabre CredentialInUseModal
        else Sem uso
            S-->>C: 200 OK
            C->>C: handleClose(), onDeleted()
        end
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(credentials): address bot review on ..."](https://github.com/cloudhumans/typebot.io/commit/dbff2acde4fcb281913339d02ba8dd91b8e58cb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40925645)</sub>

<!-- /greptile_comment -->