### PR TITLE
fix(credentials): no button-in-button in the credential dropdown

### DIFF
--- a/apps/builder/src/features/credentials/components/CredentialsDropdown.tsx
+++ b/apps/builder/src/features/credentials/components/CredentialsDropdown.tsx
@@ -197,6 +197,7 @@ export const CredentialsDropdown = ({
             )}
             {sortedCredentials.map((credentials) => (
               <MenuItem
+                as="div"
                 role="menuitem"
                 minH="40px"
                 key={credentials.id}


### PR DESCRIPTION
## Problem

Opening the HTTP block's credential dropdown logged a React `validateDOMNesting` warning: each credential row is a `MenuItem` (rendered as `<button>`) that contains the edit/delete `IconButton` — a `<button>` inside a `<button>`.

## Fix

Render that `MenuItem` as `as="div"`. Chakra's `useMenuItem` still applies `role=menuitem`, keyboard handling and the row `onClick`, so behavior is unchanged while the inner `IconButton`s become valid nesting.

## Verified on the running app (Playwright)

Opening the dropdown:
- `document.querySelectorAll('button button').length` → **0**
- no `validateDOMNesting` console warnings
- clicking **Edit credential** still opens the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Mudança de uma linha, bem delimitada ao componente de dropdown de credenciais, sem risco de regressão perceptível.

A troca de `button` para `div` no `MenuItem` é o padrão recomendado pelo Chakra UI quando o item contém elementos interativos filhos. O gerenciamento de foco via teclado e os handlers de evento continuam funcionando corretamente — o `useMenuItem` do Chakra injeta `role`, `tabIndex` e os eventos de teclado independentemente do elemento raiz. Os `IconButton`s internos já chamavam `e.stopPropagation()` antes desta PR, então a propagação de eventos permanece inalterada.

Nenhum arquivo requer atenção especial.

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    U([Usuário clica]) --> Q{Clicou onde?}
    Q -->|No texto/área do item| MI["MenuItem (as=div)\nonClick → handleMenuItemClick(id)"]
    Q -->|No IconButton Editar| IB_E["IconButton Editar\ne.stopPropagation()\nonEditClick(id)"]
    Q -->|No IconButton Excluir| IB_D["IconButton Excluir\ne.stopPropagation()\nmutate(delete)"]
    MI --> SEL["onCredentialsSelect(id)\n→ fecha menu, seleciona credencial"]
    IB_E --> MOD["Abre modal de edição"]
    IB_D --> DEL["Chama API de exclusão"]
    IB_E -. "propagação interrompida" .-> MI
    IB_D -. "propagação interrompida" .-> MI
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    U([Usuário clica]) --> Q{Clicou onde?}
    Q -->|No texto/área do item| MI["MenuItem (as=div)\nonClick → handleMenuItemClick(id)"]
    Q -->|No IconButton Editar| IB_E["IconButton Editar\ne.stopPropagation()\nonEditClick(id)"]
    Q -->|No IconButton Excluir| IB_D["IconButton Excluir\ne.stopPropagation()\nmutate(delete)"]
    MI --> SEL["onCredentialsSelect(id)\n→ fecha menu, seleciona credencial"]
    IB_E --> MOD["Abre modal de edição"]
    IB_D --> DEL["Chama API de exclusão"]
    IB_E -. "propagação interrompida" .-> MI
    IB_D -. "propagação interrompida" .-> MI
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(credentials): stop nesting a button ..."](https://github.com/cloudhumans/typebot.io/commit/4f23077c420f33b13c078d53cf720d6fea857b1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40926928)</sub>

<!-- /greptile_comment -->