### PR TITLE
feat(openapi): curated Typebot admin OpenAPI for GAD MCP

### DIFF
--- a/apps/builder/src/features/typebot/api/publishTypebot.ts
+++ b/apps/builder/src/features/typebot/api/publishTypebot.ts
@@ -18,7 +18,9 @@ import {
 import { InputBlockType } from '@typebot.io/schemas/features/blocks/inputs/constants'
 import { trackEvents } from '@typebot.io/telemetry/trackEvents'
 import { z } from 'zod'
+import { parseDefaultPublicId } from '@/features/publish/helpers/parseDefaultPublicId'
 import { isWriteTypebotForbidden } from '../helpers/isWriteTypebotForbidden'
+import { isPublicIdNotAvailable } from '../helpers/sanitizers'
 
 export const publishTypebot = authenticatedProcedure
   .meta({
@@ -146,6 +148,26 @@ export const publishTypebot = authenticatedProcedure
       hasFileUploadBlocks,
     })
 
+    // The published bot is resolved by the typebot row's publicId
+    // (findPublicTypebot queries publicTypebot where typebot.publicId matches).
+    // The builder UI sets publicId before publishing, but API callers such as
+    // the claudia-admin OpenAPI (used by the GAD) do not, which left publicId
+    // null and made the published bot unresolvable. Backfill a default here.
+    let publicId = existingTypebot.publicId
+    if (!publicId) {
+      const defaultPublicId = parseDefaultPublicId(
+        existingTypebot.name,
+        existingTypebot.id
+      )
+      publicId = (await isPublicIdNotAvailable(defaultPublicId))
+        ? `${defaultPublicId}-${existingTypebot.id.slice(0, 5)}`
+        : defaultPublicId
+      await prisma.typebot.update({
+        where: { id: existingTypebot.id },
+        data: { publicId },
+      })
+    }
+
     if (existingTypebot.publishedTypebot)
       await prisma.publicTypebot.updateMany({
         where: {
@@ -251,7 +273,7 @@ export const publishTypebot = authenticatedProcedure
         resultsTablePreferences: existingTypebot.resultsTablePreferences
           ? existingTypebot.resultsTablePreferences
           : Prisma.JsonNull,
-        publicId: existingTypebot.publicId,
+        publicId,
         customDomain: existingTypebot.customDomain,
         workspaceId: existingTypebot.workspaceId,
         isArchived: existingTypebot.isArchived,

--- a/apps/builder/src/helpers/server/routers/claudiaAdminRouter.ts
+++ b/apps/builder/src/helpers/server/routers/claudiaAdminRouter.ts
@@ -1,0 +1,25 @@
+import { router } from '../trpc'
+import { createTypebot } from '@/features/typebot/api/createTypebot'
+import { updateTypebot } from '@/features/typebot/api/updateTypebot'
+import { publishTypebot } from '@/features/typebot/api/publishTypebot'
+import { getTypebot } from '@/features/typebot/api/getTypebot'
+import { listTypebots } from '@/features/typebot/api/listTypebots'
+import { listTypebotsClaudia } from '@/features/typebot/api/listTypebotsClaudia'
+import { getTypebotHistory } from '@/features/typebot/api/getTypebotHistory'
+
+// Curated subset exposed to the GAD via the typebot-admin MCP slug.
+// Authoring only (create/update/publish/get/list/history). Excludes
+// billing/credentials/custom-domains/whatsApp/folders and DELETE.
+// Each procedure keeps its own openapi.path meta, so the generated doc
+// contains exactly these /v1/typebots paths.
+export const claudiaAdminRouter = router({
+  createTypebot,
+  updateTypebot,
+  publishTypebot,
+  getTypebot,
+  listTypebots,
+  listTypebotsClaudia,
+  getTypebotHistory,
+})
+
+export type ClaudiaAdminRouter = typeof claudiaAdminRouter

--- a/apps/builder/src/pages/api/openapi/claudia-admin.json.ts
+++ b/apps/builder/src/pages/api/openapi/claudia-admin.json.ts
@@ -16,44 +16,44 @@ const doc = generateOpenApiDocument(claudiaAdminRouter, {
 // here instead. The MCP server derives each tool's description from these
 // summary/description fields, so this directly shapes what the GAD sees.
 doc.info.description =
-  "Authoring API for CloudHumans-managed Typebot flows, exposed to the AI Companion (GAD). Create, edit, publish, and inspect flows using Typebot's canonical contract — payloads are validated server-side, so a flow is born valid or rejected with an actionable error. Authorized as the logged-in user (you can only act on workspaces your account has access to). Authoring-only — does not run or test flows."
+  "Authoring API for CloudHumans-managed Typebot flows, exposed to the AI Companion (GAD). Create, edit, publish, and inspect flows using Typebot's canonical contract — payloads are validated server-side, so a flow is born valid or rejected with an actionable error. Authorized as the logged-in user (you can only act on workspaces your account has access to). Authoring-only — does not run or test flows. Your target workspace is provided in the [SYSTEM CONTEXT] as `eddie_workspace_id` — pass it directly as `workspaceId` to createTypebot and listTypebots; do not attempt to look it up. Typical flow: listTypebots(workspaceId) to find a flow's id -> getTypebot to read it -> createTypebot/updateTypebot to author -> publishTypebot to go live."
 
 const OPERATION_DOCS: Record<string, { summary: string; description: string }> =
   {
     createTypebot: {
       summary: 'Create a Typebot flow',
       description:
-        'Create a new flow in a workspace. Requires `workspaceId` and a `typebot` object (`name` is mandatory). The authenticated user must be a non-guest member of the target workspace. Returns the created typebot (with generated `id`).',
+        'Create a new flow in a workspace. `workspaceId` is the `eddie_workspace_id` from your [SYSTEM CONTEXT] — pass it directly; do not try to discover it. Provide a `typebot` object (`name` is mandatory; groups/blocks/settings are optional and can be added later via updateTypebot). The flow is created as a DRAFT — call publishTypebot to make it live. Returns the created typebot with its generated `id`.',
     },
     updateTypebot: {
       summary: 'Update a Typebot flow',
       description:
-        'Update an existing flow identified by `typebotId` — its groups/blocks, settings, theme, or name. Partial: send only the fields you want to change. Read the current state via getTypebot first to avoid clobbering.',
+        'Edit an existing flow identified by `typebotId` — its groups/blocks, settings, theme, or name. Partial: send only the fields you want to change; read current state with getTypebot first to avoid overwriting. Changes affect the DRAFT only — call publishTypebot to make them live. Get the `typebotId` from listTypebots.',
     },
     publishTypebot: {
       summary: 'Publish a Typebot flow',
       description:
-        'Publish the current draft of the Typebot `{typebotId}`, making it the live version. Republishing overwrites the previously published version with the current draft. Publish only after the draft is complete.',
+        'Make the current draft of `{typebotId}` the live version. createTypebot and updateTypebot leave changes in draft; call this once the draft is complete. Republishing overwrites the previously published version.',
     },
     getTypebot: {
       summary: 'Get a Typebot flow',
       description:
-        'Fetch a single Typebot flow by `typebotId`, including its full definition (groups, blocks, settings, theme). Use to read current state before updating.',
+        'Fetch a single flow by `typebotId`, including its full definition (groups, blocks, settings, theme). Use to read current state before updateTypebot. Get the `typebotId` from listTypebots.',
     },
     listTypebots: {
-      summary: 'List Typebot flows',
+      summary: 'List Typebot flows (by workspace id)',
       description:
-        'List the Typebots the authenticated user can access within a workspace.',
+        "Primary way to list flows: pass `workspaceId` (the `eddie_workspace_id` from your [SYSTEM CONTEXT]). Returns each flow's `id`, `name`, and published state — use it to resolve a flow's `typebotId` before get/update/publish.",
     },
     listTypebotsClaudia: {
-      summary: 'List Typebot flows (CloudHumans)',
+      summary: 'List Typebot flows (CloudHumans, by workspace name)',
       description:
-        'CloudHumans-scoped listing: returns a lightweight `{ id, name, publicId }` for each Typebot in a workspace, selected by `workspaceName` (optionally filtered by `folderId`). Use it to resolve a typebot `id` from a workspace name.',
+        'Alternative listing keyed by workspace *name* instead of id, returning a lightweight `{ id, name, publicId }` per flow (optionally filtered by `folderId`). You normally have the workspace id (`eddie_workspace_id`) in context — prefer listTypebots. Use this only when you have a workspace name but not its id.',
     },
     getTypebotHistory: {
       summary: 'Get Typebot version history',
       description:
-        'Return the version history of the Typebot `{typebotId}` — useful to review past versions or roll back.',
+        'Return the version history of `{typebotId}` — read-only, for reviewing past versions. There is no rollback endpoint; to revert, read a past version and re-apply it via updateTypebot.',
     },
   }
 

--- a/apps/builder/src/pages/api/openapi/claudia-admin.json.ts
+++ b/apps/builder/src/pages/api/openapi/claudia-admin.json.ts
@@ -11,6 +11,68 @@ const doc = generateOpenApiDocument(claudiaAdminRouter, {
   baseUrl: 'https://app.typebot.io/api',
 })
 
+// Enrichment layer: the source tRPC procedures are shared with the full
+// public API (out of scope to edit), so we post-process the generated doc
+// here instead. The MCP server derives each tool's description from these
+// summary/description fields, so this directly shapes what the GAD sees.
+doc.info.description =
+  "Authoring API for CloudHumans-managed Typebot flows, exposed to the AI Companion (GAD). Create, edit, publish, and inspect flows using Typebot's canonical contract — payloads are validated server-side, so a flow is born valid or rejected with an actionable error. Authorized as the logged-in user (you can only act on workspaces your account has access to). Authoring-only — does not run or test flows."
+
+const OPERATION_DOCS: Record<string, { summary: string; description: string }> =
+  {
+    createTypebot: {
+      summary: 'Create a Typebot flow',
+      description:
+        'Create a new flow in a workspace. Requires `workspaceId` and a `typebot` object (`name` is mandatory). The authenticated user must be a non-guest member of the target workspace. Returns the created typebot (with generated `id`).',
+    },
+    updateTypebot: {
+      summary: 'Update a Typebot flow',
+      description:
+        'Update an existing flow identified by `typebotId` — its groups/blocks, settings, theme, or name. Partial: send only the fields you want to change. Read the current state via getTypebot first to avoid clobbering.',
+    },
+    publishTypebot: {
+      summary: 'Publish a Typebot flow',
+      description:
+        'Publish the current draft of the Typebot `{typebotId}`, making it the live version. Republishing overwrites the previously published version with the current draft. Publish only after the draft is complete.',
+    },
+    getTypebot: {
+      summary: 'Get a Typebot flow',
+      description:
+        'Fetch a single Typebot flow by `typebotId`, including its full definition (groups, blocks, settings, theme). Use to read current state before updating.',
+    },
+    listTypebots: {
+      summary: 'List Typebot flows',
+      description:
+        'List the Typebots the authenticated user can access within a workspace.',
+    },
+    listTypebotsClaudia: {
+      summary: 'List Typebot flows (CloudHumans)',
+      description:
+        'CloudHumans-scoped listing: returns a lightweight `{ id, name, publicId }` for each Typebot in a workspace, selected by `workspaceName` (optionally filtered by `folderId`). Use it to resolve a typebot `id` from a workspace name.',
+    },
+    getTypebotHistory: {
+      summary: 'Get Typebot version history',
+      description:
+        'Return the version history of the Typebot `{typebotId}` — useful to review past versions or roll back.',
+    },
+  }
+
+for (const pathItem of Object.values(doc.paths ?? {})) {
+  for (const op of Object.values(
+    (pathItem ?? {}) as Record<
+      string,
+      { operationId?: string; summary?: string; description?: string }
+    >
+  )) {
+    const operationId = op?.operationId
+    const enrichment = operationId ? OPERATION_DOCS[operationId] : undefined
+    if (op && enrichment) {
+      op.summary = enrichment.summary
+      op.description = enrichment.description
+    }
+  }
+}
+
 export default function handler(_req: NextApiRequest, res: NextApiResponse) {
   res.setHeader('Cache-Control', 'no-cache')
   res.status(200).json(doc)

--- a/apps/builder/src/pages/api/openapi/claudia-admin.json.ts
+++ b/apps/builder/src/pages/api/openapi/claudia-admin.json.ts
@@ -1,0 +1,17 @@
+import { generateOpenApiDocument } from '@lilyrose2798/trpc-openapi'
+import { NextApiRequest, NextApiResponse } from 'next'
+import { claudiaAdminRouter } from '@/helpers/server/routers/claudiaAdminRouter'
+
+// Curated OpenAPI doc for the GAD's typebot-admin MCP slug. Public, read-only.
+// baseUrl is cosmetic: the mcp dispatcher overrides servers[0].url with the
+// registry `api` value before handing the spec to FastMCP.from_openapi.
+const doc = generateOpenApiDocument(claudiaAdminRouter, {
+  title: 'Typebot Claudia Admin API',
+  version: '1.0.0',
+  baseUrl: 'https://app.typebot.io/api',
+})
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  res.setHeader('Cache-Control', 'no-cache')
+  res.status(200).json(doc)
+}

--- a/apps/builder/src/pages/api/openapi/claudia-admin.json.ts
+++ b/apps/builder/src/pages/api/openapi/claudia-admin.json.ts
@@ -73,6 +73,33 @@ for (const pathItem of Object.values(doc.paths ?? {})) {
   }
 }
 
+// trpc-openapi renders Zod unions as JSON Schema `oneOf`, which asserts that
+// exactly one branch matches. Zod unions are first-match (at-least-one) and the
+// server never enforces exclusivity, so the promise is false: e.g. the workflow
+// block's `options` union has a branch that is a bare object, which overlaps the
+// `{ action: "Return Output" }` branch and matches both. Consumers (the GAD's
+// claudia-agentic) validate tool args client-side against this doc and reject
+// payloads the server would accept. `anyOf` is the faithful semantics, so
+// rewrite every `oneOf` keyword (a schema key whose value is an array of
+// sub-schemas) to `anyOf` across the whole document. A property literally named
+// `oneOf` never has an array value (its value is a schema object), so the array
+// guard leaves it untouched.
+const convertOneOfToAnyOf = (node: unknown): void => {
+  if (Array.isArray(node)) {
+    for (const item of node) convertOneOfToAnyOf(item)
+    return
+  }
+  if (node === null || typeof node !== 'object') return
+  const obj = node as Record<string, unknown>
+  if (Array.isArray(obj.oneOf)) {
+    obj.anyOf = obj.oneOf
+    delete obj.oneOf
+  }
+  for (const value of Object.values(obj)) convertOneOfToAnyOf(value)
+}
+
+convertOneOfToAnyOf(doc)
+
 export default function handler(_req: NextApiRequest, res: NextApiResponse) {
   res.setHeader('Cache-Control', 'no-cache')
   res.status(200).json(doc)


### PR DESCRIPTION
Serves an **authoring-only** OpenAPI subset of the Typebot public API at a public route, so the `mcp` server's `typebot-admin` registry slug can point at it. Part of the GAD Typebot-authoring MCP (composezao spec `2026-07-01-typebot-admin-mgmt-via-mcp-design`).

## What
- `claudiaAdminRouter` — curated router with only the authoring procedures (create/update/publish/get/list/history). Excludes billing/credentials/custom-domains/whatsApp/folders and DELETE.
- `GET /api/openapi/claudia-admin.json` — public, read-only route returning `generateOpenApiDocument(claudiaAdminRouter)`.

The curated router is a **spec-generation artifact only** — it adds no handlers; the real REST endpoints are already served by `publicRouter` via `[...trpc].ts`.

## Verified
- `pnpm tsc --noEmit`: 0 net-new errors (baseline-compared).
- Route live returns exactly: `/v1/typebots`, `/v1/typebots/claudia`, `/v1/typebots/{typebotId}`, `/v1/typebots/{typebotId}/history`, `/v1/typebots/{typebotId}/publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>

A mudança em publishTypebot contém um caminho onde o publicId de fallback é gravado no banco sem verificar se já está em uso por outro bot, o que pode resultar em erro 500 em um cenário raro mas real.

O novo backfill de publicId funciona corretamente no caminho feliz. O problema está no ramo de fallback (linha 163): quando o defaultPublicId já está ocupado, o código deriva um novo valor concatenando prefixo + 5 chars do id, mas não verifica se esse novo valor também já existe — se existir, o prisma.typebot.update dispara uma violação de unique constraint e a publicação termina com 500 ao invés de uma mensagem de erro útil.

apps/builder/src/features/typebot/api/publishTypebot.ts — especificamente o bloco de backfill de publicId (linhas 157–168).

<sub>Reviews (6): Last reviewed commit: ["fix(openapi): rewrite oneOf-&gt;anyOf in cl..."](https://github.com/cloudhumans/typebot.io/commit/0d113c62f552ee292d988a51b9b6eb8726bbda28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41174280)</sub>

<!-- /greptile_comment -->