### PR TITLE
fix(webhook): surface fetch cause in webhook error result

### DIFF
--- a/packages/bot-engine/blocks/integrations/webhook/executeWebhookBlock.ts
+++ b/packages/bot-engine/blocks/integrations/webhook/executeWebhookBlock.ts
@@ -17,6 +17,7 @@ import { stringify } from 'qs'
 import { isDefined, isEmpty, isNotDefined, omit } from '@typebot.io/lib'
 import ky, { HTTPError, Options, TimeoutError } from 'ky'
 import { resumeWebhookExecution } from './resumeWebhookExecution'
+import { formatErrorWithCause } from './formatErrorWithCause'
 import { ExecuteIntegrationResponse } from '../../../types'
 import { parseVariables } from '@typebot.io/variables/parseVariables'
 import prisma from '@typebot.io/lib/prisma'
@@ -377,8 +378,8 @@ export const executeWebhook = async (
 
   const isLongRequest = params.disableRequestTimeout
     ? true
-    : longReqTimeoutWhitelist.some((whiteListedUrl) =>
-        url?.includes(whiteListedUrl)
+    : longReqTimeoutWhitelist.some(
+        (whiteListedUrl) => url?.includes(whiteListedUrl)
       )
 
   const isFormData = contentType?.includes('x-www-form-urlencoded')
@@ -535,8 +536,14 @@ export const executeWebhook = async (
     const response = {
       statusCode: 500,
       // This message is returned to the flow (and may be persisted), and a raw
-      // error can embed the request URL/secret query params, so mask it.
-      data: { message: mask(`Error from Typebot server: ${error}`) },
+      // error can embed the request URL/secret query params, so mask it. The
+      // `Error from Typebot server:` prefix is a marker matched byte-for-byte
+      // via includes() by @typebot.io/mcp-tools — the cause goes after it.
+      data: {
+        message: mask(
+          `Error from Typebot server: ${formatErrorWithCause(error)}`
+        ),
+      },
     }
     logger.error(
       `${workspaceLogLabel(logContext?.workspace)} - HTTP Request Failed`,
@@ -547,7 +554,7 @@ export const executeWebhook = async (
           method: request.method,
           duration: Date.now() - requestStartTime,
         },
-        error: mask(error instanceof Error ? error.message : String(error)),
+        error: mask(formatErrorWithCause(error)),
       }
     )
     logs.push({

--- a/packages/bot-engine/blocks/integrations/webhook/formatErrorWithCause.test.ts
+++ b/packages/bot-engine/blocks/integrations/webhook/formatErrorWithCause.test.ts
@@ -59,4 +59,11 @@ describe('formatErrorWithCause', () => {
     const result = formatErrorWithCause(current, 2)
     expect(result.match(/cause:/g)?.length).toBe(2)
   })
+
+  it('does not throw on AggregateErrors nested past the depth limit', () => {
+    let current = new AggregateError([new Error('leaf')], 'level 0')
+    for (let i = 1; i < 10; i++)
+      current = new AggregateError([current], `level ${i}`)
+    expect(() => formatErrorWithCause(current)).not.toThrow()
+  })
 })

--- a/packages/bot-engine/blocks/integrations/webhook/formatErrorWithCause.test.ts
+++ b/packages/bot-engine/blocks/integrations/webhook/formatErrorWithCause.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { formatErrorWithCause } from './formatErrorWithCause'
+
+describe('formatErrorWithCause', () => {
+  it('returns the error string when there is no cause', () => {
+    expect(formatErrorWithCause(new TypeError('fetch failed'))).toBe(
+      'TypeError: fetch failed'
+    )
+  })
+
+  it('appends a simple cause', () => {
+    const error = new TypeError('fetch failed', {
+      cause: new Error('connect ECONNREFUSED 10.2.3.4:443'),
+    })
+    expect(formatErrorWithCause(error)).toBe(
+      'TypeError: fetch failed (cause: Error: connect ECONNREFUSED 10.2.3.4:443)'
+    )
+  })
+
+  it('walks a nested cause chain', () => {
+    const error = new Error('a', {
+      cause: new Error('b', { cause: new Error('c') }),
+    })
+    expect(formatErrorWithCause(error)).toBe(
+      'Error: a (cause: Error: b (cause: Error: c))'
+    )
+  })
+
+  it('unwraps AggregateError.errors', () => {
+    const error = new AggregateError(
+      [
+        new Error('ECONNREFUSED ::1:443'),
+        new Error('ECONNREFUSED 127.0.0.1:443'),
+      ],
+      'fetch failed'
+    )
+    expect(formatErrorWithCause(error)).toBe(
+      'AggregateError: fetch failed [Error: ECONNREFUSED ::1:443; Error: ECONNREFUSED 127.0.0.1:443]'
+    )
+  })
+
+  it('stringifies a non-Error cause', () => {
+    const error = new Error('boom', { cause: 'plain string reason' })
+    expect(formatErrorWithCause(error)).toBe(
+      'Error: boom (cause: plain string reason)'
+    )
+  })
+
+  it('stops on a cyclic cause chain', () => {
+    const error = new Error('loop')
+    ;(error as { cause?: unknown }).cause = error
+    expect(formatErrorWithCause(error)).toBe('Error: loop')
+  })
+
+  it('honors the depth limit', () => {
+    let current = new Error('leaf')
+    for (let i = 0; i < 10; i++)
+      current = new Error(`e${i}`, { cause: current })
+    const result = formatErrorWithCause(current, 2)
+    expect(result.match(/cause:/g)?.length).toBe(2)
+  })
+})

--- a/packages/bot-engine/blocks/integrations/webhook/formatErrorWithCause.ts
+++ b/packages/bot-engine/blocks/integrations/webhook/formatErrorWithCause.ts
@@ -12,7 +12,7 @@ export const formatErrorWithCause = (error: unknown, maxDepth = 5): string => {
       value.errors.length > 0
     ) {
       const inner = value.errors
-        .map((sub) => formatErrorWithCause(sub, maxDepth - 1))
+        .map((sub) => formatErrorWithCause(sub, Math.max(0, maxDepth - 1)))
         .join('; ')
       return `${String(value)} [${inner}]`
     }

--- a/packages/bot-engine/blocks/integrations/webhook/formatErrorWithCause.ts
+++ b/packages/bot-engine/blocks/integrations/webhook/formatErrorWithCause.ts
@@ -1,0 +1,40 @@
+/**
+ * Under Node/undici a fetch network failure surfaces as `TypeError: fetch failed`
+ * with the actionable reason (ECONNREFUSED, ENOTFOUND, cert errors) hidden in
+ * `error.cause`, or in `AggregateError.errors` (happy-eyeballs IPv4/IPv6). This
+ * walks the cause chain so the reason survives instead of the opaque top-level.
+ */
+export const formatErrorWithCause = (error: unknown, maxDepth = 5): string => {
+  const stringifyOne = (value: unknown): string => {
+    if (
+      value instanceof AggregateError &&
+      Array.isArray(value.errors) &&
+      value.errors.length > 0
+    ) {
+      const inner = value.errors
+        .map((sub) => formatErrorWithCause(sub, maxDepth - 1))
+        .join('; ')
+      return `${String(value)} [${inner}]`
+    }
+    return String(value)
+  }
+
+  const parts: string[] = []
+  const seen = new Set<unknown>()
+  let current: unknown = error
+  let depth = 0
+  while (current != null && depth <= maxDepth) {
+    if (typeof current === 'object') {
+      if (seen.has(current)) break
+      seen.add(current)
+    }
+    parts.push(stringifyOne(current))
+    current =
+      current instanceof Error
+        ? (current as { cause?: unknown }).cause
+        : undefined
+    depth++
+  }
+
+  return parts.join(' (cause: ') + ')'.repeat(parts.length - 1)
+}


### PR DESCRIPTION
## Problem

When a webhook block fails on a network error, the agent (claudia-agentic) only receives the opaque `{"message":"Error from Typebot server: TypeError: fetch failed"}`. Under Node/undici, a fetch network failure surfaces as `TypeError: fetch failed` with the *actual* reason (`connect ECONNREFUSED …`, `getaddrinfo ENOTFOUND …`, cert errors) hidden in `error.cause` — or in `AggregateError.errors` when happy-eyeballs races IPv4/IPv6. The generic catch fallback in `executeWebhookBlock.ts` stringified the error directly (`${error}`), swallowing that cause. The typed catches above it (`HTTPError`, `TimeoutError`) were already fine; only this fallback was opaque.

## Solution

- New helper `formatErrorWithCause` (co-located in `blocks/integrations/webhook/`): walks the `error.cause` chain with a depth limit (default 5), unwraps `AggregateError.errors`, `String(...)`s non-Error causes, and guards against cyclic chains. Produces e.g. `TypeError: fetch failed (cause: Error: connect ECONNREFUSED 10.2.3.4:443)`.
- Used in the generic catch of `executeWebhookBlock.ts` in **two** places:
  - the message returned to the flow (kept wrapped in `mask()`, since a cause can embed a URL with secret query params);
  - the structured `error:` log (also masked).
- Unit tests cover: no cause, simple cause, nested chain, `AggregateError`, non-Error cause, cyclic chain, and depth limit.

## Contract preserved

The `Error from Typebot server:` prefix is a marker matched byte-for-byte via `includes()` by `@typebot.io/mcp-tools` (`TYPEBOT_ERROR_MARKER`) and a shim in claudia-agentic. The cause is appended **after** the prefix, so both matches keep working. No changes to `mcp-tools`.

## Notes

- This was originally planned as stacked on #255 (`feat/tool-name-immutability`); that PR has since been squash-merged into `main`, so this targets `main` directly and its diff is only the 3 webhook files.
- Validated locally: `formatErrorWithCause.test.ts` 7/7 passing (vitest), `tsc --noEmit` clean on the touched files (remaining errors in the package are pre-existing DOM/Node lib noise unrelated to this change), prettier + eslint clean via pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
