### PR TITLE
🐛bug: use undici fetch to avoid Next redirect bug

### DIFF
--- a/packages/bot-engine/blocks/integrations/webhook/executeWebhookBlock.ts
+++ b/packages/bot-engine/blocks/integrations/webhook/executeWebhookBlock.ts
@@ -16,6 +16,7 @@ import {
 import { stringify } from 'qs'
 import { isDefined, isEmpty, isNotDefined, omit } from '@typebot.io/lib'
 import ky, { HTTPError, Options, TimeoutError } from 'ky'
+import { fetch as undiciFetch, RequestInit as UndiciRequestInit } from 'undici'
 import { resumeWebhookExecution } from './resumeWebhookExecution'
 import { formatErrorWithCause } from './formatErrorWithCause'
 import { ExecuteIntegrationResponse } from '../../../types'
@@ -417,6 +418,28 @@ export const executeWebhook = async (
     body: (isFormData && body ? body : undefined) as any,
     timeout: calculateTimeout(),
     ...(isCredentialed ? { redirect: 'manual' as const } : {}),
+    // Next.js App Router replaces globalThis.fetch with an instrumented
+    // version (for cache/dedup) that intermittently throws `TypeError: fetch
+    // failed` on cross-origin redirects requiring a POST->GET downgrade
+    // (e.g. Google Apps Script's script.google.com -> script.googleusercontent.com).
+    // ky passes its internal Request object straight to a custom `fetch`, but
+    // that Request was built with Next's patched global Request class, which
+    // undici's standalone fetch doesn't recognize as valid input (it fails
+    // with "Failed to parse URL from [object Request]"). Rebuild a plain
+    // request from its parts before handing it to undici.
+    fetch: (async (request: globalThis.Request, opts?: RequestInit) => {
+      const requestBody =
+        request.method === 'GET' || request.method === 'HEAD'
+          ? undefined
+          : await request.arrayBuffer()
+      return undiciFetch(request.url, {
+        method: request.method,
+        headers: Object.fromEntries(request.headers.entries()),
+        body: requestBody,
+        redirect: request.redirect,
+        ...opts,
+      } as UndiciRequestInit)
+    }) as unknown as typeof fetch,
   } satisfies Options & { url: string; body: any }
 
   const requestStartTime = Date.now()

--- a/packages/bot-engine/blocks/integrations/webhook/executeWebhookBlock.ts
+++ b/packages/bot-engine/blocks/integrations/webhook/executeWebhookBlock.ts
@@ -438,6 +438,12 @@ export const executeWebhook = async (
         body: requestBody,
         redirect: request.redirect,
         ...opts,
+        // ky's timeout aborts via an AbortController whose signal it attaches
+        // to `request` itself (not `opts` — `findUnknownOptions` filters out
+        // standard Request options like `signal`). Forwarding it here lets an
+        // actual ky timeout also cancel the underlying undici request instead
+        // of leaving it running in the background.
+        signal: opts?.signal ?? request.signal,
       } as UndiciRequestInit)
     }) as unknown as typeof fetch,
   } satisfies Options & { url: string; body: any }

--- a/packages/bot-engine/blocks/integrations/webhook/executeWebhookBlock.ts
+++ b/packages/bot-engine/blocks/integrations/webhook/executeWebhookBlock.ts
@@ -499,9 +499,13 @@ export const executeWebhook = async (
         data: await parseResponseBody(error.response),
       }
       // With redirect:'manual' (credential-backed requests) ky throws instead of
-      // following a redirect; surface a clear reason. Under Node/undici a manual
-      // redirect usually arrives as an opaque response (type 'opaqueredirect',
-      // status 0) rather than a 3xx, so detect both shapes.
+      // following a redirect; surface a clear reason. Server-side undici
+      // deliberately deviates from the Fetch spec here and returns the raw 3xx
+      // response instead of a synthetic `opaqueredirect`
+      // (see https://github.com/nodejs/undici/issues/1193) — the `status === 0`
+      // / `type === 'opaqueredirect'` checks below are defensive for other
+      // fetch implementations, but the 3xx check is what actually fires under
+      // undici. Don't drop it: that's the SSRF guard for credentialed requests.
       const isBlockedRedirect =
         isCredentialed &&
         (error.response.status === 0 ||

--- a/packages/bot-engine/blocks/integrations/webhook/executeWebhookBlock.ts
+++ b/packages/bot-engine/blocks/integrations/webhook/executeWebhookBlock.ts
@@ -428,10 +428,13 @@ export const executeWebhook = async (
     // with "Failed to parse URL from [object Request]"). Rebuild a plain
     // request from its parts before handing it to undici.
     fetch: (async (request: globalThis.Request, opts?: RequestInit) => {
+      // `request.body` is null for any bodyless request (not just GET/HEAD —
+      // e.g. a POST/DELETE with no body configured), so check it directly
+      // instead of the method. Otherwise arrayBuffer() on a bodyless request
+      // still yields an empty ArrayBuffer, sending Content-Length: 0 instead
+      // of no body at all.
       const requestBody =
-        request.method === 'GET' || request.method === 'HEAD'
-          ? undefined
-          : await request.arrayBuffer()
+        request.body === null ? undefined : await request.arrayBuffer()
       return undiciFetch(request.url, {
         method: request.method,
         headers: Object.fromEntries(request.headers.entries()),

--- a/packages/bot-engine/package.json
+++ b/packages/bot-engine/package.json
@@ -33,7 +33,7 @@
     "openai": "4.47.1",
     "qs": "6.11.2",
     "stripe": "12.13.0",
-    "undici": "5.28.3",
+    "undici": "5.28.5",
     "isolated-vm": "4.7.2"
   },
   "devDependencies": {

--- a/packages/bot-engine/package.json
+++ b/packages/bot-engine/package.json
@@ -33,7 +33,7 @@
     "openai": "4.47.1",
     "qs": "6.11.2",
     "stripe": "12.13.0",
-    "undici": "5.28.5",
+    "undici": "5.29.0",
     "isolated-vm": "4.7.2"
   },
   "devDependencies": {

--- a/packages/bot-engine/package.json
+++ b/packages/bot-engine/package.json
@@ -33,6 +33,7 @@
     "openai": "4.47.1",
     "qs": "6.11.2",
     "stripe": "12.13.0",
+    "undici": "5.28.3",
     "isolated-vm": "4.7.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -836,8 +836,8 @@ importers:
         specifier: 12.13.0
         version: 12.13.0
       undici:
-        specifier: 5.28.3
-        version: 5.28.3
+        specifier: 5.28.5
+        version: 5.28.5
     devDependencies:
       '@typebot.io/forge':
         specifier: workspace:*
@@ -24397,6 +24397,12 @@ packages:
 
   /undici@5.28.3:
     resolution: {integrity: sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==}
+    engines: {node: '>=14.0'}
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
+  /undici@5.28.5:
+    resolution: {integrity: sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==}
     engines: {node: '>=14.0'}
     dependencies:
       '@fastify/busboy': 2.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -835,6 +835,9 @@ importers:
       stripe:
         specifier: 12.13.0
         version: 12.13.0
+      undici:
+        specifier: 5.28.3
+        version: 5.28.3
     devDependencies:
       '@typebot.io/forge':
         specifier: workspace:*
@@ -24397,7 +24400,6 @@ packages:
     engines: {node: '>=14.0'}
     dependencies:
       '@fastify/busboy': 2.1.1
-    dev: true
 
   /unenv@1.9.0:
     resolution: {integrity: sha512-QKnFNznRxmbOF1hDgzpqrlIf6NC5sbZ2OJ+5Wl3OX8uM+LUJXbj4TXvLJCtwbPTmbMHCLIz6JLKNinNsMShK9g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -836,8 +836,8 @@ importers:
         specifier: 12.13.0
         version: 12.13.0
       undici:
-        specifier: 5.28.5
-        version: 5.28.5
+        specifier: 5.29.0
+        version: 5.29.0
     devDependencies:
       '@typebot.io/forge':
         specifier: workspace:*
@@ -24401,8 +24401,8 @@ packages:
     dependencies:
       '@fastify/busboy': 2.1.1
 
-  /undici@5.28.5:
-    resolution: {integrity: sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==}
+  /undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
     dependencies:
       '@fastify/busboy': 2.1.1


### PR DESCRIPTION
## Problema

Chamadas de webhook do Typebot para endpoints que respondem com redirect cross-origin exigindo troca de método (POST→GET) — como o Google Apps Script (`script.google.com` → `script.googleusercontent.com`) — falhavam com `TypeError: fetch failed` em cerca de **44% das vezes em produção** (confirmado via Datadog APM, ocorrendo desde jan/2025). Isso afetava qualquer fluxo com esse padrão, tanto em conversas normais quanto em tools chamadas via MCP por agentes de IA.

A causa raiz: o `ky` (client HTTP usado no bloco de webhook) resolve `fetch` a partir de `globalThis.fetch`, que o Next.js App Router substitui por uma versão própria instrumentada (para cache/dedup de requests). Essa versão tem um bug conhecido ao lidar com esse tipo específico de redirect.

## Solução

Passa o `fetch` do pacote `undici` diretamente para o `ky`, contornando o fetch remendado do Next.js.

Validado empiricamente contra o endpoint real de produção: **25 chamadas sequenciais falharam 100% das vezes sem essa correção, e 0% das vezes com ela** (usando um ambiente isolado com as mesmas versões de produção — Next 14.1.0 + ky 1.2.3 + Node 18).

## Test plan

- [x] Suíte de testes de `packages/bot-engine` passando (75 testes)
- [x] Validação empírica com harness reproduzindo o bug contra o endpoint real (antes/depois)
- [ ] Acompanhar no Datadog se a taxa de erro em `@error.message:"fetch failed"` cai após o deploy

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<sub>Reviews (4): Last reviewed commit: ["fix: bump undici to 5.29.0 (CVE-2025-472..."](https://github.com/cloudhumans/typebot.io/commit/5507d09f32525f30e62d629b86c1010482e65319) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44329309)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - packages/typebot-mcp-py/CLAUDE.md ([source](https://app.greptile.com/cloud-humans/github/cloudhumans/typebot.io/-/custom-context?memory=4ee52aab-9ada-46eb-af75-6d6fbfa3e6d6))
- Context used - CLAUDE.md ([source](https://app.greptile.com/cloud-humans/github/cloudhumans/typebot.io/-/custom-context?memory=6970a077-7c35-41d4-a69f-56539d16fd6c))
- Context used - Make all comments in Brazilian Portuguese (ptBR) ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
</details>

<!-- /greptile_comment -->