### PR TITLE
feat: persist typebotId on VisitedEdge

### DIFF
--- a/packages/bot-engine/getNextGroup.ts
+++ b/packages/bot-engine/getNextGroup.ts
@@ -140,6 +140,7 @@ export const getNextGroup = async ({
             index: currentVisitedEdgeIndex as number,
             edgeId: nextEdge.id,
             resultId,
+            typebotId: state.typebotsQueue[0].typebot.typebotId ?? null,
           }
         : undefined,
   }

--- a/packages/prisma/mysql/schema.prisma
+++ b/packages/prisma/mysql/schema.prisma
@@ -291,10 +291,13 @@ model SetVariableHistoryItem {
 }
 
 model VisitedEdge {
-  result   Result @relation(fields: [resultId], references: [id], onDelete: Cascade)
-  resultId String
-  edgeId   String
-  index    Int
+  result    Result  @relation(fields: [resultId], references: [id], onDelete: Cascade)
+  resultId  String
+  edgeId    String
+  index     Int
+  // Typebot that owns the edge. Edge ids are only unique within a flow, so
+  // without this the owner is ambiguous when linked sub-flows share cloned ids.
+  typebotId String?
 
   @@unique([resultId, index])
 }

--- a/packages/prisma/postgresql/migrations/20260715000000_add_typebot_id_to_visited_edge/migration.sql
+++ b/packages/prisma/postgresql/migrations/20260715000000_add_typebot_id_to_visited_edge/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "VisitedEdge" ADD COLUMN IF NOT EXISTS "typebotId" TEXT;

--- a/packages/prisma/postgresql/schema.prisma
+++ b/packages/prisma/postgresql/schema.prisma
@@ -343,10 +343,13 @@ model SetVariableHistoryItem {
 }
 
 model VisitedEdge {
-  result   Result @relation(fields: [resultId], references: [id], onDelete: Cascade)
-  resultId String
-  edgeId   String
-  index    Int
+  result    Result  @relation(fields: [resultId], references: [id], onDelete: Cascade)
+  resultId  String
+  edgeId    String
+  index     Int
+  // Typebot that owns the edge. Edge ids are only unique within a flow, so
+  // without this the owner is ambiguous when linked sub-flows share cloned ids.
+  typebotId String?
 
   @@unique([resultId, index])
 }


### PR DESCRIPTION
## What
Adds a nullable `typebotId` column to `VisitedEdge` and fills it at write time in `getNextGroup` — the only place that constructs the row, and where the edge is read from the executing flow (`typebotsQueue[0]`), so the value is exact by construction. Prisma schema (postgres + mysql) + migration + one-line write change.

## Why
Edge ids are only unique **within** a flow. Linked sub-flows cloned from the same template share edge ids, so a `VisitedEdge` row alone can't tell **which flow** the visit happened in. The datalake models that resolve the finishing group per result (`eddie_results`, base for Shopee's per-output CSAT/SLA/transfer metrics) reconstruct the owner via the Typebot-link reachability graph — correct for 99.1%, but **structurally ambiguous for ~0.9%** (measured 2026-07-13: 348 of 38,108 entry-resolved results have a conflicting reachable sub-flow).

With `typebotId` persisted, the datalake join becomes exact (`edge_id + typebot_id`) for new data. Same pattern as the durable `resultId` (#254 + claudia#1496): new data = exact, history = graph fallback.

## Follow-ups (outside this PR)
- safe-airflow-data: extract the new column in `eddie_visitededge_to_redshift` (+ Redshift column).
- dbt-cloudhumans: prefer `typebot_id` from the visit when present, graph fallback otherwise (dbt#55).

## Notes
- Column is nullable: existing rows stay null; no backfill possible (information was never recorded).
- Preview runs don't create `VisitedEdge` rows (guarded by `resultId`), unchanged.
- `?? null` guards legacy in-flight sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>

O fluxo de atualização do banco MySQL precisa ser corrigido antes do merge.

- O Prisma Client para MySQL passa a escrever `typebotId`.
- O PR não inclui uma forma de criar essa coluna em instalações MySQL que usam `migrate:deploy`.
- PostgreSQL recebe uma migração aditiva e o valor é obtido do mesmo fluxo usado para resolver a aresta.

packages/prisma/mysql/schema.prisma e o mecanismo de migração para MySQL.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fprisma%2Fmysql%2Fschema.prisma%3A300%0A**Coluna%20ausente%20em%20deploys%20MySQL**%0A%0AEm%20instala%C3%A7%C3%B5es%20MySQL%20que%20usam%20o%20fluxo%20de%20%60migrate%3Adeploy%60%2C%20essa%20altera%C3%A7%C3%A3o%20atualiza%20o%20Prisma%20Client%2C%20mas%20n%C3%A3o%20cria%20a%20coluna%20f%C3%ADsica%2C%20pois%20esse%20fluxo%20s%C3%B3%20aplica%20migra%C3%A7%C3%B5es%20PostgreSQL%20e%20n%C3%A3o%20h%C3%A1%20uma%20migra%C3%A7%C3%A3o%20MySQL%20neste%20PR.%20Ao%20salvar%20uma%20aresta%20visitada%2C%20o%20Prisma%20enviar%C3%A1%20%60typebotId%60%20para%20uma%20tabela%20sem%20essa%20coluna%20e%20a%20execu%C3%A7%C3%A3o%20do%20bot%20falhar%C3%A1%20com%20erro%20de%20coluna%20desconhecida.%0A%0A&repo=cloudhumans%2Ftypebot.io&pr=263&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fprisma%2Fmysql%2Fschema.prisma%3A300%0A**Coluna%20ausente%20em%20deploys%20MySQL**%0A%0AEm%20instala%C3%A7%C3%B5es%20MySQL%20que%20usam%20o%20fluxo%20de%20%60migrate%3Adeploy%60%2C%20essa%20altera%C3%A7%C3%A3o%20atualiza%20o%20Prisma%20Client%2C%20mas%20n%C3%A3o%20cria%20a%20coluna%20f%C3%ADsica%2C%20pois%20esse%20fluxo%20s%C3%B3%20aplica%20migra%C3%A7%C3%B5es%20PostgreSQL%20e%20n%C3%A3o%20h%C3%A1%20uma%20migra%C3%A7%C3%A3o%20MySQL%20neste%20PR.%20Ao%20salvar%20uma%20aresta%20visitada%2C%20o%20Prisma%20enviar%C3%A1%20%60typebotId%60%20para%20uma%20tabela%20sem%20essa%20coluna%20e%20a%20execu%C3%A7%C3%A3o%20do%20bot%20falhar%C3%A1%20com%20erro%20de%20coluna%20desconhecida.%0A%0A&pr=263&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/prisma/mysql/schema.prisma:300
**Coluna ausente em deploys MySQL**

Em instalações MySQL que usam o fluxo de `migrate:deploy`, essa alteração atualiza o Prisma Client, mas não cria a coluna física, pois esse fluxo só aplica migrações PostgreSQL e não há uma migração MySQL neste PR. Ao salvar uma aresta visitada, o Prisma enviará `typebotId` para uma tabela sem essa coluna e a execução do bot falhará com erro de coluna desconhecida.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: persist typebotId on VisitedEdge"](https://github.com/cloudhumans/typebot.io/commit/6b41b602aa9f27a57afddd3c528381ae96aff5c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44582786)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - packages/typebot-mcp-py/CLAUDE.md ([source](https://app.greptile.com/cloud-humans/github/cloudhumans/typebot.io/-/custom-context?memory=4ee52aab-9ada-46eb-af75-6d6fbfa3e6d6))
- Context used - CLAUDE.md ([source](https://app.greptile.com/cloud-humans/github/cloudhumans/typebot.io/-/custom-context?memory=6970a077-7c35-41d4-a69f-56539d16fd6c))

<!-- /greptile_comment -->