### PR TITLE
ci: add gitleaks secret scan (ci-workflows@v1)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,21 @@
+name: gitleaks
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * 1"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    uses: cloudhumans/ci-workflows/.github/workflows/gitleaks.yml@v1
+    secrets: inherit


### PR DESCRIPTION
Adiciona o caller do reusable workflow de scan de secrets (`cloudhumans/ci-workflows@v1`).

- Roda gitleaks em PRs/push/agendado, comenta na linha do segredo e sobe SARIF.
- `secrets: inherit` repassa o `GITLEAKS_LICENSE` da org.

Rollout padronizado do time.

<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>

O workflow precisa de ajustes antes do merge para garantir que o scan publique resultados e rode em PRs de forks.

- O upload SARIF pode falhar por falta de permissão no `GITHUB_TOKEN`.
- PRs vindos de forks não recebem o `GITLEAKS_LICENSE` herdado.
- O restante da mudança é pequeno e isolado ao workflow novo.

.github/workflows/gitleaks.yml

<details open><summary><h3>Security Review</h3></summary>

O scan de secrets pode falhar em caminhos importantes: o upload SARIF não tem a permissão necessária e PRs de forks não recebem o segredo de licença herdado.
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fgitleaks.yml%3A10-12%0A**Upload%20SARIF%20Sem%20Permiss%C3%A3o**%0A%0AQuando%20o%20workflow%20chamado%20tenta%20publicar%20SARIF%20no%20Code%20Scanning%2C%20o%20%60GITHUB_TOKEN%60%20deste%20caller%20s%C3%B3%20tem%20%60contents%3A%20read%60%20e%20%60pull-requests%3A%20write%60.%20Esse%20caminho%20precisa%20de%20%60security-events%3A%20write%60%20e%20pode%20falhar%20com%20acesso%20negado%2C%20deixando%20o%20scan%20executado%20apenas%20nos%20logs%20e%20sem%20os%20alertas%20de%20seguran%C3%A7a%20esperados.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fgitleaks.yml%3A21%0A**Forks%20Ficam%20Sem%20Licen%C3%A7a**%0A%0AEm%20%60pull_request%60%20vindo%20de%20fork%2C%20%60secrets%3A%20inherit%60%20n%C3%A3o%20repassa%20o%20%60GITLEAKS_LICENSE%60%20da%20org%20para%20o%20runner.%20Se%20o%20reusable%20workflow%20usa%20essa%20licen%C3%A7a%20para%20rodar%20o%20gitleaks%20no%20reposit%C3%B3rio%20da%20organiza%C3%A7%C3%A3o%2C%20esses%20PRs%20entram%20no%20job%20sem%20o%20segredo%20e%20o%20scan%20pode%20abortar%20justamente%20no%20caminho%20de%20contribui%C3%A7%C3%A3o%20externa.%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=258&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fgitleaks.yml%3A10-12%0A**Upload%20SARIF%20Sem%20Permiss%C3%A3o**%0A%0AQuando%20o%20workflow%20chamado%20tenta%20publicar%20SARIF%20no%20Code%20Scanning%2C%20o%20%60GITHUB_TOKEN%60%20deste%20caller%20s%C3%B3%20tem%20%60contents%3A%20read%60%20e%20%60pull-requests%3A%20write%60.%20Esse%20caminho%20precisa%20de%20%60security-events%3A%20write%60%20e%20pode%20falhar%20com%20acesso%20negado%2C%20deixando%20o%20scan%20executado%20apenas%20nos%20logs%20e%20sem%20os%20alertas%20de%20seguran%C3%A7a%20esperados.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fgitleaks.yml%3A21%0A**Forks%20Ficam%20Sem%20Licen%C3%A7a**%0A%0AEm%20%60pull_request%60%20vindo%20de%20fork%2C%20%60secrets%3A%20inherit%60%20n%C3%A3o%20repassa%20o%20%60GITLEAKS_LICENSE%60%20da%20org%20para%20o%20runner.%20Se%20o%20reusable%20workflow%20usa%20essa%20licen%C3%A7a%20para%20rodar%20o%20gitleaks%20no%20reposit%C3%B3rio%20da%20organiza%C3%A7%C3%A3o%2C%20esses%20PRs%20entram%20no%20job%20sem%20o%20segredo%20e%20o%20scan%20pode%20abortar%20justamente%20no%20caminho%20de%20contribui%C3%A7%C3%A3o%20externa.%0A%0A&pr=258&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/gitleaks.yml:10-12
**Upload SARIF Sem Permissão**

Quando o workflow chamado tenta publicar SARIF no Code Scanning, o `GITHUB_TOKEN` deste caller só tem `contents: read` e `pull-requests: write`. Esse caminho precisa de `security-events: write` e pode falhar com acesso negado, deixando o scan executado apenas nos logs e sem os alertas de segurança esperados.

### Issue 2 of 2
.github/workflows/gitleaks.yml:21
**Forks Ficam Sem Licença**

Em `pull_request` vindo de fork, `secrets: inherit` não repassa o `GITLEAKS_LICENSE` da org para o runner. Se o reusable workflow usa essa licença para rodar o gitleaks no repositório da organização, esses PRs entram no job sem o segredo e o scan pode abortar justamente no caminho de contribuição externa.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: add gitleaks secret scan (ci-workflo..."](https://github.com/cloudhumans/typebot.io/commit/4ceb02040e0253d34cf2a59113a915ad0c11f927) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44155029)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - packages/typebot-mcp-py/CLAUDE.md ([source](https://app.greptile.com/cloud-humans/github/cloudhumans/typebot.io/-/custom-context?memory=4ee52aab-9ada-46eb-af75-6d6fbfa3e6d6))
- Context used - CLAUDE.md ([source](https://app.greptile.com/cloud-humans/github/cloudhumans/typebot.io/-/custom-context?memory=6970a077-7c35-41d4-a69f-56539d16fd6c))
- Context used - Make all comments in Brazilian Portuguese (ptBR) ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
</details>

<!-- /greptile_comment -->