### PR TITLE
feat: make tool name immutable (block rename/archive/delete of tools)

### DIFF
--- a/apps/builder/src/features/editor/components/EditableTypebotName.tsx
+++ b/apps/builder/src/features/editor/components/EditableTypebotName.tsx
@@ -2,6 +2,7 @@ import {
   Editable,
   EditablePreview,
   EditableInput,
+  Text,
   Tooltip,
   useColorModeValue,
 } from '@chakra-ui/react'
@@ -11,10 +12,12 @@ import { useTranslate } from '@tolgee/react'
 type EditableProps = {
   defaultName: string
   onNewName: (newName: string) => void
+  isReadOnly?: boolean
 }
 export const EditableTypebotName = ({
   defaultName,
   onNewName,
+  isReadOnly = false,
 }: EditableProps) => {
   const { t } = useTranslate()
   const emptyNameBg = useColorModeValue('gray.100', 'gray.700')
@@ -25,6 +28,22 @@ export const EditableTypebotName = ({
     if (newName === defaultName) return
     onNewName(newName)
   }
+
+  if (isReadOnly)
+    return (
+      <Tooltip label={t('editor.header.toolName.immutable.tooltip')}>
+        <Text
+          noOfLines={2}
+          maxW="150px"
+          overflow="hidden"
+          fontSize="14px"
+          minW="30px"
+          minH="20px"
+        >
+          {currentName}
+        </Text>
+      </Tooltip>
+    )
 
   return (
     <Tooltip label={t('rename')}>

--- a/apps/builder/src/features/editor/components/TypebotHeader.tsx
+++ b/apps/builder/src/features/editor/components/TypebotHeader.tsx
@@ -205,6 +205,7 @@ const LeftElements = ({
             key={`typebot-name-${typebot?.name ?? ''}`}
             defaultName={typebot?.name ?? ''}
             onNewName={handleNameSubmit}
+            isReadOnly={typebot?.settings?.general?.type === 'TOOL'}
           />
           )
         </HStack>

--- a/apps/builder/src/features/typebot/api/createTypebot.test.ts
+++ b/apps/builder/src/features/typebot/api/createTypebot.test.ts
@@ -1,4 +1,5 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { router } from '@/helpers/server/trpc'
 import { createTypebot } from './createTypebot'
 import { WorkspaceRole, Plan } from '@typebot.io/prisma'
 import { getUserRoleInWorkspace } from '@/features/workspace/helpers/getUserRoleInWorkspace'
@@ -11,6 +12,7 @@ vi.mock('@typebot.io/lib/prisma', () => ({
     },
     typebot: {
       create: vi.fn(),
+      findMany: vi.fn(),
     },
     dashboardFolder: {
       findUnique: vi.fn(),
@@ -46,16 +48,19 @@ describe('createTypebot', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mockWorkspace as any
     )
+    vi.mocked(prisma.typebot.findMany).mockResolvedValue([])
     vi.mocked(getUserRoleInWorkspace).mockReturnValue(WorkspaceRole.ADMIN)
   })
 
   it('should throw if TOOL is missing tenant', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const caller = createTypebot.createCaller({ user: mockUser } as any)
+    const caller = router({ createTypebot }).createCaller({
+      user: mockUser,
+    } as never)
 
     await expect(
-      caller({
+      caller.createTypebot({
         workspaceId: mockWorkspace.id,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -73,10 +78,12 @@ describe('createTypebot', () => {
   it('should throw if TOOL is missing toolDescription', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const caller = createTypebot.createCaller({ user: mockUser } as any)
+    const caller = router({ createTypebot }).createCaller({
+      user: mockUser,
+    } as never)
 
     await expect(
-      caller({
+      caller.createTypebot({
         workspaceId: mockWorkspace.id,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -105,10 +112,12 @@ describe('createTypebot', () => {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const caller = createTypebot.createCaller({ user: mockUser } as any)
+    const caller = router({ createTypebot }).createCaller({
+      user: mockUser,
+    } as never)
 
     await expect(
-      caller({
+      caller.createTypebot({
         workspaceId: mockWorkspace.id,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         typebot: {
@@ -117,6 +126,67 @@ describe('createTypebot', () => {
           tenant: 'ten-1',
           toolDescription: 'desc',
         },
+      })
+    ).resolves.toBeDefined()
+  })
+
+  it('should throw if a TOOL with a colliding sanitized name exists in the tenant', async () => {
+    vi.mocked(prisma.typebot.findMany).mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { name: 'Get Order' } as any,
+    ])
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const caller = router({ createTypebot }).createCaller({
+      user: mockUser,
+    } as never)
+
+    await expect(
+      caller.createTypebot({
+        workspaceId: mockWorkspace.id,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        typebot: {
+          name: 'get order',
+          settings: { general: { type: 'TOOL' } },
+          tenant: 'ten-1',
+          toolDescription: 'desc',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+      })
+    ).rejects.toThrow('already exists in this tenant')
+  })
+
+  it('should create a TOOL when the same name exists in a different tenant', async () => {
+    // findMany is scoped by tenant, so a colliding name in another tenant is
+    // simply not returned here.
+    vi.mocked(prisma.typebot.findMany).mockResolvedValue([])
+    vi.mocked(prisma.typebot.create).mockResolvedValue({
+      id: 'tb-3',
+      workspaceId: mockWorkspace.id,
+      name: 'Get Order',
+      settings: { general: { type: 'TOOL' } },
+      tenant: 'ten-2',
+      toolDescription: 'desc',
+      groups: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const caller = router({ createTypebot }).createCaller({
+      user: mockUser,
+    } as never)
+
+    await expect(
+      caller.createTypebot({
+        workspaceId: mockWorkspace.id,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        typebot: {
+          name: 'Get Order',
+          settings: { general: { type: 'TOOL' } },
+          tenant: 'ten-2',
+          toolDescription: 'desc',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
       })
     ).resolves.toBeDefined()
   })
@@ -133,10 +203,12 @@ describe('createTypebot', () => {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const caller = createTypebot.createCaller({ user: mockUser } as any)
+    const caller = router({ createTypebot }).createCaller({
+      user: mockUser,
+    } as never)
 
     await expect(
-      caller({
+      caller.createTypebot({
         workspaceId: mockWorkspace.id,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         typebot: {

--- a/apps/builder/src/features/typebot/api/createTypebot.test.ts
+++ b/apps/builder/src/features/typebot/api/createTypebot.test.ts
@@ -130,6 +130,27 @@ describe('createTypebot', () => {
     ).resolves.toBeDefined()
   })
 
+  it('should throw if a TOOL name sanitizes to an empty MCP name', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const caller = router({ createTypebot }).createCaller({
+      user: mockUser,
+    } as never)
+
+    await expect(
+      caller.createTypebot({
+        workspaceId: mockWorkspace.id,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        typebot: {
+          name: '!!!',
+          settings: { general: { type: 'TOOL' } },
+          tenant: 'ten-1',
+          toolDescription: 'desc',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+      })
+    ).rejects.toThrow('at least one letter or number')
+  })
+
   it('should throw if a TOOL with a colliding sanitized name exists in the tenant', async () => {
     vi.mocked(prisma.typebot.findMany).mockResolvedValue([
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/builder/src/features/typebot/api/createTypebot.ts
+++ b/apps/builder/src/features/typebot/api/createTypebot.ts
@@ -15,6 +15,7 @@ import {
 import { createId } from '@paralleldrive/cuid2'
 import { EventType } from '@typebot.io/schemas/features/events/constants'
 import { trackEvents } from '@typebot.io/telemetry/trackEvents'
+import { isToolNameTaken } from '../helpers/isToolNameTaken'
 
 const typebotCreateSchemaPick = {
   name: true,
@@ -97,14 +98,23 @@ export const createTypebot = authenticatedProcedure
         message: 'Name is mandatory',
       })
 
-    if (
-      typebot.settings?.general?.type === 'TOOL' &&
-      (!typebot.tenant || !typebot.toolDescription)
-    )
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: 'Tenant and Tool description are mandatory for Tool workflows',
-      })
+    if (typebot.settings?.general?.type === 'TOOL') {
+      if (!typebot.tenant || !typebot.toolDescription)
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message:
+            'Tenant and Tool description are mandatory for Tool workflows',
+        })
+
+      if (
+        typebot.name &&
+        (await isToolNameTaken({ name: typebot.name, tenant: typebot.tenant }))
+      )
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `A tool named '${typebot.name}' already exists in this tenant. Tool names must be unique.`,
+        })
+    }
 
     if (typebot.folderId) {
       const existingFolder = await prisma.dashboardFolder.findUnique({

--- a/apps/builder/src/features/typebot/api/createTypebot.ts
+++ b/apps/builder/src/features/typebot/api/createTypebot.ts
@@ -16,6 +16,7 @@ import { createId } from '@paralleldrive/cuid2'
 import { EventType } from '@typebot.io/schemas/features/events/constants'
 import { trackEvents } from '@typebot.io/telemetry/trackEvents'
 import { isToolNameTaken } from '../helpers/isToolNameTaken'
+import { sanitizeToolName } from '@typebot.io/lib/sanitizeToolName'
 
 const typebotCreateSchemaPick = {
   name: true,
@@ -104,6 +105,13 @@ export const createTypebot = authenticatedProcedure
           code: 'BAD_REQUEST',
           message:
             'Tenant and Tool description are mandatory for Tool workflows',
+        })
+
+      if (typebot.name && sanitizeToolName(typebot.name) === '')
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message:
+            'Tool name must contain at least one letter or number so the agent can reference it.',
         })
 
       if (

--- a/apps/builder/src/features/typebot/api/createTypebot.ts
+++ b/apps/builder/src/features/typebot/api/createTypebot.ts
@@ -107,17 +107,14 @@ export const createTypebot = authenticatedProcedure
             'Tenant and Tool description are mandatory for Tool workflows',
         })
 
-      if (typebot.name && sanitizeToolName(typebot.name) === '')
+      if (sanitizeToolName(typebot.name) === '')
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message:
             'Tool name must contain at least one letter or number so the agent can reference it.',
         })
 
-      if (
-        typebot.name &&
-        (await isToolNameTaken({ name: typebot.name, tenant: typebot.tenant }))
-      )
+      if (await isToolNameTaken({ name: typebot.name, tenant: typebot.tenant }))
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: `A tool named '${typebot.name}' already exists in this tenant. Tool names must be unique.`,

--- a/apps/builder/src/features/typebot/api/deleteTypebot.test.ts
+++ b/apps/builder/src/features/typebot/api/deleteTypebot.test.ts
@@ -1,0 +1,88 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { router } from '@/helpers/server/trpc'
+import { deleteTypebot } from './deleteTypebot'
+import { WorkspaceRole } from '@typebot.io/prisma'
+import prisma from '@typebot.io/lib/prisma'
+import { isWriteTypebotForbidden } from '../helpers/isWriteTypebotForbidden'
+
+vi.mock('@typebot.io/lib/prisma', () => ({
+  default: {
+    typebot: {
+      findFirst: vi.fn(),
+      delete: vi.fn(),
+    },
+    typebotEditQueue: { deleteMany: vi.fn() },
+    bannedIp: { deleteMany: vi.fn() },
+    $executeRaw: vi.fn(),
+    $transaction: vi.fn(),
+  },
+}))
+vi.mock('../helpers/isWriteTypebotForbidden', () => ({
+  isWriteTypebotForbidden: vi.fn(),
+}))
+
+describe('deleteTypebot', () => {
+  const mockUser = { id: 'user-1', email: 'test@test.com' }
+
+  const baseExistingTypebot = {
+    id: 'tb-1',
+    workspace: {
+      id: 'ws-1',
+      name: 'ws',
+      isSuspended: false,
+      isPastDue: false,
+      members: [{ userId: mockUser.id, role: WorkspaceRole.ADMIN }],
+    },
+    collaborators: [],
+  }
+
+  const caller = () =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    router({ deleteTypebot }).createCaller({ user: mockUser } as never)
+      .deleteTypebot
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(isWriteTypebotForbidden).mockResolvedValue(false)
+    vi.mocked(prisma.$transaction).mockResolvedValue([])
+  })
+
+  it('should reject deleting a published TOOL', async () => {
+    vi.mocked(prisma.typebot.findFirst).mockResolvedValue({
+      ...baseExistingTypebot,
+      settings: { general: { type: 'TOOL' } },
+      publishedTypebot: { id: 'pub-1' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+
+    await expect(caller()({ typebotId: 'tb-1' })).rejects.toThrow(
+      'Published tools cannot be deleted'
+    )
+  })
+
+  it('should allow deleting a never-published (draft) TOOL', async () => {
+    vi.mocked(prisma.typebot.findFirst).mockResolvedValue({
+      ...baseExistingTypebot,
+      settings: { general: { type: 'TOOL' } },
+      publishedTypebot: null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+
+    await expect(caller()({ typebotId: 'tb-1' })).resolves.toEqual({
+      message: 'success',
+    })
+  })
+
+  it('should allow deleting a published non-TOOL flow', async () => {
+    vi.mocked(prisma.typebot.findFirst).mockResolvedValue({
+      ...baseExistingTypebot,
+      settings: { general: { type: 'default' } },
+      publishedTypebot: { id: 'pub-1' },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+
+    await expect(caller()({ typebotId: 'tb-1' })).resolves.toEqual({
+      message: 'success',
+    })
+  })
+})

--- a/apps/builder/src/features/typebot/api/deleteTypebot.ts
+++ b/apps/builder/src/features/typebot/api/deleteTypebot.ts
@@ -1,6 +1,7 @@
 import prisma from '@typebot.io/lib/prisma'
 import { authenticatedProcedure } from '@/helpers/server/trpc'
 import { TRPCError } from '@trpc/server'
+import { Settings } from '@typebot.io/schemas'
 import { z } from 'zod'
 import { isWriteTypebotForbidden } from '../helpers/isWriteTypebotForbidden'
 
@@ -35,6 +36,8 @@ export const deleteTypebot = authenticatedProcedure
       },
       select: {
         id: true,
+        settings: true,
+        publishedTypebot: { select: { id: true } },
         workspace: {
           select: {
             id: true,
@@ -62,6 +65,16 @@ export const deleteTypebot = authenticatedProcedure
       (await isWriteTypebotForbidden(existingTypebot, user))
     )
       throw new TRPCError({ code: 'NOT_FOUND', message: 'Typebot not found' })
+
+    const isTool =
+      !!existingTypebot.settings &&
+      (existingTypebot.settings as unknown as Settings).general?.type === 'TOOL'
+
+    if (isTool && existingTypebot.publishedTypebot)
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'Published tools cannot be deleted',
+      })
 
     await prisma.$transaction([
       prisma.$executeRaw`

--- a/apps/builder/src/features/typebot/api/importTypebot.test.ts
+++ b/apps/builder/src/features/typebot/api/importTypebot.test.ts
@@ -1,0 +1,94 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { router } from '@/helpers/server/trpc'
+import { importTypebot } from './importTypebot'
+import { WorkspaceRole, Plan } from '@typebot.io/prisma'
+import { getUserRoleInWorkspace } from '@/features/workspace/helpers/getUserRoleInWorkspace'
+import { parseTestTypebot } from '@typebot.io/playwright/databaseHelpers'
+import prisma from '@typebot.io/lib/prisma'
+
+vi.mock('@typebot.io/lib/prisma', () => ({
+  default: {
+    workspace: {
+      findUnique: vi.fn(),
+    },
+    typebot: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+}))
+vi.mock('@typebot.io/telemetry/trackEvents', () => ({
+  trackEvents: vi.fn(),
+}))
+vi.mock('@typebot.io/migrations/migrateTypebot', () => ({
+  migrateTypebot: vi.fn((t) => t),
+}))
+vi.mock('../helpers/sanitizers', () => ({
+  sanitizeFolderId: vi.fn(() => undefined),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sanitizeGroups: vi.fn(() => (groups: any) => groups),
+  sanitizeSettings: vi.fn((s) => s),
+  sanitizeVariables: vi.fn(() => []),
+}))
+vi.mock('@/features/workspace/helpers/getUserRoleInWorkspace', () => ({
+  getUserRoleInWorkspace: vi.fn(),
+}))
+
+describe('importTypebot', () => {
+  const mockUser = { id: 'user-1', email: 'test@test.com' }
+  const mockWorkspace = {
+    id: 'ws-1',
+    members: [{ userId: mockUser.id, role: WorkspaceRole.ADMIN }],
+    plan: Plan.FREE,
+  }
+
+  const toolTypebot = (name: string) =>
+    parseTestTypebot({
+      version: '6',
+      name,
+      tenant: 'ten-1',
+      toolDescription: 'desc',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      settings: { general: { type: 'TOOL' } } as any,
+    })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(prisma.workspace.findUnique).mockResolvedValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockWorkspace as any
+    )
+    vi.mocked(prisma.typebot.findMany).mockResolvedValue([])
+    vi.mocked(getUserRoleInWorkspace).mockReturnValue(WorkspaceRole.ADMIN)
+  })
+
+  const caller = () =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    router({ importTypebot }).createCaller({ user: mockUser } as never)
+      .importTypebot
+
+  it('should throw if an imported TOOL name sanitizes to an empty MCP name', async () => {
+    await expect(
+      caller()({
+        workspaceId: mockWorkspace.id,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        typebot: toolTypebot('!!!') as any,
+      })
+    ).rejects.toThrow('at least one letter or number')
+  })
+
+  it('should throw if an imported TOOL collides with an existing tool in the tenant', async () => {
+    vi.mocked(prisma.typebot.findMany).mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { name: 'Get Order' } as any,
+    ])
+
+    await expect(
+      caller()({
+        workspaceId: mockWorkspace.id,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        typebot: toolTypebot('get order') as any,
+      })
+    ).rejects.toThrow('already exists in this tenant')
+  })
+})

--- a/apps/builder/src/features/typebot/api/importTypebot.test.ts
+++ b/apps/builder/src/features/typebot/api/importTypebot.test.ts
@@ -91,4 +91,24 @@ describe('importTypebot', () => {
       })
     ).rejects.toThrow('already exists in this tenant')
   })
+
+  it('should throw if an imported TOOL has no tenant', async () => {
+    const typebot = parseTestTypebot({
+      version: '6',
+      name: 'Get Order',
+      toolDescription: 'desc',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      settings: { general: { type: 'TOOL' } } as any,
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (typebot as any).tenant
+
+    await expect(
+      caller()({
+        workspaceId: mockWorkspace.id,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        typebot: typebot as any,
+      })
+    ).rejects.toThrow('Tenant and Tool description are mandatory')
+  })
 })

--- a/apps/builder/src/features/typebot/api/importTypebot.ts
+++ b/apps/builder/src/features/typebot/api/importTypebot.ts
@@ -21,6 +21,7 @@ import { preprocessTypebot } from '@typebot.io/schemas/features/typebot/helpers/
 import { migrateTypebot } from '@typebot.io/migrations/migrateTypebot'
 import { trackEvents } from '@typebot.io/telemetry/trackEvents'
 import { isToolNameTaken } from '../helpers/isToolNameTaken'
+import { sanitizeToolName } from '@typebot.io/lib/sanitizeToolName'
 
 const omittedProps = {
   id: true,
@@ -129,19 +130,27 @@ export const importTypebot = authenticatedProcedure
 
     const migratedTypebot = await migrateImportingTypebot(typebot)
 
-    if (
-      migratedTypebot.settings?.general?.type === 'TOOL' &&
-      migratedTypebot.tenant &&
-      migratedTypebot.name &&
-      (await isToolNameTaken({
-        name: migratedTypebot.name,
-        tenant: migratedTypebot.tenant,
-      }))
-    )
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: `A tool named '${migratedTypebot.name}' already exists in this tenant. Tool names must be unique.`,
-      })
+    if (migratedTypebot.settings?.general?.type === 'TOOL') {
+      if (migratedTypebot.name && sanitizeToolName(migratedTypebot.name) === '')
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message:
+            'Tool name must contain at least one letter or number so the agent can reference it.',
+        })
+
+      if (
+        migratedTypebot.tenant &&
+        migratedTypebot.name &&
+        (await isToolNameTaken({
+          name: migratedTypebot.name,
+          tenant: migratedTypebot.tenant,
+        }))
+      )
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `A tool named '${migratedTypebot.name}' already exists in this tenant. Tool names must be unique.`,
+        })
+    }
 
     const groups = (
       migratedTypebot.groups

--- a/apps/builder/src/features/typebot/api/importTypebot.ts
+++ b/apps/builder/src/features/typebot/api/importTypebot.ts
@@ -20,6 +20,7 @@ import {
 import { preprocessTypebot } from '@typebot.io/schemas/features/typebot/helpers/preprocessTypebot'
 import { migrateTypebot } from '@typebot.io/migrations/migrateTypebot'
 import { trackEvents } from '@typebot.io/telemetry/trackEvents'
+import { isToolNameTaken } from '../helpers/isToolNameTaken'
 
 const omittedProps = {
   id: true,
@@ -127,6 +128,20 @@ export const importTypebot = authenticatedProcedure
       throw new TRPCError({ code: 'NOT_FOUND', message: 'Workspace not found' })
 
     const migratedTypebot = await migrateImportingTypebot(typebot)
+
+    if (
+      migratedTypebot.settings?.general?.type === 'TOOL' &&
+      migratedTypebot.tenant &&
+      migratedTypebot.name &&
+      (await isToolNameTaken({
+        name: migratedTypebot.name,
+        tenant: migratedTypebot.tenant,
+      }))
+    )
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: `A tool named '${migratedTypebot.name}' already exists in this tenant. Tool names must be unique.`,
+      })
 
     const groups = (
       migratedTypebot.groups

--- a/apps/builder/src/features/typebot/api/importTypebot.ts
+++ b/apps/builder/src/features/typebot/api/importTypebot.ts
@@ -131,6 +131,13 @@ export const importTypebot = authenticatedProcedure
     const migratedTypebot = await migrateImportingTypebot(typebot)
 
     if (migratedTypebot.settings?.general?.type === 'TOOL') {
+      if (!migratedTypebot.tenant || !migratedTypebot.toolDescription)
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message:
+            'Tenant and Tool description are mandatory for Tool workflows',
+        })
+
       if (sanitizeToolName(migratedTypebot.name) === '')
         throw new TRPCError({
           code: 'BAD_REQUEST',
@@ -139,11 +146,10 @@ export const importTypebot = authenticatedProcedure
         })
 
       if (
-        migratedTypebot.tenant &&
-        (await isToolNameTaken({
+        await isToolNameTaken({
           name: migratedTypebot.name,
           tenant: migratedTypebot.tenant,
-        }))
+        })
       )
         throw new TRPCError({
           code: 'BAD_REQUEST',

--- a/apps/builder/src/features/typebot/api/importTypebot.ts
+++ b/apps/builder/src/features/typebot/api/importTypebot.ts
@@ -131,7 +131,7 @@ export const importTypebot = authenticatedProcedure
     const migratedTypebot = await migrateImportingTypebot(typebot)
 
     if (migratedTypebot.settings?.general?.type === 'TOOL') {
-      if (migratedTypebot.name && sanitizeToolName(migratedTypebot.name) === '')
+      if (sanitizeToolName(migratedTypebot.name) === '')
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message:
@@ -140,7 +140,6 @@ export const importTypebot = authenticatedProcedure
 
       if (
         migratedTypebot.tenant &&
-        migratedTypebot.name &&
         (await isToolNameTaken({
           name: migratedTypebot.name,
           tenant: migratedTypebot.tenant,

--- a/apps/builder/src/features/typebot/api/updateTypebot.test.ts
+++ b/apps/builder/src/features/typebot/api/updateTypebot.test.ts
@@ -1,0 +1,175 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { router } from '@/helpers/server/trpc'
+import { updateTypebot } from './updateTypebot'
+import { WorkspaceRole, Plan } from '@typebot.io/prisma'
+import prisma from '@typebot.io/lib/prisma'
+import { isWriteTypebotForbidden } from '../helpers/isWriteTypebotForbidden'
+
+vi.mock('@typebot.io/lib/prisma', () => ({
+  default: {
+    typebot: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}))
+vi.mock('../helpers/isWriteTypebotForbidden', () => ({
+  isWriteTypebotForbidden: vi.fn(),
+}))
+vi.mock('@/helpers/isCloudProdInstance', () => ({
+  isCloudProdInstance: vi.fn(() => false),
+}))
+vi.mock('@typebot.io/migrations/migrateTypebot', () => ({
+  migrateTypebot: vi.fn((t) => t),
+}))
+vi.mock('../helpers/sanitizers', () => ({
+  isCustomDomainNotAvailable: vi.fn(() => false),
+  isPublicIdNotAvailable: vi.fn(() => false),
+  sanitizeCustomDomain: vi.fn(() => undefined),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sanitizeGroups: vi.fn(() => (groups: any) => groups),
+  sanitizeSettings: vi.fn((s) => s),
+  sanitizeVariables: vi.fn(() => []),
+}))
+vi.mock('@typebot.io/schemas', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@typebot.io/schemas')>()
+  return {
+    ...actual,
+    typebotSchema: { parse: (t: unknown) => t },
+  }
+})
+
+describe('updateTypebot', () => {
+  const mockUser = { id: 'user-1', email: 'test@test.com' }
+
+  const baseExistingTypebot = {
+    id: 'tb-1',
+    name: 'My Tool',
+    version: '6',
+    customDomain: null,
+    publicId: null,
+    updatedAt: new Date('2020-01-01'),
+    workspace: {
+      id: 'ws-1',
+      name: 'ws',
+      plan: Plan.FREE,
+      isSuspended: false,
+      isPastDue: false,
+      members: [{ userId: mockUser.id, role: WorkspaceRole.ADMIN }],
+    },
+    collaborators: [],
+  }
+
+  const asTool = { settings: { general: { type: 'TOOL' } } }
+  const asFlow = { settings: { general: { type: 'default' } } }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(isWriteTypebotForbidden).mockResolvedValue(false)
+    vi.mocked(prisma.typebot.update).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (async ({ data }: any) => ({ id: 'tb-1', ...data })) as any
+    )
+  })
+
+  const caller = () =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    router({ updateTypebot }).createCaller({ user: mockUser } as never)
+      .updateTypebot
+
+  it('should reject renaming a TOOL', async () => {
+    vi.mocked(prisma.typebot.findFirst).mockResolvedValue({
+      ...baseExistingTypebot,
+      ...asTool,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+
+    await expect(
+      caller()({
+        typebotId: 'tb-1',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        typebot: { name: 'Renamed Tool' } as any,
+      })
+    ).rejects.toThrow('Tool name is immutable')
+  })
+
+  it('should reject renaming a TOOL even when payload omits settings', async () => {
+    vi.mocked(prisma.typebot.findFirst).mockResolvedValue({
+      ...baseExistingTypebot,
+      ...asTool,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+
+    await expect(
+      caller()({
+        typebotId: 'tb-1',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        typebot: { name: 'Renamed Tool' } as any,
+      })
+    ).rejects.toThrow('Tool name is immutable')
+  })
+
+  it('should reject archiving a TOOL', async () => {
+    vi.mocked(prisma.typebot.findFirst).mockResolvedValue({
+      ...baseExistingTypebot,
+      ...asTool,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+
+    await expect(
+      caller()({
+        typebotId: 'tb-1',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        typebot: { isArchived: true } as any,
+      })
+    ).rejects.toThrow('Tools cannot be archived')
+  })
+
+  it('should allow editing a TOOL toolDescription (identity untouched)', async () => {
+    vi.mocked(prisma.typebot.findFirst).mockResolvedValue({
+      ...baseExistingTypebot,
+      ...asTool,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+
+    await expect(
+      caller()({
+        typebotId: 'tb-1',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        typebot: { toolDescription: 'updated description' } as any,
+      })
+    ).resolves.toBeDefined()
+  })
+
+  it('should allow passing the same name for a TOOL (no-op rename)', async () => {
+    vi.mocked(prisma.typebot.findFirst).mockResolvedValue({
+      ...baseExistingTypebot,
+      ...asTool,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+
+    await expect(
+      caller()({
+        typebotId: 'tb-1',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        typebot: { name: 'My Tool' } as any,
+      })
+    ).resolves.toBeDefined()
+  })
+
+  it('should allow renaming a non-TOOL flow', async () => {
+    vi.mocked(prisma.typebot.findFirst).mockResolvedValue({
+      ...baseExistingTypebot,
+      ...asFlow,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+
+    await expect(
+      caller()({
+        typebotId: 'tb-1',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        typebot: { name: 'Renamed Flow' } as any,
+      })
+    ).resolves.toBeDefined()
+  })
+})

--- a/apps/builder/src/features/typebot/api/updateTypebot.ts
+++ b/apps/builder/src/features/typebot/api/updateTypebot.ts
@@ -43,6 +43,7 @@ const typebotUpdateSchemaPick = {
   updatedAt: true,
   tenant: true,
   toolDescription: true,
+  isArchived: true,
 } as const
 
 export const updateTypebot = authenticatedProcedure
@@ -88,6 +89,7 @@ export const updateTypebot = authenticatedProcedure
       select: {
         version: true,
         id: true,
+        name: true,
         customDomain: true,
         publicId: true,
         settings: true,
@@ -163,17 +165,34 @@ export const updateTypebot = authenticatedProcedure
         })
     }
 
-    if (
-      existingTypebot.settings &&
-      (existingTypebot.settings as unknown as Settings).general?.type ===
-        'TOOL' &&
-      ((typebot.tenant !== undefined && !typebot.tenant) ||
-        (typebot.toolDescription !== undefined && !typebot.toolDescription))
-    )
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: 'Tenant and Tool description are mandatory for Tool workflows',
-      })
+    const isExistingTool =
+      !!existingTypebot.settings &&
+      (existingTypebot.settings as unknown as Settings).general?.type === 'TOOL'
+
+    if (isExistingTool) {
+      if (typebot.name !== undefined && typebot.name !== existingTypebot.name)
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message:
+            'Tool name is immutable: it is the identity agents reference. Rename is not allowed.',
+        })
+
+      if (typebot.isArchived === true)
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Tools cannot be archived',
+        })
+
+      if (
+        (typebot.tenant !== undefined && !typebot.tenant) ||
+        (typebot.toolDescription !== undefined && !typebot.toolDescription)
+      )
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message:
+            'Tenant and Tool description are mandatory for Tool workflows',
+        })
+    }
 
     const groups = typebot.groups
       ? await sanitizeGroups(existingTypebot.workspace.id)(typebot.groups)
@@ -244,6 +263,7 @@ export const updateTypebot = authenticatedProcedure
           workspaceId: existingTypebot.workspace.id,
         }),
         isClosed: typebot.isClosed,
+        isArchived: typebot.isArchived,
         isSecondaryFlow: typebot.isSecondaryFlow ?? false,
         whatsAppCredentialsId: typebot.whatsAppCredentialsId ?? undefined,
         tenant: typebot.tenant,

--- a/apps/builder/src/features/typebot/helpers/isToolNameTaken.test.ts
+++ b/apps/builder/src/features/typebot/helpers/isToolNameTaken.test.ts
@@ -1,0 +1,54 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { isToolNameTaken } from './isToolNameTaken'
+import prisma from '@typebot.io/lib/prisma'
+
+vi.mock('@typebot.io/lib/prisma', () => ({
+  default: {
+    typebot: {
+      findMany: vi.fn(),
+    },
+  },
+}))
+
+describe('isToolNameTaken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns true when an existing tool sanitizes to the same name', async () => {
+    vi.mocked(prisma.typebot.findMany).mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { name: 'Get Order' } as any,
+    ])
+
+    await expect(
+      isToolNameTaken({ name: 'get order', tenant: 'ten-1' })
+    ).resolves.toBe(true)
+  })
+
+  it('returns false when no existing tool collides', async () => {
+    vi.mocked(prisma.typebot.findMany).mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { name: 'Cancel Order' } as any,
+    ])
+
+    await expect(
+      isToolNameTaken({ name: 'Get Order', tenant: 'ten-1' })
+    ).resolves.toBe(false)
+  })
+
+  it('scopes the lookup to non-archived TOOL typebots of the given tenant', async () => {
+    vi.mocked(prisma.typebot.findMany).mockResolvedValue([])
+
+    await isToolNameTaken({ name: 'Get Order', tenant: 'ten-1' })
+
+    expect(prisma.typebot.findMany).toHaveBeenCalledWith({
+      where: {
+        tenant: 'ten-1',
+        isArchived: { not: true },
+        settings: { path: ['general', 'type'], equals: 'TOOL' },
+      },
+      select: { name: true },
+    })
+  })
+})

--- a/apps/builder/src/features/typebot/helpers/isToolNameTaken.ts
+++ b/apps/builder/src/features/typebot/helpers/isToolNameTaken.ts
@@ -1,0 +1,26 @@
+import prisma from '@typebot.io/lib/prisma'
+import { sanitizeToolName } from '@typebot.io/lib/sanitizeToolName'
+
+/**
+ * A tool's MCP name is `sanitizeToolName(name)` and doubles as its identity in
+ * `tools/call`. Two non-archived tools resolving to the same sanitized name in
+ * the same tenant would make the lookup ambiguous, so creation must reject it.
+ */
+export const isToolNameTaken = async ({
+  name,
+  tenant,
+}: {
+  name: string
+  tenant: string
+}): Promise<boolean> => {
+  const target = sanitizeToolName(name)
+  const existingTools = await prisma.typebot.findMany({
+    where: {
+      tenant,
+      isArchived: { not: true },
+      settings: { path: ['general', 'type'], equals: 'TOOL' },
+    },
+    select: { name: true },
+  })
+  return existingTools.some((tool) => sanitizeToolName(tool.name) === target)
+}

--- a/apps/builder/src/i18n/de.json
+++ b/apps/builder/src/i18n/de.json
@@ -157,6 +157,7 @@
   "editor.header.resultsButton.label": "Ergebnisse",
   "editor.header.savingSpinner.label": "Speichern...",
   "editor.header.settingsButton.label": "Einstellungen",
+  "editor.header.toolName.immutable.tooltip": "This tool's name is permanent and can't be changed.",
   "editor.header.themeButton.label": "Design",
   "editor.sidebarBlock.abTest.label": "AB-Test",
   "editor.sidebarBlock.analytics.label": "Analytics",

--- a/apps/builder/src/i18n/en.json
+++ b/apps/builder/src/i18n/en.json
@@ -336,6 +336,7 @@
   "editor.header.resultsButton.label": "Results",
   "editor.header.savingSpinner.label": "Saving...",
   "editor.header.settingsButton.label": "Settings",
+  "editor.header.toolName.immutable.tooltip": "This tool's name is permanent and can't be changed.",
   "editor.header.themeButton.label": "Theme",
   "editor.header.tooltip.changeIcon.label": "Change icon",
   "editor.header.undo.tooltip.label": "Changes reverted!",

--- a/apps/builder/src/i18n/es.json
+++ b/apps/builder/src/i18n/es.json
@@ -336,6 +336,7 @@
   "editor.header.resultsButton.label": "Resultados",
   "editor.header.savingSpinner.label": "Guardando...",
   "editor.header.settingsButton.label": "Configuración",
+  "editor.header.toolName.immutable.tooltip": "This tool's name is permanent and can't be changed.",
   "editor.header.themeButton.label": "Tema",
   "editor.header.tooltip.changeIcon.label": "Cambiar ícono",
   "editor.header.undo.tooltip.label": "¡Cambios revertidos!",

--- a/apps/builder/src/i18n/fr.json
+++ b/apps/builder/src/i18n/fr.json
@@ -270,6 +270,7 @@
   "editor.header.resultsButton.label": "Résultats",
   "editor.header.savingSpinner.label": "Enregistrement...",
   "editor.header.settingsButton.label": "Paramètres",
+  "editor.header.toolName.immutable.tooltip": "This tool's name is permanent and can't be changed.",
   "editor.header.themeButton.label": "Thème",
   "editor.header.tooltip.changeIcon.label": "Changer l'icone",
   "editor.header.undo.tooltip.label": "Modificiations annulées !",

--- a/apps/builder/src/i18n/it.json
+++ b/apps/builder/src/i18n/it.json
@@ -270,6 +270,7 @@
   "editor.header.resultsButton.label": "Risultati",
   "editor.header.savingSpinner.label": "Risparmio...",
   "editor.header.settingsButton.label": "Impostazioni",
+  "editor.header.toolName.immutable.tooltip": "This tool's name is permanent and can't be changed.",
   "editor.header.themeButton.label": "Tema",
   "editor.header.tooltip.changeIcon.label": "Cambia icona",
   "editor.header.undo.tooltip.label": "Modifiche annullate!",

--- a/apps/builder/src/i18n/pt-BR.json
+++ b/apps/builder/src/i18n/pt-BR.json
@@ -336,6 +336,7 @@
   "editor.header.resultsButton.label": "Resultados",
   "editor.header.savingSpinner.label": "Salvando...",
   "editor.header.settingsButton.label": "Configurações",
+  "editor.header.toolName.immutable.tooltip": "O nome desta ferramenta é permanente e não pode ser alterado.",
   "editor.header.themeButton.label": "Tema",
   "editor.header.tooltip.changeIcon.label": "Alterar Ícone",
   "editor.header.undo.tooltip.label": "Alterações revertidas Changes reverted!",

--- a/apps/builder/src/i18n/pt.json
+++ b/apps/builder/src/i18n/pt.json
@@ -171,6 +171,7 @@
   "editor.header.resultsButton.label": "Resultados",
   "editor.header.savingSpinner.label": "Salvando...",
   "editor.header.settingsButton.label": "Configurações",
+  "editor.header.toolName.immutable.tooltip": "O nome desta ferramenta é permanente e não pode ser alterado.",
   "editor.header.themeButton.label": "Tema",
   "editor.sidebarBlock.abTest.label": "Teste AB",
   "editor.sidebarBlock.analytics.label": "Analytics",

--- a/apps/builder/src/i18n/ro.json
+++ b/apps/builder/src/i18n/ro.json
@@ -158,6 +158,7 @@
   "editor.header.resultsButton.label": "Rezultate",
   "editor.header.savingSpinner.label": "Salvare...",
   "editor.header.settingsButton.label": "Setări",
+  "editor.header.toolName.immutable.tooltip": "This tool's name is permanent and can't be changed.",
   "editor.header.themeButton.label": "Temă",
   "editor.sidebarBlock.abTest.label": "Testul AB",
   "editor.sidebarBlock.analytics.label": "Analitica",

--- a/packages/lib/sanitizeToolName.test.ts
+++ b/packages/lib/sanitizeToolName.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeToolName } from './sanitizeToolName'
+
+describe('sanitizeToolName', () => {
+  it('lowercases and replaces spaces with a single underscore', () => {
+    expect(sanitizeToolName('Get Order Status')).toBe('get_order_status')
+  })
+
+  it('keeps existing underscores and hyphens', () => {
+    expect(sanitizeToolName('get_order-status')).toBe('get_order-status')
+  })
+
+  it('collapses runs of separators and trims leading/trailing ones', () => {
+    expect(sanitizeToolName('  Get   Order!! ')).toBe('get_order')
+  })
+
+  it('returns an empty string when nothing survives normalization', () => {
+    expect(sanitizeToolName('!!!')).toBe('')
+    expect(sanitizeToolName('   ')).toBe('')
+    expect(sanitizeToolName('@#$%')).toBe('')
+  })
+})

--- a/packages/lib/sanitizeToolName.ts
+++ b/packages/lib/sanitizeToolName.ts
@@ -1,0 +1,11 @@
+/**
+ * Normalize a tool name to be MCP-compliant.
+ * MCP tool names must be lowercase, URL-safe, without spaces.
+ */
+export function sanitizeToolName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, '_')
+    .replace(/_{2,}/g, '_')
+    .replace(/^_+|_+$/g, '')
+}

--- a/packages/lib/sanitizeToolName.ts
+++ b/packages/lib/sanitizeToolName.ts
@@ -3,9 +3,13 @@
  * MCP tool names must be lowercase, URL-safe, without spaces.
  */
 export function sanitizeToolName(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9_-]/g, '_')
-    .replace(/_{2,}/g, '_')
-    .replace(/^_+|_+$/g, '')
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]/g, '_')
+      .replace(/_{2,}/g, '_')
+      // Previous step collapsed `_{2,}` to a single `_`, so edges hold at most one
+      // underscore — matching without a quantifier avoids backtracking (Sonar S8786).
+      .replace(/^_|_$/g, '')
+  )
 }

--- a/packages/mcp-tools/helpers/sanitizeToolName.ts
+++ b/packages/mcp-tools/helpers/sanitizeToolName.ts
@@ -1,11 +1,1 @@
-/**
- * Normalize a tool name to be MCP-compliant.
- * MCP tool names must be lowercase, URL-safe, without spaces.
- */
-export function sanitizeToolName(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9_-]/g, '_')
-    .replace(/_{2,}/g, '_')
-    .replace(/^_+|_+$/g, '')
-}
+export { sanitizeToolName } from '@typebot.io/lib/sanitizeToolName'


### PR DESCRIPTION
## Problem

Tools are typebots with `settings.general.type === 'TOOL'`. A tool's name becomes its **MCP tool name** (`sanitizeToolName`), and agents reference tools by that name via a whitelist. Because MCP has no tool id — the name *is* the identity — renaming, archiving, or deleting a tool leaves the referencing agents with **stale refs that break silently**. There is currently no server-side guard on any of these mutations.

Decision (Fabio, 2026-07-07): make the tool name **immutable per product**, enforced server-side. `sanitizeToolName(name)` then becomes a stable identifier for free — no new column, no backfill, no `title` propagation. Full design: `docs/superpowers/specs/2026-07-07-typebot-tool-frozen-slug-design.md`.

## What this PR does (Component 1)

All mutation paths (builder UI, REST `PATCH/DELETE /v1/typebots`, controlled-flows, GAD admin MCP) route through these tRPC procedures, so guarding them here closes every path.

- **`updateTypebot`** — when the **existing DB record** is a TOOL:
  - reject a `name` change → `400 "Tool name is immutable…"`
  - reject `isArchived === true` → `400 "Tools cannot be archived"`
  - `toolDescription` and other fields stay editable.
  - The guard reads the *existing* record's `settings`, never the payload, so a payload that omits `settings` cannot slip past it. (`isArchived` is now part of the update schema/write so the guard is meaningful; non-TOOL flows are unaffected — the field is a no-op unless explicitly sent.)
- **`deleteTypebot`** — reject deleting a TOOL that has a `publishedTypebot` → `400 "Published tools cannot be deleted"`. A **never-published (draft)** TOOL can still be deleted (agents only ever see published tools). Non-TOOL flows: unchanged.
- **`createTypebot` / `importTypebot`** — reject a new TOOL whose `sanitizeToolName(name)` collides with a **non-archived TOOL in the same tenant** → `400 "A tool named '<name>' already exists…"` (a duplicate would be ambiguous at `tools/call`, which resolves by first match). Same name in a **different tenant** is allowed. Shared via a new `isToolNameTaken` helper.
- **UI** — `EditableTypebotName` renders a read-only, tooltipped label when the typebot is a TOOL, so the user can't type a new name and hit a save error. New i18n key `editor.header.toolName.immutable.tooltip` (pt/en translated, English fallback for the other locales).

To reuse the MCP name normalization in the builder without duplicating logic, `sanitizeToolName` was relocated to `@typebot.io/lib` (a dependency of both the builder and `@typebot.io/mcp-tools`); `mcp-tools` re-exports it, so existing importers (viewer `/api/mcp`, `transformToMCPTool`) are unchanged. No data migration — existing tool names remain byte-for-byte.

## Testing

- `deleteTypebot.test.ts` (published TOOL → 400, draft TOOL → ok, published non-TOOL → ok) and `isToolNameTaken.test.ts` (same-tenant collision, no collision, tenant-scoped query) run under vitest and pass.
- `createTypebot.test.ts` / `updateTypebot.test.ts` cover rename→400, archive→400, payload-without-settings→400, toolDescription editable, non-TOOL rename ok, and same-name-different-tenant ok. They use the `router({ proc }).createCaller(...)` pattern from `updateCredentials.test.ts` (the pre-existing `createTypebot.test.ts` used a `proc.createCaller` form that never actually ran — fixed here).
- `pnpm tsc --noEmit` clean on all changed files; ESLint and Prettier pass (pre-commit hook).

Note: the repo's automated vitest run (`vitest run`) is scoped to `packages/**`; app-level tRPC specs that import the full schema/forge block graph don't load in that ad-hoc harness (a pre-existing limitation), so `createTypebot`/`updateTypebot` specs are validated via typecheck + lint here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>

This is close, but one update path should be fixed before merging.

- An existing TOOL can still change `settings.general.type` through `updateTypebot`.
- Once that happens, later updates can bypass the TOOL-specific rename, archive, and delete protections.
- The import validation now covers the missing tenant and description cases from the changed code.

apps/builder/src/features/typebot/api/updateTypebot.ts

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Ftypebot%2Fapi%2FupdateTypebot.ts%3A172-195%0A**Tipo%20ainda%20mut%C3%A1vel**%0A%0AEste%20bloco%20protege%20uma%20TOOL%20existente%20contra%20rename%20e%20archive%2C%20mas%20n%C3%A3o%20impede%20o%20mesmo%20update%20de%20mudar%20%60settings.general.type%60.%20Um%20caller%20com%20permiss%C3%A3o%20de%20escrita%20pode%20enviar%20uma%20atualiza%C3%A7%C3%A3o%20para%20uma%20TOOL%20publicada%20com%20%60settings.general.type%60%20voltando%20para%20um%20fluxo%20comum%3B%20depois%20disso%2C%20updates%20seguintes%20n%C3%A3o%20entram%20mais%20neste%20guard%20e%20o%20registro%20pode%20ser%20renomeado%2C%20arquivado%20ou%20deletado%20como%20n%C3%A3o-TOOL.%20Isso%20deixa%20agentes%20com%20refer%C3%AAncias%20MCP%20antigas%20para%20uma%20ferramenta%20que%20o%20servidor%20deixou%20de%20tratar%20como%20identidade%20imut%C3%A1vel.%20A%20atualiza%C3%A7%C3%A3o%20de%20uma%20TOOL%20existente%20precisa%20rejeitar%20mudan%C3%A7as%20no%20tipo%20salvo%2C%20ou%20preservar%20%60settings.general.type%20%3D%3D%3D%20'TOOL'%60%20ao%20gravar%20%60updatedSettings%60.%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=255&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fbuilder%2Fsrc%2Ffeatures%2Ftypebot%2Fapi%2FupdateTypebot.ts%3A172-195%0A**Tipo%20ainda%20mut%C3%A1vel**%0A%0AEste%20bloco%20protege%20uma%20TOOL%20existente%20contra%20rename%20e%20archive%2C%20mas%20n%C3%A3o%20impede%20o%20mesmo%20update%20de%20mudar%20%60settings.general.type%60.%20Um%20caller%20com%20permiss%C3%A3o%20de%20escrita%20pode%20enviar%20uma%20atualiza%C3%A7%C3%A3o%20para%20uma%20TOOL%20publicada%20com%20%60settings.general.type%60%20voltando%20para%20um%20fluxo%20comum%3B%20depois%20disso%2C%20updates%20seguintes%20n%C3%A3o%20entram%20mais%20neste%20guard%20e%20o%20registro%20pode%20ser%20renomeado%2C%20arquivado%20ou%20deletado%20como%20n%C3%A3o-TOOL.%20Isso%20deixa%20agentes%20com%20refer%C3%AAncias%20MCP%20antigas%20para%20uma%20ferramenta%20que%20o%20servidor%20deixou%20de%20tratar%20como%20identidade%20imut%C3%A1vel.%20A%20atualiza%C3%A7%C3%A3o%20de%20uma%20TOOL%20existente%20precisa%20rejeitar%20mudan%C3%A7as%20no%20tipo%20salvo%2C%20ou%20preservar%20%60settings.general.type%20%3D%3D%3D%20'TOOL'%60%20ao%20gravar%20%60updatedSettings%60.%0A%0A&pr=255&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/builder/src/features/typebot/api/updateTypebot.ts:172-195
**Tipo ainda mutável**

Este bloco protege uma TOOL existente contra rename e archive, mas não impede o mesmo update de mudar `settings.general.type`. Um caller com permissão de escrita pode enviar uma atualização para uma TOOL publicada com `settings.general.type` voltando para um fluxo comum; depois disso, updates seguintes não entram mais neste guard e o registro pode ser renomeado, arquivado ou deletado como não-TOOL. Isso deixa agentes com referências MCP antigas para uma ferramenta que o servidor deixou de tratar como identidade imutável. A atualização de uma TOOL existente precisa rejeitar mudanças no tipo salvo, ou preservar `settings.general.type === 'TOOL'` ao gravar `updatedSettings`.

`````

</details>

<sub>Reviews (6): Last reviewed commit: ["fix(lib): drop quantifier from sanitizeT..."](https://github.com/cloudhumans/typebot.io/commit/7c1d9f1f9e4572f52dc8fcfaa19b45d17cf74b8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42408572)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->