### PR TITLE
feat: persist typebotId on VisitedEdge

### DIFF
--- a/packages/bot-engine/getNextGroup.ts
+++ b/packages/bot-engine/getNextGroup.ts
@@ -140,6 +140,10 @@ export const getNextGroup = async ({
             index: currentVisitedEdgeIndex as number,
             edgeId: nextEdge.id,
             resultId,
+            // Contract: when non-null this is a Typebot.id. Do NOT fall back to
+            // typebot.id — in prod sessions that's the PublicTypebot id (a
+            // different id space), indistinguishable from a Typebot.id once
+            // stored, which silently poisons downstream joins. null = unknown.
             typebotId: state.typebotsQueue[0].typebot.typebotId ?? null,
           }
         : undefined,

--- a/packages/bot-engine/getNextGroup.ts
+++ b/packages/bot-engine/getNextGroup.ts
@@ -140,6 +140,7 @@ export const getNextGroup = async ({
             index: currentVisitedEdgeIndex as number,
             edgeId: nextEdge.id,
             resultId,
+            typebotId: state.typebotsQueue[0].typebot.typebotId ?? null,
           }
         : undefined,
   }

--- a/packages/prisma/mysql/schema.prisma
+++ b/packages/prisma/mysql/schema.prisma
@@ -291,10 +291,13 @@ model SetVariableHistoryItem {
 }
 
 model VisitedEdge {
-  result   Result @relation(fields: [resultId], references: [id], onDelete: Cascade)
-  resultId String
-  edgeId   String
-  index    Int
+  result    Result  @relation(fields: [resultId], references: [id], onDelete: Cascade)
+  resultId  String
+  edgeId    String
+  index     Int
+  // Typebot that owns the edge. Edge ids are only unique within a flow, so
+  // without this the owner is ambiguous when linked sub-flows share cloned ids.
+  typebotId String?
 
   @@unique([resultId, index])
 }

--- a/packages/prisma/postgresql/migrations/20260715000000_add_typebot_id_to_visited_edge/migration.sql
+++ b/packages/prisma/postgresql/migrations/20260715000000_add_typebot_id_to_visited_edge/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "VisitedEdge" ADD COLUMN IF NOT EXISTS "typebotId" TEXT;

--- a/packages/prisma/postgresql/schema.prisma
+++ b/packages/prisma/postgresql/schema.prisma
@@ -343,10 +343,13 @@ model SetVariableHistoryItem {
 }
 
 model VisitedEdge {
-  result   Result @relation(fields: [resultId], references: [id], onDelete: Cascade)
-  resultId String
-  edgeId   String
-  index    Int
+  result    Result  @relation(fields: [resultId], references: [id], onDelete: Cascade)
+  resultId  String
+  edgeId    String
+  index     Int
+  // Typebot that owns the edge. Edge ids are only unique within a flow, so
+  // without this the owner is ambiguous when linked sub-flows share cloned ids.
+  typebotId String?
 
   @@unique([resultId, index])
 }

--- a/packages/schemas/features/result.ts
+++ b/packages/schemas/features/result.ts
@@ -30,6 +30,7 @@ export const visitedEdgeSchema = z.object({
   edgeId: z.string(),
   resultId: z.string(),
   index: z.number(),
+  typebotId: z.string().nullable(),
 }) satisfies z.ZodType<VisitedEdge>
 
 export const resultWithAnswersInputSchema = resultSchema.merge(


### PR DESCRIPTION
## What
Adds a nullable `typebotId` column to `VisitedEdge` and fills it at write time in `getNextGroup` — the only place that constructs the row, and where the edge is read from the executing flow (`typebotsQueue[0]`), so the value is exact by construction. Prisma schema (postgres + mysql) + migration + one-line write change.

## Why
Edge ids are only unique **within** a flow. Linked sub-flows cloned from the same template share edge ids, so a `VisitedEdge` row alone can't tell **which flow** the visit happened in. The datalake models that resolve the finishing group per result (`eddie_results`, base for Shopee's per-output CSAT/SLA/transfer metrics) reconstruct the owner via the Typebot-link reachability graph — correct for 99.1%, but **structurally ambiguous for ~0.9%** (measured 2026-07-13: 348 of 38,108 entry-resolved results have a conflicting reachable sub-flow).

With `typebotId` persisted, the datalake join becomes exact (`edge_id + typebot_id`) for new data. Same pattern as the durable `resultId` (#254 + claudia#1496): new data = exact, history = graph fallback.

## Follow-ups (outside this PR)
- safe-airflow-data: extract the new column in `eddie_visitededge_to_redshift` (+ Redshift column).
- dbt-cloudhumans: prefer `typebot_id` from the visit when present, graph fallback otherwise (dbt#55).

## Notes
- Column is nullable: existing rows stay null; no backfill possible (information was never recorded).
- Preview runs don't create `VisitedEdge` rows (guarded by `resultId`), unchanged.
- `?? null` guards legacy in-flight sessions.
- MySQL deploys: this repo applies MySQL schema exclusively via `db:push` (`migrate-deploy.ts` is a no-op unless `DATABASE_URL` starts with `postgres`; there is no mysql migrations directory) — the updated `mysql/schema.prisma` covers it, same convention as every past schema change. Both of our instances run Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

As mudanças parecem seguras para merge.

- O campo é anulável para preservar registros históricos.
- Os schemas PostgreSQL e MySQL estão alinhados.
- O ponto de escrita e o contrato de resultado incluem o novo campo.
- Nenhum problema bloqueante elegível foi encontrado no código alterado.

<sub>Reviews (3): Last reviewed commit: ["fix: include typebotId in visitedEdgeSch..."](https://github.com/cloudhumans/typebot.io/commit/c9e65678a14c1c7caf1da38aa6089cb6eb11744a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44620122)</sub>

**Context used:**

- Context used - packages/typebot-mcp-py/CLAUDE.md ([source](https://app.greptile.com/cloud-humans/github/cloudhumans/typebot.io/-/custom-context?memory=4ee52aab-9ada-46eb-af75-6d6fbfa3e6d6))
- Context used - CLAUDE.md ([source](https://app.greptile.com/cloud-humans/github/cloudhumans/typebot.io/-/custom-context?memory=6970a077-7c35-41d4-a69f-56539d16fd6c))

<!-- /greptile_comment -->