### PR TITLE
fix(docker): add python3/make/g++ for isolated-vm source build on arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,17 @@ FROM node:18-bullseye-slim AS base
 WORKDIR /app
 ARG SCOPE
 ENV SCOPE=${SCOPE}
-# Install required base packages (openssl + curl for preStop drain hook and build)
+# Install required base packages (openssl + curl for preStop drain hook and build).
+# python3/make/g++ are needed by node-gyp to compile isolated-vm from source on
+# arm64 hosts (no prebuilt binary published for linux/arm64) — no-op overhead on
+# amd64, where the prebuilt binary is used and node-gyp never runs.
 RUN apt-get -qy update \
     && apt-get -qy --no-install-recommends install \
     openssl \
     curl \
+    python3 \
+    make \
+    g++ \
     && apt-get autoremove -yq \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,31 @@ FROM node:18-bullseye-slim AS base
 WORKDIR /app
 ARG SCOPE
 ENV SCOPE=${SCOPE}
-# Install required base packages (openssl + curl for preStop drain hook and build).
-# python3/make/g++ are needed by node-gyp to compile isolated-vm from source on
-# arm64 hosts (no prebuilt binary published for linux/arm64) — no-op overhead on
-# amd64, where the prebuilt binary is used and node-gyp never runs.
+# Install required base packages (openssl + curl for preStop drain hook and build)
 RUN apt-get -qy update \
     && apt-get -qy --no-install-recommends install \
     openssl \
     curl \
+    && apt-get autoremove -yq \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+RUN npm --global install pnpm@8
+
+# Dev-container stage: base + toolchain pro node-gyp compilar isolated-vm do
+# código-fonte em hosts arm64 (não há binário pré-compilado pra linux/arm64;
+# em amd64 o binário pronto é usado e o node-gyp nem roda). Os containers de
+# desenvolvimento do composezao (typebot-builder/viewer, que rodam `pnpm
+# install` em runtime) fazem build com target=dev. Mantido fora de base pra
+# runner (imagem de produção) não carregar compilador C++.
+FROM base AS dev
+RUN apt-get -qy update \
+    && apt-get -qy --no-install-recommends install \
     python3 \
     make \
     g++ \
     && apt-get autoremove -yq \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-RUN npm --global install pnpm@8
 
 FROM base AS pruner
 RUN npm --global install turbo@1.11.3
@@ -24,9 +34,11 @@ WORKDIR /app
 COPY . .
 RUN turbo prune --scope=${SCOPE} --docker
 
+# git pro pnpm resolver deps de repositório; python3/make/g++ pro node-gyp
+# compilar isolated-vm do código-fonte em arm64 (ver stage dev acima).
 FROM base AS builder
 RUN apt-get -qy update \
-    && apt-get -qy --no-install-recommends install git \
+    && apt-get -qy --no-install-recommends install git python3 make g++ \
     && apt-get autoremove -yq \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Resumo

`isolated-vm` não publica binário pré-compilado pra `linux/arm64` — o `pnpm install` cai pro node-gyp, que precisa de `python3` + toolchain C++, ausentes na `node:18-bullseye-slim`. Resultado: qualquer build da imagem em host arm64 com cache frio (ex.: Docker Desktop em Apple Silicon) falha com `gyp ERR! find Python`.

Adiciona `python3 make g++` ao stage `base` (herdado por pruner/builder/runner). No-op em amd64, onde o binário pré-compilado é usado e o node-gyp nem roda.

## Contexto

Encontrado testando a stack composezao num Mac Mini via [composezao#158](https://github.com/cloudhumans/composezao-da-massa/pull/158) (home box). Sem este fix, `typebot-migrate`/`typebot-builder`/`typebot-viewer` não buildam em arm64. Emular amd64 via Rosetta não é alternativa: o `prisma generate` crasha sob Rosetta com `assertion failed [block != nullptr]` (bug conhecido do Rosetta com o JIT do V8).

## Test plan

- [x] Build completo das imagens typebot (migrate/builder/viewer) em arm64 (Mac Mini, Docker Desktop) — `pnpm install` compila `isolated-vm` do zero com sucesso e a stack sobe
- [x] Fluxo E2E validado com a stack de pé (login CloudChat + Claudia MF)
- [ ] Rebuild em amd64 (CI) — deve ser no-op além de ~30MB a mais de pacotes apt no stage base

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Mudança cirúrgica e bem comentada — a toolchain de build fica restrita aos stages `dev` e `builder`, e o `runner` (imagem de produção) continua limpo, derivando somente de `base`.

A alteração resolve a regressão em arm64 sem comprometer a imagem de produção. O stage `runner` não herda `python3`, `make` ou `g++`, e o novo stage `dev` está claramente documentado para o caso de uso do composezao.

Nenhum arquivo requer atenção especial.

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["node:18-bullseye-slim"]
    B["base\nopenssl · curl · pnpm"]
    C["dev\n+ python3 · make · g++\n(composezao arm64)"]
    D["pruner\n+ turbo\nturbo prune"]
    E["builder\n+ git · python3 · make · g++\npnpm install + turbo build"]
    F["runner\n(produção)\nsem toolchain C++"]

    A --> B
    B --> C
    B --> D
    B --> E
    B --> F
    E -- "artefatos compilados\n(.next/standalone, prisma...)" --> F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["node:18-bullseye-slim"]
    B["base\nopenssl · curl · pnpm"]
    C["dev\n+ python3 · make · g++\n(composezao arm64)"]
    D["pruner\n+ turbo\nturbo prune"]
    E["builder\n+ git · python3 · make · g++\npnpm install + turbo build"]
    F["runner\n(produção)\nsem toolchain C++"]

    A --> B
    B --> C
    B --> D
    B --> E
    B --> F
    E -- "artefatos compilados\n(.next/standalone, prisma...)" --> F
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(docker): keep build toolchain out of..."](https://github.com/cloudhumans/typebot.io/commit/7dada01ff9381dbdee75017499fd09b893b0e13d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41472692)</sub>

<!-- /greptile_comment -->