### PR TITLE
fix(webhook): surface code and stack frames when a fetch cause has no message

### DIFF
--- a/packages/bot-engine/blocks/integrations/webhook/formatErrorWithCause.test.ts
+++ b/packages/bot-engine/blocks/integrations/webhook/formatErrorWithCause.test.ts
@@ -60,6 +60,38 @@ describe('formatErrorWithCause', () => {
     expect(result.match(/cause:/g)?.length).toBe(2)
   })
 
+  it('falls back to top stack frames when a cause has an empty message', () => {
+    // undici's makeNetworkError() creates `new Error(undefined)` — no message,
+    // so only the stack identifies which network failure occurred.
+    const cause = new Error()
+    const error = new TypeError('fetch failed', { cause })
+    const result = formatErrorWithCause(error)
+    expect(result).toMatch(/^TypeError: fetch failed \(cause: Error \[at /)
+    expect(result).toContain('formatErrorWithCause.test.ts')
+  })
+
+  it('includes the code of an empty-message cause when present', () => {
+    const cause = Object.assign(new Error(), { code: 'UND_ERR_SOCKET' })
+    const error = new TypeError('fetch failed', { cause })
+    expect(formatErrorWithCause(error)).toContain('[code=UND_ERR_SOCKET]')
+  })
+
+  it('keeps just the name when an empty-message cause has no stack', () => {
+    const cause = new Error()
+    cause.stack = undefined
+    const error = new TypeError('fetch failed', { cause })
+    expect(formatErrorWithCause(error)).toBe(
+      'TypeError: fetch failed (cause: Error)'
+    )
+  })
+
+  it('does not append stack frames when the cause has a message', () => {
+    const error = new TypeError('fetch failed', {
+      cause: new Error('connect ECONNREFUSED 10.2.3.4:443'),
+    })
+    expect(formatErrorWithCause(error)).not.toContain('[at ')
+  })
+
   it('does not throw on AggregateErrors nested past the depth limit', () => {
     let current = new AggregateError([new Error('leaf')], 'level 0')
     for (let i = 1; i < 10; i++)

--- a/packages/bot-engine/blocks/integrations/webhook/formatErrorWithCause.ts
+++ b/packages/bot-engine/blocks/integrations/webhook/formatErrorWithCause.ts
@@ -16,6 +16,25 @@ export const formatErrorWithCause = (error: unknown, maxDepth = 5): string => {
         .join('; ')
       return `${String(value)} [${inner}]`
     }
+    // undici network errors can carry no message at all (makeNetworkError()
+    // called with no reason yields `new Error(undefined)`), so String() gives
+    // just "Error". The code and top stack frames are then the only thing
+    // identifying which failure occurred — surface them.
+    if (value instanceof Error && value.message === '') {
+      const code = (value as { code?: unknown }).code
+      const frames = value.stack
+        ?.split('\n')
+        .slice(1, 4)
+        .map((line) => line.trim().replace(/^at /, ''))
+        .filter(Boolean)
+      return [
+        String(value),
+        code == null ? undefined : `[code=${String(code)}]`,
+        frames && frames.length > 0 ? `[at ${frames.join(' <- ')}]` : undefined,
+      ]
+        .filter(Boolean)
+        .join(' ')
+    }
     return String(value)
   }
 


### PR DESCRIPTION
## Problem

Follow-up to #256. In production the webhook fetch failures are still opaque: every network error since the deploy logs exactly `TypeError: fetch failed (cause: Error)` (58/58 occurrences in 7 days). The cause chain *is* being walked — but undici creates these specific errors via `makeNetworkError()` **with no message at all** (`new Error(undefined)`), so `String(err)` yields just `Error`.

In undici 5.29 (the runtime of the `node:18` prod image) only 3 code paths produce this empty error, and the top stack frames are the only thing that distinguishes them:

- `httpRedirectFetch` — redirect status ≠ 303 with a non-replayable request body (matches the failing POSTs to Google Apps Script, which always answer 302, and the Shopify `www → myshopify` 301s)
- `httpNetworkOrCacheFetch` — a 407 response with `window: 'no-window'`
- opaque 206 range responses

## Solution

In `formatErrorWithCause`, when a cause is an `Error` with an **empty message**, fall back to its `code` (when present) and the first 3 stack frames:

```
TypeError: fetch failed (cause: Error [at makeNetworkError (node:internal/deps/undici/undici:5851:35) <- httpRedirectFetch (node:internal/deps/undici/undici:10902:32) <- httpFetch (...)])
```

Verified end-to-end on `node:18-bullseye-slim` against real undici failures (407 and 302+stream-body): the two paths now produce distinct, identifying messages. Causes that *do* have a message are formatted exactly as before (covered by a regression test).

A single production occurrence after this deploy pinpoints which undici path is killing the Apps Script POSTs (~50% failure rate for bowe/zerezes today), directing the actual fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>

This is close, but the response exposure should be fixed before merging.

- Empty-message fetch causes now include stack frames.
- The webhook error path can return that formatted text to the flow.
- Webhooks without credentials do not mask those internal details.

packages/bot-engine/blocks/integrations/webhook/formatErrorWithCause.ts

<details open><summary><h3>Security Review</h3></summary>

The updated formatter can expose internal stack frames and runtime codes through the webhook response message.
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fbot-engine%2Fblocks%2Fintegrations%2Fwebhook%2FformatErrorWithCause.ts%3A34%0A**Stack%20Exposta%20Ao%20Fluxo**%0A%0AEste%20fallback%20coloca%20os%20frames%20de%20stack%20na%20string%20retornada%20por%20%60formatErrorWithCause%60.%20No%20erro%20gen%C3%A9rico%20do%20webhook%2C%20essa%20mesma%20string%20vira%20%60response.data.message%60%20e%20volta%20para%20o%20fluxo%3B%20para%20webhooks%20sem%20credenciais%2C%20a%20m%C3%A1scara%20recebe%20um%20conjunto%20vazio%20de%20segredos%20e%20n%C3%A3o%20remove%20nada.%20Quando%20o%20%60fetch%60%20do%20undici%20falha%20com%20uma%20causa%20sem%20mensagem%2C%20o%20usu%C3%A1rio%20ou%20agente%20pode%20receber%20detalhes%20internos%20como%20%60node%3Ainternal%2Fdeps%2Fundici%2F...%60%2C%20caminhos%20de%20m%C3%B3dulos%20e%20c%C3%B3digos%20do%20runtime.%20Esses%20dados%20deveriam%20ficar%20no%20diagn%C3%B3stico%20interno%2C%20ou%20a%20mensagem%20externa%20precisa%20ser%20sanitizada%20antes%20de%20retornar%20ao%20fluxo.%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=257&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fbot-engine%2Fblocks%2Fintegrations%2Fwebhook%2FformatErrorWithCause.ts%3A34%0A**Stack%20Exposta%20Ao%20Fluxo**%0A%0AEste%20fallback%20coloca%20os%20frames%20de%20stack%20na%20string%20retornada%20por%20%60formatErrorWithCause%60.%20No%20erro%20gen%C3%A9rico%20do%20webhook%2C%20essa%20mesma%20string%20vira%20%60response.data.message%60%20e%20volta%20para%20o%20fluxo%3B%20para%20webhooks%20sem%20credenciais%2C%20a%20m%C3%A1scara%20recebe%20um%20conjunto%20vazio%20de%20segredos%20e%20n%C3%A3o%20remove%20nada.%20Quando%20o%20%60fetch%60%20do%20undici%20falha%20com%20uma%20causa%20sem%20mensagem%2C%20o%20usu%C3%A1rio%20ou%20agente%20pode%20receber%20detalhes%20internos%20como%20%60node%3Ainternal%2Fdeps%2Fundici%2F...%60%2C%20caminhos%20de%20m%C3%B3dulos%20e%20c%C3%B3digos%20do%20runtime.%20Esses%20dados%20deveriam%20ficar%20no%20diagn%C3%B3stico%20interno%2C%20ou%20a%20mensagem%20externa%20precisa%20ser%20sanitizada%20antes%20de%20retornar%20ao%20fluxo.%0A%0A&pr=257&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/bot-engine/blocks/integrations/webhook/formatErrorWithCause.ts:34
**Stack Exposta Ao Fluxo**

Este fallback coloca os frames de stack na string retornada por `formatErrorWithCause`. No erro genérico do webhook, essa mesma string vira `response.data.message` e volta para o fluxo; para webhooks sem credenciais, a máscara recebe um conjunto vazio de segredos e não remove nada. Quando o `fetch` do undici falha com uma causa sem mensagem, o usuário ou agente pode receber detalhes internos como `node:internal/deps/undici/...`, caminhos de módulos e códigos do runtime. Esses dados deveriam ficar no diagnóstico interno, ou a mensagem externa precisa ser sanitizada antes de retornar ao fluxo.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(webhook): surface code and stack fra..."](https://github.com/cloudhumans/typebot.io/commit/777756ec4d11c578f6ce7cd47f0be29d4da4639e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43432598)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->