### PR TITLE
fix(credentials): post embedded navigate message to all allow-listed parent origins

### DIFF
--- a/apps/builder/src/features/credentials/components/CredentialInUseModal.tsx
+++ b/apps/builder/src/features/credentials/components/CredentialInUseModal.tsx
@@ -86,30 +86,37 @@ export const CredentialInUseModal = ({
   // to /controlled-flows/<typebotId>.
   const handleUsageClick = (typebotId: string) => (e: React.MouseEvent) => {
     if (!isEmbedded || window.parent === window) return
-    // postMessage needs a concrete target origin. Derive it from the embedding
-    // page (document.referrer) and accept it only if the allow-list matches —
-    // the list may hold wildcard patterns, which aren't valid postMessage
-    // targets, so we never post to a pattern directly.
-    let targetOrigin: string | undefined
+    // We can't read the parent's origin cross-origin, and document.referrer is
+    // unreliable here (the embedded-auth redirects leave it pointing at our own
+    // origin, which is itself allow-listed). So post to every concrete
+    // allow-listed origin except our own; the browser only delivers to the one
+    // that matches the real parent and drops the rest (no leakage — all are
+    // trusted and the receiver re-checks event.origin). Wildcard allow-list
+    // entries aren't valid targets, so we resolve those to the concrete parent
+    // via ancestorOrigins/referrer when they match the allow-list.
+    const selfOrigin = window.location.origin
+    const targets = new Set<string>()
+    for (const origin of getAllowedOrigins())
+      if (origin && !origin.includes('*') && origin !== selfOrigin)
+        targets.add(origin)
+    const hints = window.location.ancestorOrigins
+      ? Array.from(window.location.ancestorOrigins)
+      : []
     try {
-      const referrerOrigin = document.referrer
-        ? new URL(document.referrer).origin
-        : undefined
-      if (referrerOrigin && isOriginAllowed(referrerOrigin))
-        targetOrigin = referrerOrigin
+      if (document.referrer) hints.push(new URL(document.referrer).origin)
     } catch {
-      targetOrigin = undefined
+      // Ignore a malformed referrer.
     }
-    if (!targetOrigin) {
-      const [firstAllowed] = getAllowedOrigins()
-      if (firstAllowed && !firstAllowed.includes('*'))
-        targetOrigin = firstAllowed
-    }
-    if (!targetOrigin) return
+    for (const origin of hints)
+      if (origin && origin !== selfOrigin && isOriginAllowed(origin))
+        targets.add(origin)
+    if (targets.size === 0) return
     e.preventDefault()
-    window.parent.postMessage(
-      { type: 'typebot:navigate-to-flow', typebotId },
-      targetOrigin
+    targets.forEach((origin) =>
+      window.parent.postMessage(
+        { type: 'typebot:navigate-to-flow', typebotId },
+        origin
+      )
     )
     onClose()
   }

--- a/apps/builder/src/features/credentials/components/CredentialInUseModal.tsx
+++ b/apps/builder/src/features/credentials/components/CredentialInUseModal.tsx
@@ -26,7 +26,7 @@ import { useRouter } from 'next/router'
 import { useUser } from '@/features/account/hooks/useUser'
 import {
   getAllowedOrigins,
-  isOriginAllowed,
+  resolveEmbeddingTargetOrigins,
 } from '@/features/embedded-auth/utils'
 import {
   AlertIcon,
@@ -86,31 +86,15 @@ export const CredentialInUseModal = ({
   // to /controlled-flows/<typebotId>.
   const handleUsageClick = (typebotId: string) => (e: React.MouseEvent) => {
     if (!isEmbedded || window.parent === window) return
-    // We can't read the parent's origin cross-origin, and document.referrer is
-    // unreliable here (the embedded-auth redirects leave it pointing at our own
-    // origin, which is itself allow-listed). So post to every concrete
-    // allow-listed origin except our own; the browser only delivers to the one
-    // that matches the real parent and drops the rest (no leakage — all are
-    // trusted and the receiver re-checks event.origin). Wildcard allow-list
-    // entries aren't valid targets, so we resolve those to the concrete parent
-    // via ancestorOrigins/referrer when they match the allow-list.
-    const selfOrigin = window.location.origin
-    const targets = new Set<string>()
-    for (const origin of getAllowedOrigins())
-      if (origin && !origin.includes('*') && origin !== selfOrigin)
-        targets.add(origin)
-    const hints = window.location.ancestorOrigins
-      ? Array.from(window.location.ancestorOrigins)
-      : []
-    try {
-      if (document.referrer) hints.push(new URL(document.referrer).origin)
-    } catch {
-      // Ignore a malformed referrer.
-    }
-    for (const origin of hints)
-      if (origin && origin !== selfOrigin && isOriginAllowed(origin))
-        targets.add(origin)
-    if (targets.size === 0) return
+    const targets = resolveEmbeddingTargetOrigins({
+      allowedOrigins: getAllowedOrigins(),
+      selfOrigin: window.location.origin,
+      ancestorOrigins: window.location.ancestorOrigins
+        ? Array.from(window.location.ancestorOrigins)
+        : [],
+      referrer: document.referrer,
+    })
+    if (targets.length === 0) return
     e.preventDefault()
     targets.forEach((origin) =>
       window.parent.postMessage(

--- a/apps/builder/src/features/embedded-auth/utils.ts
+++ b/apps/builder/src/features/embedded-auth/utils.ts
@@ -1,6 +1,8 @@
 import { env } from '@typebot.io/env'
 import { isOriginAllowed as checkOriginAllowed } from '@typebot.io/lib/origin'
 
+export { resolveEmbeddingTargetOrigins } from '@typebot.io/lib/origin'
+
 // Helper function to get the allowed origins for postMessage
 export const getAllowedOrigins = (): string[] => {
   const allowedOrigins = env.NEXT_PUBLIC_EMBEDDED_AUTH_ALLOWED_ORIGIN

--- a/packages/lib/origin.test.ts
+++ b/packages/lib/origin.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import { resolveEmbeddingTargetOrigins } from './origin'
+
+const CLOUDCHAT = 'https://cloudchat.cloudhumans.com'
+const CLOUDCHAT2 = 'https://cloudchat2.cloudhumans.com'
+const EDDIE = 'https://eddie.us-east-1.prd.cloudhumans.io'
+const WILDCARD = 'https://*.app.cloudhumans.com'
+
+describe('resolveEmbeddingTargetOrigins', () => {
+  it('returns every concrete allow-listed origin except our own', () => {
+    expect(
+      resolveEmbeddingTargetOrigins({
+        allowedOrigins: [EDDIE, CLOUDCHAT, CLOUDCHAT2],
+        selfOrigin: EDDIE,
+      })
+    ).toEqual([CLOUDCHAT, CLOUDCHAT2])
+  })
+
+  it('excludes wildcard entries (invalid postMessage targets)', () => {
+    expect(
+      resolveEmbeddingTargetOrigins({
+        allowedOrigins: [EDDIE, WILDCARD, CLOUDCHAT],
+        selfOrigin: EDDIE,
+      })
+    ).toEqual([CLOUDCHAT])
+  })
+
+  it('resolves a wildcard entry to the concrete parent via ancestorOrigins', () => {
+    const parent = 'https://acme.app.cloudhumans.com'
+    expect(
+      resolveEmbeddingTargetOrigins({
+        allowedOrigins: [EDDIE, WILDCARD],
+        selfOrigin: EDDIE,
+        ancestorOrigins: [parent],
+      })
+    ).toEqual([parent])
+  })
+
+  it('resolves a wildcard entry to the concrete parent via referrer', () => {
+    const parent = 'https://acme.app.cloudhumans.com'
+    expect(
+      resolveEmbeddingTargetOrigins({
+        allowedOrigins: [EDDIE, WILDCARD],
+        selfOrigin: EDDIE,
+        referrer: `${parent}/some/path?x=1`,
+      })
+    ).toEqual([parent])
+  })
+
+  it('ignores hints that are not allow-listed', () => {
+    expect(
+      resolveEmbeddingTargetOrigins({
+        allowedOrigins: [EDDIE, CLOUDCHAT],
+        selfOrigin: EDDIE,
+        ancestorOrigins: ['https://evil.example.com'],
+        referrer: 'https://evil.example.com/x',
+      })
+    ).toEqual([CLOUDCHAT])
+  })
+
+  it('never targets our own origin even when it appears as a hint', () => {
+    expect(
+      resolveEmbeddingTargetOrigins({
+        allowedOrigins: [EDDIE, CLOUDCHAT],
+        selfOrigin: EDDIE,
+        ancestorOrigins: [EDDIE],
+        referrer: `${EDDIE}/typebots/x/edit`,
+      })
+    ).toEqual([CLOUDCHAT])
+  })
+
+  it('does not duplicate an origin present both in the list and as a hint', () => {
+    expect(
+      resolveEmbeddingTargetOrigins({
+        allowedOrigins: [EDDIE, CLOUDCHAT],
+        selfOrigin: EDDIE,
+        ancestorOrigins: [CLOUDCHAT],
+        referrer: `${CLOUDCHAT}/x`,
+      })
+    ).toEqual([CLOUDCHAT])
+  })
+
+  it('returns no targets when only wildcards exist and no hint matches', () => {
+    expect(
+      resolveEmbeddingTargetOrigins({
+        allowedOrigins: [EDDIE, WILDCARD],
+        selfOrigin: EDDIE,
+        ancestorOrigins: ['https://not-allowed.example.com'],
+      })
+    ).toEqual([])
+  })
+
+  it('tolerates a malformed referrer', () => {
+    expect(
+      resolveEmbeddingTargetOrigins({
+        allowedOrigins: [EDDIE, CLOUDCHAT],
+        selfOrigin: EDDIE,
+        referrer: 'not-a-url',
+      })
+    ).toEqual([CLOUDCHAT])
+  })
+})

--- a/packages/lib/origin.ts
+++ b/packages/lib/origin.ts
@@ -4,57 +4,60 @@
  * @param pattern - The pattern to match against (e.g., "https://*.app.cloudhumans.com")
  * @returns true if the origin matches the pattern
  */
-export const matchesOriginPattern = (origin: string, pattern: string): boolean => {
+export const matchesOriginPattern = (
+  origin: string,
+  pattern: string
+): boolean => {
   // Handle wildcard patterns like "https://*.app.cloudhumans.com"
   if (pattern.includes('://*.')) {
     try {
       // Extract the domain from the pattern: "https://*.app.cloudhumans.com" -> "app.cloudhumans.com"
       const patternUrl = new URL(pattern.replace('*.', 'dummy.'))
       const domain = patternUrl.hostname.replace('dummy.', '')
-      
+
       // Extract hostname from origin
       const originUrl = new URL(origin)
       const hostname = originUrl.hostname
-      
+
       // Check exact match first
       if (hostname === domain) return true
-      
+
       // For wildcard, ensure it's a direct subdomain (only one additional level)
       if (hostname.endsWith('.' + domain)) {
         const prefix = hostname.replace('.' + domain, '')
         // Ensure the prefix doesn't contain dots (prevents subdomain injection)
         return !prefix.includes('.')
       }
-      
+
       return false
     } catch {
       return false
     }
   }
-  
+
   // Handle simple wildcard patterns like "*.app.cloudhumans.com" (no protocol)
   if (pattern.startsWith('*.')) {
     const domain = pattern.substring(2)
     try {
       const originUrl = new URL(origin)
       const hostname = originUrl.hostname
-      
+
       // Check exact match first
       if (hostname === domain) return true
-      
+
       // For wildcard, ensure it's a direct subdomain (only one additional level)
       if (hostname.endsWith('.' + domain)) {
         const prefix = hostname.replace('.' + domain, '')
         // Ensure the prefix doesn't contain dots (prevents subdomain injection)
         return !prefix.includes('.')
       }
-      
+
       return false
     } catch {
       return false
     }
   }
-  
+
   // Exact match for full URLs or simple patterns
   return origin === pattern
 }
@@ -65,6 +68,60 @@ export const matchesOriginPattern = (origin: string, pattern: string): boolean =
  * @param allowedPatterns - Array of allowed origin patterns (may include wildcards)
  * @returns true if the origin matches any of the allowed patterns
  */
-export const isOriginAllowed = (origin: string, allowedPatterns: string[]): boolean => {
-  return allowedPatterns.some(pattern => matchesOriginPattern(origin, pattern))
+export const isOriginAllowed = (
+  origin: string,
+  allowedPatterns: string[]
+): boolean => {
+  return allowedPatterns.some((pattern) =>
+    matchesOriginPattern(origin, pattern)
+  )
+}
+
+/**
+ * Resolve the concrete origin(s) to postMessage a request to an embedding
+ * parent frame. The parent origin can't be read cross-origin, and
+ * document.referrer is unreliable when the embedded app performs its own
+ * sign-in redirects (it can end up pointing at the app's own — allow-listed —
+ * origin). So we target every concrete allow-listed origin except our own: the
+ * browser only delivers to the one matching the real parent and drops the rest
+ * (safe — all targets are trusted and the receiver re-checks event.origin).
+ * Wildcard allow-list entries aren't valid postMessage targets, so they're
+ * resolved to a concrete origin via ancestorOrigins / referrer when those match
+ * the allow-list. Pure, so it can be unit-tested without a DOM.
+ */
+export const resolveEmbeddingTargetOrigins = ({
+  allowedOrigins,
+  selfOrigin,
+  ancestorOrigins = [],
+  referrer,
+}: {
+  allowedOrigins: string[]
+  selfOrigin: string
+  ancestorOrigins?: string[]
+  referrer?: string
+}): string[] => {
+  const targets = new Set<string>()
+  for (const origin of allowedOrigins) {
+    if (origin && !origin.includes('*') && origin !== selfOrigin) {
+      targets.add(origin)
+    }
+  }
+  const hints = [...ancestorOrigins]
+  if (referrer) {
+    try {
+      hints.push(new URL(referrer).origin)
+    } catch {
+      // Ignore a malformed referrer.
+    }
+  }
+  for (const origin of hints) {
+    if (
+      origin &&
+      origin !== selfOrigin &&
+      isOriginAllowed(origin, allowedOrigins)
+    ) {
+      targets.add(origin)
+    }
+  }
+  return [...targets]
 }


### PR DESCRIPTION
## Problem

After #247/#275 shipped, clicking a flow in the embedded credential-in-use modal still didn't navigate — the `postMessage` was being silently dropped by the browser.

Root cause (confirmed against the prod `NEXT_PUBLIC_EMBEDDED_AUTH_ALLOWED_ORIGIN`): the previous code resolved a **single** target origin from `document.referrer`, falling back to the first allow-list entry. But:

- The typebot's **own** origin (`https://eddie.us-east-1.prd.cloudhumans.io`) is itself in the allow-list (it's needed for the embedded-auth handshake) and is the **first** entry.
- The embedded-auth redirect chain leaves `document.referrer` pointing at that same (eddie) origin.

So we resolved `targetOrigin = eddie` and called `window.parent.postMessage(data, "https://eddie…")`, while the real parent is CloudChat (`https://cloudchat.cloudhumans.com`). A `postMessage` whose `targetOrigin` doesn't match the parent's origin is **silently dropped** → no navigation.

## Fix

We can't read the parent's origin cross-origin, and `document.referrer` is unreliable here. So post to **every concrete allow-listed origin except our own** — the browser delivers only to the one matching the real parent and drops the rest. This is safe: all targets are allow-listed (trusted) and the claudia-app receiver still re-checks `event.origin`. Wildcard allow-list entries (e.g. `https://*.app.cloudhumans.com`) aren't valid `postMessage` targets, so they're resolved to a concrete parent origin via `window.location.ancestorOrigins` / `document.referrer` when those match the allow-list.

## Test

- [ ] Embedded in CloudChat: open the credential-in-use modal, click a flow → CloudChat navigates to `/controlled-flows/<id>`.
- [ ] Standalone builder: link still opens `/typebots/<id>/edit` normally.

Follow-up to #247. Receiver side (#275) unchanged.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

A mudança é segura para merge — resolve um bug real de entrega silenciosa de postMessage sem introduzir novos riscos.

A lógica de resolução de origens está correta: o primeiro loop coleta todas as origens concretas e não-próprias da allow-list, o segundo resolve entradas com wildcard via ancestorOrigins/referrer validando contra a allow-list. O uso de Set previne duplicatas. O fallback para Firefox (ancestorOrigins ausente) é tratado. A suite de testes cobre os cenários críticos incluindo hints inválidos, deduplicação e referrer malformado. Nenhum caminho de execução com comportamento incorreto foi identificado.

Nenhum arquivo requer atenção especial.

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CC as CloudChat (parent)
    participant Eddie as Typebot Builder (iframe)
    participant Browser as Browser engine

    CC->>Eddie: embed via iframe
    Note over Eddie: user clicks flow in CredentialInUseModal

    Eddie->>Eddie: "resolveEmbeddingTargetOrigins()<br/>allowedOrigins=[eddie, cloudchat]<br/>selfOrigin=eddie → targets=[cloudchat]"

    Eddie->>Browser: "postMessage({type:typebot:navigate-to-flow}, "https://cloudchat…")"
    Note over Browser: targetOrigin matches parent's origin
    Browser->>CC: message delivered ✓
    CC->>CC: route to /controlled-flows/id
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CC as CloudChat (parent)
    participant Eddie as Typebot Builder (iframe)
    participant Browser as Browser engine

    CC->>Eddie: embed via iframe
    Note over Eddie: user clicks flow in CredentialInUseModal

    Eddie->>Eddie: "resolveEmbeddingTargetOrigins()<br/>allowedOrigins=[eddie, cloudchat]<br/>selfOrigin=eddie → targets=[cloudchat]"

    Eddie->>Browser: "postMessage({type:typebot:navigate-to-flow}, "https://cloudchat…")"
    Note over Browser: targetOrigin matches parent's origin
    Browser->>CC: message delivered ✓
    CC->>CC: route to /controlled-flows/id
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(credentials): extract embedded ..."](https://github.com/cloudhumans/typebot.io/commit/2ca108c47f201457acbd06993b4bacaa8971546d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41495262)</sub>

<!-- /greptile_comment -->