### PR TITLE
fix(lib): strip null bytes from Prisma write args to prevent Postgres 22P05

### DIFF
--- a/packages/lib/prisma.ts
+++ b/packages/lib/prisma.ts
@@ -1,5 +1,6 @@
 import { env } from '@typebot.io/env'
 import { PrismaClient } from '@typebot.io/prisma'
+import { sanitizeNullBytes } from './sanitizeNullBytes'
 
 declare const global: { prisma: PrismaClient }
 let prisma: PrismaClient
@@ -23,6 +24,20 @@ prisma.$use(async (params, next) => {
   const after = Date.now()
 
   return result
+})
+
+const NULL_BYTE_WRITE_ACTIONS = new Set([
+  'create',
+  'createMany',
+  'update',
+  'updateMany',
+  'upsert',
+])
+
+prisma.$use(async (params, next) => {
+  if (params.args && NULL_BYTE_WRITE_ACTIONS.has(params.action))
+    params.args = sanitizeNullBytes(params.args)
+  return next(params)
 })
 
 export default prisma

--- a/packages/lib/sanitizeNullBytes.test.ts
+++ b/packages/lib/sanitizeNullBytes.test.ts
@@ -118,6 +118,19 @@ describe('sanitizeNullBytes', () => {
     expect(result.data.sibling).toBe(untouchedSibling)
   })
 
+  it('stores a key that sanitizes to __proto__ as an own property', () => {
+    const input = { ['__pr\u0000oto__']: { polluted: true } }
+    const result = sanitizeNullBytes(input)
+
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype)
+    expect(Object.prototype.hasOwnProperty.call(result, '__proto__')).toBe(
+      true
+    )
+    expect(
+      (result as Record<string, unknown>)['__proto__']
+    ).toEqual({ polluted: true })
+  })
+
   it('strips null bytes from object keys', () => {
     const input = { ['a\u0000b']: 'value' }
     const result = sanitizeNullBytes(input)

--- a/packages/lib/sanitizeNullBytes.test.ts
+++ b/packages/lib/sanitizeNullBytes.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest'
+import { Prisma } from '@typebot.io/prisma'
+import { sanitizeNullBytes } from './sanitizeNullBytes'
+
+describe('sanitizeNullBytes', () => {
+  it('strips a single null byte from a string', () => {
+    expect(sanitizeNullBytes('foo\u0000bar')).toBe('foobar')
+  })
+
+  it('strips multiple/consecutive null bytes', () => {
+    expect(sanitizeNullBytes('foo\u0000\u0000\u0000bar')).toBe('foobar')
+    expect(sanitizeNullBytes('\u0000\u0000\u0000')).toBe('')
+  })
+
+  it('strips null bytes deep inside nested objects', () => {
+    expect(sanitizeNullBytes({ a: { b: { c: 'foo\u0000bar' } } })).toEqual({
+      a: { b: { c: 'foobar' } },
+    })
+  })
+
+  it('strips null bytes inside arrays, including array-in-object-in-array nesting', () => {
+    expect(sanitizeNullBytes(['foo\u0000bar', 'clean'])).toEqual([
+      'foobar',
+      'clean',
+    ])
+    expect(
+      sanitizeNullBytes([{ items: ['a\u0000b', { nested: 'c\u0000d' }] }])
+    ).toEqual([{ items: ['ab', { nested: 'cd' }] }])
+  })
+
+  it('returns the same reference for clean strings, objects, and arrays', () => {
+    const cleanString = 'clean'
+    expect(sanitizeNullBytes(cleanString)).toBe(cleanString)
+
+    const cleanObject = { a: { b: 'clean' } }
+    expect(sanitizeNullBytes(cleanObject)).toBe(cleanObject)
+
+    const cleanArray = [{ a: 'clean' }, 'also clean']
+    expect(sanitizeNullBytes(cleanArray)).toBe(cleanArray)
+  })
+
+  it('does not mutate the input object and returns a new reference', () => {
+    const dirty = { a: { b: 'foo\u0000bar' } }
+    const result = sanitizeNullBytes(dirty)
+
+    expect(result).not.toBe(dirty)
+    expect(dirty.a.b).toBe('foo\u0000bar')
+    expect(result).toEqual({ a: { b: 'foobar' } })
+  })
+
+  it('passes Date instances through by identity', () => {
+    const date = new Date()
+    expect(sanitizeNullBytes(date)).toBe(date)
+    expect(sanitizeNullBytes({ date })).toEqual({ date })
+    expect(sanitizeNullBytes({ date }).date).toBe(date)
+  })
+
+  it('passes Buffer and Uint8Array through by identity', () => {
+    const buffer = Buffer.from('foo\u0000bar')
+    expect(sanitizeNullBytes(buffer)).toBe(buffer)
+
+    const uint8Array = new Uint8Array([0, 1, 2])
+    expect(sanitizeNullBytes(uint8Array)).toBe(uint8Array)
+  })
+
+  it('passes Prisma JsonNull and DbNull sentinels through by identity', () => {
+    expect(sanitizeNullBytes(Prisma.JsonNull)).toBe(Prisma.JsonNull)
+    expect(sanitizeNullBytes(Prisma.DbNull)).toBe(Prisma.DbNull)
+  })
+
+  it('passes primitives through unchanged', () => {
+    expect(sanitizeNullBytes(42)).toBe(42)
+    expect(sanitizeNullBytes(true)).toBe(true)
+    expect(sanitizeNullBytes(null)).toBe(null)
+    expect(sanitizeNullBytes(undefined)).toBe(undefined)
+    expect(sanitizeNullBytes(BigInt(42))).toBe(BigInt(42))
+  })
+
+  it('deep-cleans a realistic tool-call payload while preserving structure and untouched references', () => {
+    const untouchedSibling = { untouched: true }
+    const payload = {
+      data: {
+        state: {
+          typebotsQueue: [
+            {
+              typebot: {
+                variables: [{ id: 'v1', value: 'ped\u0000ido' }],
+              },
+            },
+          ],
+        },
+        sibling: untouchedSibling,
+      },
+    }
+
+    const result = sanitizeNullBytes(payload)
+
+    expect(result).toEqual({
+      data: {
+        state: {
+          typebotsQueue: [
+            {
+              typebot: {
+                variables: [{ id: 'v1', value: 'pedido' }],
+              },
+            },
+          ],
+        },
+        sibling: { untouched: true },
+      },
+    })
+    expect(result.data.sibling).toBe(untouchedSibling)
+  })
+
+  it('leaves object keys containing null bytes intact (values-only scope)', () => {
+    const input = { ['a\u0000b']: 'value' }
+    const result = sanitizeNullBytes(input)
+
+    expect(Object.keys(result)).toEqual(['a\u0000b'])
+    expect(result['a\u0000b']).toBe('value')
+  })
+})

--- a/packages/lib/sanitizeNullBytes.test.ts
+++ b/packages/lib/sanitizeNullBytes.test.ts
@@ -112,11 +112,12 @@ describe('sanitizeNullBytes', () => {
     expect(result.data.sibling).toBe(untouchedSibling)
   })
 
-  it('leaves object keys containing null bytes intact (values-only scope)', () => {
+  it('strips null bytes from object keys', () => {
     const input = { ['a\u0000b']: 'value' }
     const result = sanitizeNullBytes(input)
 
-    expect(Object.keys(result)).toEqual(['a\u0000b'])
-    expect(result['a\u0000b']).toBe('value')
+    expect(result).not.toBe(input)
+    expect(Object.keys(result)).toEqual(['ab'])
+    expect(result['ab']).toBe('value')
   })
 })

--- a/packages/lib/sanitizeNullBytes.test.ts
+++ b/packages/lib/sanitizeNullBytes.test.ts
@@ -123,12 +123,20 @@ describe('sanitizeNullBytes', () => {
     const result = sanitizeNullBytes(input)
 
     expect(Object.getPrototypeOf(result)).toBe(Object.prototype)
-    expect(Object.prototype.hasOwnProperty.call(result, '__proto__')).toBe(
-      true
-    )
-    expect(
-      (result as Record<string, unknown>)['__proto__']
-    ).toEqual({ polluted: true })
+    expect(Object.prototype.hasOwnProperty.call(result, '__proto__')).toBe(true)
+    expect((result as Record<string, unknown>)['__proto__']).toEqual({
+      polluted: true,
+    })
+  })
+
+  it('preserves a null prototype on sanitized copies', () => {
+    const input = Object.create(null) as Record<string, unknown>
+    input.dirty = 'foo\u0000bar'
+    const result = sanitizeNullBytes(input)
+
+    expect(result).not.toBe(input)
+    expect(Object.getPrototypeOf(result)).toBe(null)
+    expect(result.dirty).toBe('foobar')
   })
 
   it('strips null bytes from object keys', () => {
@@ -137,6 +145,6 @@ describe('sanitizeNullBytes', () => {
 
     expect(result).not.toBe(input)
     expect(Object.keys(result)).toEqual(['ab'])
-    expect(result['ab']).toBe('value')
+    expect((result as Record<string, unknown>)['ab']).toBe('value')
   })
 })

--- a/packages/lib/sanitizeNullBytes.test.ts
+++ b/packages/lib/sanitizeNullBytes.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { Prisma } from '@typebot.io/prisma'
 import { sanitizeNullBytes } from './sanitizeNullBytes'
+
+// Prisma's JsonNull/DbNull sentinels are class instances with a non-Object
+// prototype (verified against @prisma/client 5.12.1). Stubs keep this suite
+// free of the generated client, which CI's unit-test job never generates.
+class SentinelStub {}
+const jsonNullStub = new SentinelStub()
+const dbNullStub = new SentinelStub()
 
 describe('sanitizeNullBytes', () => {
   it('strips a single null byte from a string', () => {
@@ -63,9 +69,9 @@ describe('sanitizeNullBytes', () => {
     expect(sanitizeNullBytes(uint8Array)).toBe(uint8Array)
   })
 
-  it('passes Prisma JsonNull and DbNull sentinels through by identity', () => {
-    expect(sanitizeNullBytes(Prisma.JsonNull)).toBe(Prisma.JsonNull)
-    expect(sanitizeNullBytes(Prisma.DbNull)).toBe(Prisma.DbNull)
+  it('passes class-instance sentinels (Prisma JsonNull/DbNull shape) through by identity', () => {
+    expect(sanitizeNullBytes(jsonNullStub)).toBe(jsonNullStub)
+    expect(sanitizeNullBytes(dbNullStub)).toBe(dbNullStub)
   })
 
   it('passes primitives through unchanged', () => {

--- a/packages/lib/sanitizeNullBytes.ts
+++ b/packages/lib/sanitizeNullBytes.ts
@@ -36,7 +36,15 @@ export const sanitizeNullBytes = <T>(value: T): T => {
       const cleanedKey = sanitizeNullBytes(key)
       const cleaned = sanitizeNullBytes(value[key])
       if (cleanedKey !== key || cleaned !== value[key]) changed = true
-      next[cleanedKey] = cleaned
+      // defineProperty, not bracket assignment: a sanitized key equal to
+      // "__proto__" would otherwise hit the inherited Annex B setter and
+      // swap the copy's prototype instead of storing an own property.
+      Object.defineProperty(next, cleanedKey, {
+        value: cleaned,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      })
     }
     return (changed ? next : value) as T
   }

--- a/packages/lib/sanitizeNullBytes.ts
+++ b/packages/lib/sanitizeNullBytes.ts
@@ -7,11 +7,13 @@ const isPlainObject = (value: unknown): value is Record<string, unknown> => {
 }
 
 /**
- * Removes U+0000 from every string in a value tree. PostgreSQL text/jsonb
- * cannot store the null byte (error 22P05); AI agents occasionally send one
- * in tool-call args. Returns the same reference when nothing changed. Non-plain
- * objects (Date, Buffer, Prisma JsonNull/DbNull sentinels, Decimal) pass
- * through untouched by identity.
+ * Removes U+0000 from every string in a value tree, including object keys
+ * (jsonb rejects the null byte in keys too — external webhook responses are
+ * merged raw into session state). PostgreSQL text/jsonb cannot store the null
+ * byte (error 22P05); AI agents occasionally send one in tool-call args.
+ * Returns the same reference when nothing changed. Non-plain objects (Date,
+ * Buffer, Prisma JsonNull/DbNull sentinels, Decimal) pass through untouched
+ * by identity.
  */
 export const sanitizeNullBytes = <T>(value: T): T => {
   if (typeof value === 'string')
@@ -31,9 +33,10 @@ export const sanitizeNullBytes = <T>(value: T): T => {
     let changed = false
     const next: Record<string, unknown> = {}
     for (const key of Object.keys(value)) {
+      const cleanedKey = sanitizeNullBytes(key)
       const cleaned = sanitizeNullBytes(value[key])
-      if (cleaned !== value[key]) changed = true
-      next[key] = cleaned
+      if (cleanedKey !== key || cleaned !== value[key]) changed = true
+      next[cleanedKey] = cleaned
     }
     return (changed ? next : value) as T
   }

--- a/packages/lib/sanitizeNullBytes.ts
+++ b/packages/lib/sanitizeNullBytes.ts
@@ -1,0 +1,41 @@
+const NULL_BYTE = /\u0000/g
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  if (value === null || typeof value !== 'object') return false
+  const proto = Object.getPrototypeOf(value)
+  return proto === Object.prototype || proto === null
+}
+
+/**
+ * Removes U+0000 from every string in a value tree. PostgreSQL text/jsonb
+ * cannot store the null byte (error 22P05); AI agents occasionally send one
+ * in tool-call args. Returns the same reference when nothing changed. Non-plain
+ * objects (Date, Buffer, Prisma JsonNull/DbNull sentinels, Decimal) pass
+ * through untouched by identity.
+ */
+export const sanitizeNullBytes = <T>(value: T): T => {
+  if (typeof value === 'string')
+    return (
+      value.includes('\u0000') ? value.replace(NULL_BYTE, '') : value
+    ) as T
+  if (Array.isArray(value)) {
+    let changed = false
+    const next = value.map((item) => {
+      const cleaned = sanitizeNullBytes(item)
+      if (cleaned !== item) changed = true
+      return cleaned
+    })
+    return (changed ? next : value) as T
+  }
+  if (isPlainObject(value)) {
+    let changed = false
+    const next: Record<string, unknown> = {}
+    for (const key of Object.keys(value)) {
+      const cleaned = sanitizeNullBytes(value[key])
+      if (cleaned !== value[key]) changed = true
+      next[key] = cleaned
+    }
+    return (changed ? next : value) as T
+  }
+  return value
+}

--- a/packages/lib/sanitizeNullBytes.ts
+++ b/packages/lib/sanitizeNullBytes.ts
@@ -6,6 +6,22 @@ const isPlainObject = (value: unknown): value is Record<string, unknown> => {
   return proto === Object.prototype || proto === null
 }
 
+// defineProperty, not bracket assignment: a key equal to "__proto__" (whether
+// sanitized into it or already present as an own key, as JSON.parse can
+// produce) would otherwise hit the inherited Annex B setter and swap the
+// copy's prototype instead of storing an own property.
+const defineOwn = (
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown
+) =>
+  Object.defineProperty(target, key, {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  })
+
 /**
  * Removes U+0000 from every string in a value tree, including object keys
  * (jsonb rejects the null byte in keys too — external webhook responses are
@@ -14,6 +30,9 @@ const isPlainObject = (value: unknown): value is Record<string, unknown> => {
  * Returns the same reference when nothing changed. Non-plain objects (Date,
  * Buffer, Prisma JsonNull/DbNull sentinels, Decimal) pass through untouched
  * by identity.
+ *
+ * Runs on every Prisma write (middleware hot path), so copies are allocated
+ * lazily: a clean tree allocates nothing.
  */
 export const sanitizeNullBytes = <T>(value: T): T => {
   if (typeof value === 'string')
@@ -21,32 +40,34 @@ export const sanitizeNullBytes = <T>(value: T): T => {
       value.includes('\u0000') ? value.replace(NULL_BYTE, '') : value
     ) as T
   if (Array.isArray(value)) {
-    let changed = false
-    const next = value.map((item) => {
-      const cleaned = sanitizeNullBytes(item)
-      if (cleaned !== item) changed = true
-      return cleaned
-    })
-    return (changed ? next : value) as T
+    let next: unknown[] | undefined
+    for (let i = 0; i < value.length; i++) {
+      const cleaned = sanitizeNullBytes(value[i])
+      if (next === undefined && cleaned !== value[i]) next = value.slice(0, i)
+      if (next !== undefined) next.push(cleaned)
+    }
+    return (next ?? value) as T
   }
   if (isPlainObject(value)) {
-    let changed = false
-    const next: Record<string, unknown> = {}
-    for (const key of Object.keys(value)) {
-      const cleanedKey = sanitizeNullBytes(key)
+    const keys = Object.keys(value)
+    let next: Record<string, unknown> | undefined
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i]
       const cleaned = sanitizeNullBytes(value[key])
-      if (cleanedKey !== key || cleaned !== value[key]) changed = true
-      // defineProperty, not bracket assignment: a sanitized key equal to
-      // "__proto__" would otherwise hit the inherited Annex B setter and
-      // swap the copy's prototype instead of storing an own property.
-      Object.defineProperty(next, cleanedKey, {
-        value: cleaned,
-        writable: true,
-        enumerable: true,
-        configurable: true,
-      })
+      const cleanedKey = sanitizeNullBytes(key)
+      if (
+        next === undefined &&
+        (cleanedKey !== key || cleaned !== value[key])
+      ) {
+        next = Object.create(Object.getPrototypeOf(value)) as Record<
+          string,
+          unknown
+        >
+        for (let j = 0; j < i; j++) defineOwn(next, keys[j], value[keys[j]])
+      }
+      if (next !== undefined) defineOwn(next, cleanedKey, cleaned)
     }
-    return (changed ? next : value) as T
+    return (next ?? value) as T
   }
   return value
 }

--- a/packages/prisma/index.ts
+++ b/packages/prisma/index.ts
@@ -21,4 +21,7 @@ const prismaInstance =
 
 if (process.env.NODE_ENV !== 'production') global.prisma = prismaInstance
 
+// Script/test-only client (packages/scripts, Playwright fixtures). Unlike
+// @typebot.io/lib/prisma, it has NO null-byte sanitizer middleware — runtime
+// code must import the client from @typebot.io/lib/prisma instead.
 export const prisma: PrismaClient = prismaInstance


### PR DESCRIPTION
## Problem

MCP tool calls on the viewer (`/api/mcp` `tools/call`) fail with `PrismaClientUnknownRequestError` → PostgresError **22P05** `"unsupported Unicode escape sequence — NUL cannot be converted to text"` inside `prisma.chatSession.create()` (~21×/day in production, LangSmith alert "Typebot — tools falhando").

Root cause (traced end-to-end): an AI agent occasionally sends a tool-call argument containing a literal **null byte (U+0000)**. The value flows through `prefilledVariables` → `prefillVariables`/`safeStringify` (pure passthrough for strings) → `SessionState` → `chatSession.create`. PostgreSQL can *never* store U+0000 in `jsonb`/`text` (C-string backend) — no server-side setting allows it, and swapping `jsonb` for `json` only delays the same error to query time.

The vulnerable surface is wider than the crashing call: `updateSession`, `restartSession`, `upsertResult` (`Result.variables` + nested `Log`/`SetVariableHistoryItem`), `saveAnswer`, `saveLogs` all persist user/external strings into jsonb/text, and null bytes can also enter via chat replies and HTTP-block responses. No sanitization existed anywhere in the repo; upstream Typebot has no fix.

## Fix

One global choke point instead of per-callsite patches: a second `$use` middleware on the shared Prisma client (`packages/lib/prisma.ts`, used by builder **and** viewer) deep-strips U+0000 from string values on `create`/`createMany`/`update`/`updateMany`/`upsert` — covering every current and future write, including nested `createMany` payloads.

The helper (`packages/lib/sanitizeNullBytes.ts`) is pure and immutable:

- fast-path: clean payloads return the **same reference** (no allocation on the hot write path)
- prototype-guard passes `Date`, `Buffer`/`Uint8Array`, and `Prisma.JsonNull`/`DbNull` sentinels through by identity (Prisma matches sentinels by identity)
- values-only scope; U+0000 only (lone surrogates raise a different error, 22021, never observed)

Reads are untouched.

## Test

- [x] Unit: 12 vitest cases (`packages/lib/sanitizeNullBytes.test.ts`) — strip single/multiple/nested, reference-equality fast path, immutability, Date/Buffer/sentinel identity, realistic SessionState payload — 12/12 green
- [x] E2E before/after on local compose stack: `tools/call` with `"pedido": "12345\u0000ABC"` — **before** (fix stashed): JSON-RPC error with the exact production 22P05; **after**: 200, stored value `12345ABC`, zero U+0000 in persisted state
- [x] Smoke: null-byte-free tool call unaffected
- [ ] Post-deploy: Datadog `service:typebot-viewer "MCP request failed"` — shopee 22P05 pattern (~1/h) stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

A mudança é segura para merge — adiciona um middleware imutável e de alocação preguiçosa que resolve um crash de produção confirmado sem alterar nenhuma lógica de leitura ou contrato de API existente.

A implementação é correta, bem testada (13 casos unitários cobrindo fast-path, proto-pollution, null-prototype, sentinelas Prisma e payloads realistas) e verificada em stack local com o cenário exato de produção. Os imports de @typebot.io/prisma em código de runtime fora de packages/scripts/ são apenas de tipos, não da instância sem sanitização. Nenhum comportamento incorreto foi identificado nos caminhos de escrita cobertos.

Nenhum arquivo requer atenção especial.

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Agent as Agente MCP
    participant API as /api/mcp (viewer)
    participant PrismaLib as @typebot.io/lib/prisma
    participant MW1 as Middleware 1 (timing)
    participant MW2 as Middleware 2 (sanitizeNullBytes)
    participant PG as PostgreSQL

    Agent->>API: tools/call com args contendo U+0000
    API->>PrismaLib: "chatSession.create({ data: { ... } })"
    PrismaLib->>MW1: "params.action = create"
    MW1->>MW2: next(params)
    MW2->>MW2: sanitizeNullBytes(params.args) strip U+0000
    MW2->>PG: query com payload limpo
    PG-->>MW2: row criada sem 22P05
    MW2-->>MW1: result
    MW1-->>PrismaLib: result
    PrismaLib-->>API: ChatSession
    API-->>Agent: 200 OK
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Agent as Agente MCP
    participant API as /api/mcp (viewer)
    participant PrismaLib as @typebot.io/lib/prisma
    participant MW1 as Middleware 1 (timing)
    participant MW2 as Middleware 2 (sanitizeNullBytes)
    participant PG as PostgreSQL

    Agent->>API: tools/call com args contendo U+0000
    API->>PrismaLib: "chatSession.create({ data: { ... } })"
    PrismaLib->>MW1: "params.action = create"
    MW1->>MW2: next(params)
    MW2->>MW2: sanitizeNullBytes(params.args) strip U+0000
    MW2->>PG: query com payload limpo
    PG-->>MW2: row criada sem 22P05
    MW2-->>MW1: result
    MW1-->>PrismaLib: result
    PrismaLib-->>API: ChatSession
    API-->>Agent: 200 OK
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["perf(lib): allocate sanitized copies laz..."](https://github.com/cloudhumans/typebot.io/commit/c1173c728974f68e6a514715901e7583a9832d2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41696399)</sub>

<!-- /greptile_comment -->