### PR TITLE
fix(credentials): navigate the CloudChat host when opening an in-use flow while embedded

### DIFF
--- a/apps/builder/src/features/credentials/components/CredentialInUseModal.tsx
+++ b/apps/builder/src/features/credentials/components/CredentialInUseModal.tsx
@@ -24,7 +24,10 @@ import { T, useTranslate } from '@tolgee/react'
 import NextLink from 'next/link'
 import { useRouter } from 'next/router'
 import { useUser } from '@/features/account/hooks/useUser'
-import { getAllowedOrigins } from '@/features/embedded-auth/utils'
+import {
+  getAllowedOrigins,
+  isOriginAllowed,
+} from '@/features/embedded-auth/utils'
 import {
   AlertIcon,
   CloseIcon,
@@ -83,22 +86,25 @@ export const CredentialInUseModal = ({
   // to /controlled-flows/<typebotId>.
   const handleUsageClick = (typebotId: string) => (e: React.MouseEvent) => {
     if (!isEmbedded || window.parent === window) return
-    const allowedOrigins = getAllowedOrigins()
-    let referrerOrigin: string | undefined
+    // postMessage needs a concrete target origin. Derive it from the embedding
+    // page (document.referrer) and accept it only if the allow-list matches —
+    // the list may hold wildcard patterns, which aren't valid postMessage
+    // targets, so we never post to a pattern directly.
+    let targetOrigin: string | undefined
     try {
-      referrerOrigin = document.referrer
+      const referrerOrigin = document.referrer
         ? new URL(document.referrer).origin
         : undefined
+      if (referrerOrigin && isOriginAllowed(referrerOrigin))
+        targetOrigin = referrerOrigin
     } catch {
-      referrerOrigin = undefined
+      targetOrigin = undefined
     }
-    // Post only to the actual embedding origin, falling back to the first
-    // allow-listed one, so the message isn't delivered to every allow-listed
-    // origin.
-    const targetOrigin =
-      referrerOrigin && allowedOrigins.includes(referrerOrigin)
-        ? referrerOrigin
-        : allowedOrigins[0]
+    if (!targetOrigin) {
+      const [firstAllowed] = getAllowedOrigins()
+      if (firstAllowed && !firstAllowed.includes('*'))
+        targetOrigin = firstAllowed
+    }
     if (!targetOrigin) return
     e.preventDefault()
     window.parent.postMessage(

--- a/apps/builder/src/features/credentials/components/CredentialInUseModal.tsx
+++ b/apps/builder/src/features/credentials/components/CredentialInUseModal.tsx
@@ -23,6 +23,7 @@ import {
 import { T, useTranslate } from '@tolgee/react'
 import NextLink from 'next/link'
 import { useRouter } from 'next/router'
+import { useUser } from '@/features/account/hooks/useUser'
 import { getAllowedOrigins } from '@/features/embedded-auth/utils'
 import {
   AlertIcon,
@@ -67,7 +68,12 @@ export const CredentialInUseModal = ({
 }: Props) => {
   const { t } = useTranslate()
   const router = useRouter()
-  const isEmbedded = router.query.embedded === 'true'
+  const { user } = useUser()
+  // The query param is the primary signal, but it can be absent after an
+  // in-app route change while the CloudChat session persists; the session
+  // flag keeps us in embedded mode in that case.
+  const isEmbedded =
+    router.query.embedded === 'true' || !!user?.cloudChatAuthorization
   const isSave = variant === 'save'
 
   // Inside CloudChat the builder runs in an iframe. A plain in-iframe route
@@ -76,13 +82,28 @@ export const CredentialInUseModal = ({
   // router instead. The parent matches `typebot:navigate-to-flow` and routes
   // to /controlled-flows/<typebotId>.
   const handleUsageClick = (typebotId: string) => (e: React.MouseEvent) => {
-    if (!isEmbedded) return
+    if (!isEmbedded || window.parent === window) return
+    const allowedOrigins = getAllowedOrigins()
+    let referrerOrigin: string | undefined
+    try {
+      referrerOrigin = document.referrer
+        ? new URL(document.referrer).origin
+        : undefined
+    } catch {
+      referrerOrigin = undefined
+    }
+    // Post only to the actual embedding origin, falling back to the first
+    // allow-listed one, so the message isn't delivered to every allow-listed
+    // origin.
+    const targetOrigin =
+      referrerOrigin && allowedOrigins.includes(referrerOrigin)
+        ? referrerOrigin
+        : allowedOrigins[0]
+    if (!targetOrigin) return
     e.preventDefault()
-    getAllowedOrigins().forEach((origin) =>
-      window.parent.postMessage(
-        { type: 'typebot:navigate-to-flow', typebotId },
-        origin
-      )
+    window.parent.postMessage(
+      { type: 'typebot:navigate-to-flow', typebotId },
+      targetOrigin
     )
     onClose()
   }

--- a/apps/builder/src/features/credentials/components/CredentialInUseModal.tsx
+++ b/apps/builder/src/features/credentials/components/CredentialInUseModal.tsx
@@ -22,6 +22,8 @@ import {
 } from '@chakra-ui/react'
 import { T, useTranslate } from '@tolgee/react'
 import NextLink from 'next/link'
+import { useRouter } from 'next/router'
+import { getAllowedOrigins } from '@/features/embedded-auth/utils'
 import {
   AlertIcon,
   CloseIcon,
@@ -64,7 +66,26 @@ export const CredentialInUseModal = ({
   isForceDeleting,
 }: Props) => {
   const { t } = useTranslate()
+  const router = useRouter()
+  const isEmbedded = router.query.embedded === 'true'
   const isSave = variant === 'save'
+
+  // Inside CloudChat the builder runs in an iframe. A plain in-iframe route
+  // change would drop the embedded auth params (?embedded&jwt) and leave the
+  // host URL stale, so we ask the CloudChat parent to navigate via its own
+  // router instead. The parent matches `typebot:navigate-to-flow` and routes
+  // to /controlled-flows/<typebotId>.
+  const handleUsageClick = (typebotId: string) => (e: React.MouseEvent) => {
+    if (!isEmbedded) return
+    e.preventDefault()
+    getAllowedOrigins().forEach((origin) =>
+      window.parent.postMessage(
+        { type: 'typebot:navigate-to-flow', typebotId },
+        origin
+      )
+    )
+    onClose()
+  }
 
   const iconBg = useColorModeValue('orange.100', 'orange.900')
   const iconColor = useColorModeValue('orange.500', 'orange.300')
@@ -174,6 +195,7 @@ export const CredentialInUseModal = ({
                   key={`${u.source}:${u.typebotId}:${u.via ?? ''}`}
                   as={NextLink}
                   href={`/typebots/${u.typebotId}/edit`}
+                  onClick={handleUsageClick(u.typebotId)}
                   display="block"
                   px={4}
                   py={3}


### PR DESCRIPTION
## Problem

In the credential-in-use modal, the impacted-flow rows linked to `/typebots/<id>/edit` with a plain `NextLink`. When the builder runs **embedded inside CloudChat** (iframe with `?embedded=true&jwt=`), that route change happens **inside the iframe** — it drops the embedded auth params (breaking auth) and leaves the CloudChat host URL stale on the old flow. So clicking an impacted flow broke navigation in production.

The iframe only receives `embedded=true` + `jwt` — it gets **no** `accountId`/`basePath`, so the builder cannot construct the host URL `/app/accounts/<accountId>/claudia/controlled-flows/<id>` on its own.

## Fix

When embedded (`router.query.embedded === 'true'`), instead of navigating in-iframe, post a message to the CloudChat parent and let it navigate via its own router:

```js
window.parent.postMessage({ type: 'typebot:navigate-to-flow', typebotId }, origin)
```

(origins from the existing `getAllowedOrigins()` / `NEXT_PUBLIC_EMBEDDED_AUTH_ALLOWED_ORIGIN`). Standalone behavior is unchanged — it still uses the normal link.

This reuses the same one-way postMessage channel CloudChat already listens on for `typebot:published`. The id in the `controlled-flows/<id>` route is the `typebotId`, which is exactly what the impacted-flow list already has.

## Paired change (coordinated deploy)

Requires the matching handler in **claudia-app** (`flow-builder-page.tsx`) that maps `typebot:navigate-to-flow` → `navigator.navigate('/controlled-flows/<typebotId>')`. PR: _(claudia-app link to be added)_.

Deploy order is safe either way: if claudia-app isn't updated yet, the message is simply ignored (no regression); the link just won't navigate until both are live.

## Test

- [ ] Standalone builder: clicking an impacted flow still opens `/typebots/<id>/edit`.
- [ ] Embedded in CloudChat: clicking an impacted flow switches the CloudChat route to that flow (URL bar updates, auth preserved), with the claudia-app PR deployed.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

A mudança é segura para merge. Toda a lógica nova fica dentro do handler de clique e só age quando o builder está em iframe, sem alterar o caminho standalone.

A origem do postMessage é validada contra a allow-list antes de ser usada, o fallback preserva a navegação padrão quando nenhuma origem válida é encontrada, e a guarda `window.parent === window` evita auto-envio acidental. O deploy pode ser feito em qualquer ordem sem regressão, pois o handler no claudia-app simplesmente ignora mensagens desconhecidas.

Nenhum arquivo requer atenção especial.

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    actor User
    participant Modal as CredentialInUseModal (iframe)
    participant Handler as handleUsageClick
    participant Parent as CloudChat (parent window)

    User->>Modal: Clica em fluxo afetado
    Modal->>Handler: onClick(e)
    alt "não está embedded OU window.parent === window"
        Handler-->>Modal: return (navegação padrão ocorre)
    else está embedded no iframe
        Handler->>Handler: Extrai origin de document.referrer
        Handler->>Handler: isOriginAllowed(referrerOrigin)?
        alt referrer válido e permitido
            Handler->>Handler: "targetOrigin = referrerOrigin"
        else sem referrer ou não permitido
            Handler->>Handler: "targetOrigin = primeiro da allow-list (sem '*')"
        end
        alt targetOrigin resolvido
            Handler->>Handler: e.preventDefault()
            Handler->>Parent: "postMessage({ type: 'typebot:navigate-to-flow', typebotId }, targetOrigin)"
            Handler->>Modal: onClose()
            Parent->>Parent: "Navega para /controlled-flows/<typebotId>"
        else targetOrigin não resolvido
            Handler-->>Modal: return (navegação padrão ocorre)
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    actor User
    participant Modal as CredentialInUseModal (iframe)
    participant Handler as handleUsageClick
    participant Parent as CloudChat (parent window)

    User->>Modal: Clica em fluxo afetado
    Modal->>Handler: onClick(e)
    alt "não está embedded OU window.parent === window"
        Handler-->>Modal: return (navegação padrão ocorre)
    else está embedded no iframe
        Handler->>Handler: Extrai origin de document.referrer
        Handler->>Handler: isOriginAllowed(referrerOrigin)?
        alt referrer válido e permitido
            Handler->>Handler: "targetOrigin = referrerOrigin"
        else sem referrer ou não permitido
            Handler->>Handler: "targetOrigin = primeiro da allow-list (sem '*')"
        end
        alt targetOrigin resolvido
            Handler->>Handler: e.preventDefault()
            Handler->>Parent: "postMessage({ type: 'typebot:navigate-to-flow', typebotId }, targetOrigin)"
            Handler->>Modal: onClose()
            Parent->>Parent: "Navega para /controlled-flows/<typebotId>"
        else targetOrigin não resolvido
            Handler-->>Modal: return (navegação padrão ocorre)
        end
    end
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(credentials): resolve a concrete pos..."](https://github.com/cloudhumans/typebot.io/commit/aef6521b21fc47632b50906f79aafb1c5a71a72a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40940825)</sub>

<!-- /greptile_comment -->