### PR TITLE
🐛bug: return picked sheet via opener when embedded

### DIFF
--- a/apps/builder/src/features/blocks/integrations/googleSheets/helpers/popupMessaging.ts
+++ b/apps/builder/src/features/blocks/integrations/googleSheets/helpers/popupMessaging.ts
@@ -4,16 +4,17 @@
 // different origin), Google refuses to render its consent / account-chooser
 // screens (Sec-Fetch-Dest: iframe → 403) and partitions cookies/storage. We run
 // both the OAuth connect and the Drive Picker in a top-level popup that escapes
-// the iframe sandbox, then hand the result back over a same-origin
-// BroadcastChannel.
+// the iframe sandbox, then hand the result back to the builder.
 //
-// Why BroadcastChannel instead of window.opener.postMessage: after a popup
-// navigates to Google's OAuth and back, COOP can sever window.opener (a
-// browsing-context-group switch the spec never restores). BroadcastChannel is
-// same-origin and opener-independent — the popup returns to our origin
-// (callback-complete / google-picker) and posts; the builder on the same origin
-// receives it regardless. A single channel carries both message types; each
-// listener filters by message `type`.
+// Return transport: the OAuth connect popup navigates to Google and back, which
+// COOP can use to sever window.opener (a browsing-context-group switch the spec
+// never restores), so it returns over a same-origin BroadcastChannel. But
+// BroadcastChannel is storage-partitioned: a builder embedded cross-site is in a
+// different partition than the top-level popup and never receives it. The Picker
+// popup never navigates cross-origin (the Picker is an overlay), so it keeps its
+// opener and additionally posts via window.opener.postMessage, which crosses the
+// partition boundary. Both message types share the channel and a listener
+// filters by message `type`; the picked message is also delivered via opener.
 export const GOOGLE_SHEETS_OAUTH_CHANNEL = 'google-sheets-oauth' as const
 
 export const GOOGLE_SHEETS_CONNECTED_MESSAGE =

--- a/apps/builder/src/features/blocks/integrations/googleSheets/helpers/popupMessaging.ts
+++ b/apps/builder/src/features/blocks/integrations/googleSheets/helpers/popupMessaging.ts
@@ -12,9 +12,10 @@
 // BroadcastChannel is storage-partitioned: a builder embedded cross-site is in a
 // different partition than the top-level popup and never receives it. The Picker
 // popup never navigates cross-origin (the Picker is an overlay), so it keeps its
-// opener and additionally posts via window.opener.postMessage, which crosses the
-// partition boundary. Both message types share the channel and a listener
-// filters by message `type`; the picked message is also delivered via opener.
+// opener and returns via window.opener.postMessage, which crosses the partition
+// boundary, falling back to the channel only when there is no opener. Both
+// message types share the channel and a listener filters by message `type`; the
+// picked message also arrives as an origin-checked window message.
 export const GOOGLE_SHEETS_OAUTH_CHANNEL = 'google-sheets-oauth' as const
 
 export const GOOGLE_SHEETS_CONNECTED_MESSAGE =

--- a/apps/builder/src/features/blocks/integrations/googleSheets/hooks/useGoogleSheetsOAuthListener.ts
+++ b/apps/builder/src/features/blocks/integrations/googleSheets/hooks/useGoogleSheetsOAuthListener.ts
@@ -81,8 +81,8 @@ export const useGoogleSheetsOAuthListener = () => {
       return true
     }
 
-    channel.onmessage = (event: MessageEvent) => {
-      const connected = parseGoogleSheetsConnectedMessage(event.data)
+    const handlePayload = (data: unknown) => {
+      const connected = parseGoogleSheetsConnectedMessage(data)
       if (connected) {
         // Only refresh the credentials list when an update actually happened.
         if (
@@ -93,13 +93,29 @@ export const useGoogleSheetsOAuthListener = () => {
           trpcContext.credentials.listCredentials.invalidate()
         return
       }
-      const picked = parseGoogleSheetsSpreadsheetPickedMessage(event.data)
-      if (picked) {
-        // Matches GoogleSheetsSettings' handleSpreadsheetIdChange: set
-        // spreadsheetId without clearing sheetId (no regression).
+      const picked = parseGoogleSheetsSpreadsheetPickedMessage(data)
+      if (picked)
+        // Set spreadsheetId without clearing sheetId (no regression).
         applyOptions(picked.blockId, { spreadsheetId: picked.spreadsheetId })
-      }
     }
-    return () => channel.close()
+
+    channel.onmessage = (event: MessageEvent) => handlePayload(event.data)
+
+    // The Picker popup keeps its opener (it never navigates cross-origin) and
+    // posts the result here too. Embedded cross-site, the builder iframe is in a
+    // different storage partition than the top-level popup, so the
+    // BroadcastChannel above never arrives; this opener path crosses that
+    // boundary. Validate the origin — window messages, unlike BroadcastChannel,
+    // are not same-origin by design.
+    const onWindowMessage = (event: MessageEvent) => {
+      if (event.origin !== globalThis.location.origin) return
+      handlePayload(event.data)
+    }
+    globalThis.addEventListener('message', onWindowMessage)
+
+    return () => {
+      channel.close()
+      globalThis.removeEventListener('message', onWindowMessage)
+    }
   }, [trpcContext])
 }

--- a/apps/builder/src/pages/google-picker.tsx
+++ b/apps/builder/src/pages/google-picker.tsx
@@ -117,19 +117,24 @@ export default function Page() {
         blockId,
         spreadsheetId,
       }
-      // The Picker renders as an overlay, so this popup never navigates
-      // cross-origin and keeps its opener — unlike the OAuth connect popup.
-      // Post to the opener too: BroadcastChannel is storage-partitioned, so a
-      // builder embedded cross-site (CloudChat iframe) is in a different
-      // partition and never receives the channel message; opener.postMessage
-      // crosses that boundary. Keep the channel for standalone.
-      const channel = new BroadcastChannel(GOOGLE_SHEETS_OAUTH_CHANNEL)
-      channel.postMessage(message)
-      globalThis.opener?.postMessage(message, globalThis.location.origin)
-      globalThis.setTimeout(() => {
-        channel.close()
-        globalThis.close()
-      }, 200)
+      // The Picker is an overlay, so this popup never navigates cross-origin and
+      // keeps its opener (unlike the OAuth connect popup, which COOP severs).
+      // Prefer opener.postMessage: it reaches the builder both standalone and
+      // embedded, crossing the storage-partition boundary that stops the
+      // BroadcastChannel when embedded cross-site (CloudChat iframe). Fall back
+      // to the channel only when there's no opener — using both would deliver the
+      // pick twice.
+      if (globalThis.opener) {
+        globalThis.opener.postMessage(message, globalThis.location.origin)
+        globalThis.setTimeout(() => globalThis.close(), 200)
+      } else {
+        const channel = new BroadcastChannel(GOOGLE_SHEETS_OAUTH_CHANNEL)
+        channel.postMessage(message)
+        globalThis.setTimeout(() => {
+          channel.close()
+          globalThis.close()
+        }, 200)
+      }
     }
 
     const picker = new window.google.picker.PickerBuilder()

--- a/apps/builder/src/pages/google-picker.tsx
+++ b/apps/builder/src/pages/google-picker.tsx
@@ -117,11 +117,15 @@ export default function Page() {
         blockId,
         spreadsheetId,
       }
-      // Broadcast on the same-origin channel (opener-independent — see
-      // popupMessaging.ts). Delivery across windows is async, so let it flush
-      // before closing or the message is dropped.
+      // The Picker renders as an overlay, so this popup never navigates
+      // cross-origin and keeps its opener — unlike the OAuth connect popup.
+      // Post to the opener too: BroadcastChannel is storage-partitioned, so a
+      // builder embedded cross-site (CloudChat iframe) is in a different
+      // partition and never receives the channel message; opener.postMessage
+      // crosses that boundary. Keep the channel for standalone.
       const channel = new BroadcastChannel(GOOGLE_SHEETS_OAUTH_CHANNEL)
       channel.postMessage(message)
+      globalThis.opener?.postMessage(message, globalThis.location.origin)
       globalThis.setTimeout(() => {
         channel.close()
         globalThis.close()


### PR DESCRIPTION
Ao criar/editar uma tool com Google Sheets dentro da ClaudIA (builder embutido no CloudChat), o usuário seleciona a planilha no picker e **nada acontece** — a planilha não é vinculada à tool. Reportado por Capim e Agilize. Não é o bug de OAuth (esse já foi corrigido); a autenticação funciona, a falha é ao anexar a planilha.

**Causa:** desde o #231 o resultado do Drive Picker volta pro builder **só por um `BroadcastChannel` same-origin**. Esse canal é particionado por storage: um builder embutido cross-site (iframe do CloudChat) fica numa partição diferente do popup top-level e nunca recebe a mensagem — o pick é descartado silenciosamente. Diferente do connect do OAuth, cujo `credentialsId` é gravado server-side no callback e por isso sobrevive.

**Correção:** o popup do picker nunca navega cross-origin (o Picker é overlay), então mantém o `opener`. Passamos a devolver o pick também por `window.opener.postMessage` (imune à partição), e o listener durável do editor passa a aceitar `window 'message'` com validação de origin, além do canal. O `BroadcastChannel` é mantido para o modo standalone. O fluxo de connect do OAuth não é alterado.

⚠️ **Precisa de validação no fluxo real (embedded/cross-site)** — o stack local (devbox) não reproduz o cenário (same-site `localhost`), e o `CLAUDE.md` do typebot avisa que mudanças no fluxo embedded exigem teste no fluxo real. Roteiro: conectar Google Sheets numa tool no editor embutido → Pick a spreadsheet → escolher → confirmar que o nome aparece no bloco e persiste após reload.

Issue: https://dev.azure.com/cloudhumans/ClaudIA/_workitems/edit/7908

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (2): Last reviewed commit: ["🐛bug: avoid double delivery of picked s..."](https://github.com/cloudhumans/typebot.io/commit/9ecebf6f682c036b4b1ff3e32cb1c2fb98ad53c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44276571)</sub>

**Context used:**

- Context used - packages/typebot-mcp-py/CLAUDE.md ([source](https://app.greptile.com/cloud-humans/github/cloudhumans/typebot.io/-/custom-context?memory=4ee52aab-9ada-46eb-af75-6d6fbfa3e6d6))
- Context used - CLAUDE.md ([source](https://app.greptile.com/cloud-humans/github/cloudhumans/typebot.io/-/custom-context?memory=6970a077-7c35-41d4-a69f-56539d16fd6c))

<!-- /greptile_comment -->