### PR TITLE
feat: expose resultId in continueChat response

### DIFF
--- a/packages/bot-engine/apiHandlers/continueChat.ts
+++ b/packages/bot-engine/apiHandlers/continueChat.ts
@@ -113,6 +113,7 @@ export const continueChat = async ({
   return {
     messages,
     input,
+    resultId: session.state.typebotsQueue[0].resultId,
     clientSideActions,
     dynamicTheme: parseDynamicTheme(newSessionState),
     logs: isPreview ? logs : logs?.filter(filterPotentiallySensitiveLogs),

--- a/packages/bot-engine/apiHandlers/continueChat.ts
+++ b/packages/bot-engine/apiHandlers/continueChat.ts
@@ -113,7 +113,7 @@ export const continueChat = async ({
   return {
     messages,
     input,
-    resultId: session.state.typebotsQueue[0].resultId,
+    resultId: session.state.typebotsQueue.at(0)?.resultId,
     clientSideActions,
     dynamicTheme: parseDynamicTheme(newSessionState),
     logs: isPreview ? logs : logs?.filter(filterPotentiallySensitiveLogs),

--- a/packages/schemas/features/chat/schema.ts
+++ b/packages/schemas/features/chat/schema.ts
@@ -392,6 +392,7 @@ export const startPreviewChatResponseSchema = startChatResponseSchema.omit({
 })
 
 export const continueChatResponseSchema = chatResponseBaseSchema.extend({
+  resultId: z.string().optional(),
   toolOutput: z
     .unknown()
     .optional()


### PR DESCRIPTION
## Resumo
`continueChat` agora retorna o `resultId` da sessão no seu response — o `startChat` já retornava. Campo **opcional/aditivo**, sem alteração de rota.

## Contexto
Parte 1 (upstream) do fix de robustez das **Métricas de Performance dos Eddies**. Hoje o cruzamento de um result do Eddie com a conversa/CSAT/SLA no datalake depende da variável `helpdeskId` capturada pelo fluxo — frágil e inexistente em bots de integração. Expondo o `resultId` em todo turno, a ClaudIA (PR seguinte) pode persistí-lo e habilitar o join canônico durável `claudia_conversation.active_flow_result_id = eddie_rs_results.id`.

## Mudanças
- `packages/schemas/features/chat/schema.ts`: `resultId: z.string().optional()` no `continueChatResponseSchema`.
- `packages/bot-engine/apiHandlers/continueChat.ts`: retorna `resultId: session.state.typebotsQueue[0].resultId`.

## Blast radius
Baixo. Campo opcional -> embeds/builder ignoram sem quebrar. Em preview o valor é `undefined` (consistente com `startPreviewChatResponseSchema`). O acesso já é usado no mesmo handler (linha do `isPreview`).

## Como testar
Iniciar e continuar uma conversa num fluxo com result persistido (não-preview) e verificar que o JSON do `continueChat` traz `resultId`.

Azure: AB#7826 — https://dev.azure.com/cloudhumans/ClaudIA/_workitems/edit/7826

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

A mudança parece segura para merge, com um ajuste pequeno recomendado para sessões antigas sem result no estado.

- O novo campo é aditivo e opcional no schema.
- O acesso ao `typebotsQueue[0].resultId` já existia no mesmo handler.
- Sessões live novas devem retornar o id corretamente; sessões migradas sem esse valor ainda podem receber `undefined`.

packages/bot-engine/apiHandlers/continueChat.ts

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fbot-engine%2FapiHandlers%2FcontinueChat.ts%3A116%0A**Sess%C3%B5es%20Migradas%20Sem%20ResultId**%0A%0AQuando%20uma%20sess%C3%A3o%20live%20antiga%20foi%20migrada%20sem%20%60resultId%60%20no%20estado%2C%20este%20campo%20novo%20volta%20como%20%60undefined%60%2C%20embora%20o%20objetivo%20do%20response%20seja%20permitir%20o%20join%20dur%C3%A1vel%20pelo%20id%20do%20result.%20Nesse%20caso%2C%20o%20cliente%20recebe%20um%20%60continueChat%60%20v%C3%A1lido%2C%20mas%20ainda%20n%C3%A3o%20consegue%20correlacionar%20a%20conversa%20com%20o%20result.%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=254&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fbot-engine%2FapiHandlers%2FcontinueChat.ts%3A116%0A**Sess%C3%B5es%20Migradas%20Sem%20ResultId**%0A%0AQuando%20uma%20sess%C3%A3o%20live%20antiga%20foi%20migrada%20sem%20%60resultId%60%20no%20estado%2C%20este%20campo%20novo%20volta%20como%20%60undefined%60%2C%20embora%20o%20objetivo%20do%20response%20seja%20permitir%20o%20join%20dur%C3%A1vel%20pelo%20id%20do%20result.%20Nesse%20caso%2C%20o%20cliente%20recebe%20um%20%60continueChat%60%20v%C3%A1lido%2C%20mas%20ainda%20n%C3%A3o%20consegue%20correlacionar%20a%20conversa%20com%20o%20result.%0A%0A&pr=254&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/bot-engine/apiHandlers/continueChat.ts:116
**Sessões Migradas Sem ResultId**

Quando uma sessão live antiga foi migrada sem `resultId` no estado, este campo novo volta como `undefined`, embora o objetivo do response seja permitir o join durável pelo id do result. Nesse caso, o cliente recebe um `continueChat` válido, mas ainda não consegue correlacionar a conversa com o result.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: expose resultId in continueChat re..."](https://github.com/cloudhumans/typebot.io/commit/f22f0eb89ea5817f6e826b82a70fe5f0a2f32de6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42371238)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Make all comments in Brazilian Portuguese (ptBR) ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->