### PR TITLE
Remove Authenticating text from embedded loading screen

### DIFF
--- a/apps/builder/src/features/embedded-auth/EmbeddedAuthWrapper.tsx
+++ b/apps/builder/src/features/embedded-auth/EmbeddedAuthWrapper.tsx
@@ -24,7 +24,7 @@ export const EmbeddedAuthWrapper = ({ children }: PropsWithChildren) => {
   if (isLoading) {
     return (
       <Flex h="100vh" justify="center" align="center" flexDirection="column">
-        <Spinner size="lg" aria-label={t('embeddedAuth.loading')} />
+        <Spinner size="lg" label={t('embeddedAuth.loading')} />
       </Flex>
     )
   }

--- a/apps/builder/src/features/embedded-auth/EmbeddedAuthWrapper.tsx
+++ b/apps/builder/src/features/embedded-auth/EmbeddedAuthWrapper.tsx
@@ -21,15 +21,8 @@ export const EmbeddedAuthWrapper = ({ children }: PropsWithChildren) => {
 
   if (isLoading) {
     return (
-      <Flex
-        h="100vh"
-        justify="center"
-        align="center"
-        flexDirection="column"
-        gap={4}
-      >
+      <Flex h="100vh" justify="center" align="center" flexDirection="column">
         <Spinner size="lg" />
-        <Text>{'Authenticating...'}</Text>
       </Flex>
     )
   }

--- a/apps/builder/src/features/embedded-auth/EmbeddedAuthWrapper.tsx
+++ b/apps/builder/src/features/embedded-auth/EmbeddedAuthWrapper.tsx
@@ -1,9 +1,11 @@
 import { PropsWithChildren } from 'react'
 import { Flex, Spinner, Text } from '@chakra-ui/react'
+import { useTranslate } from '@tolgee/react'
 import { useEmbeddedAuth } from '@/hooks/useEmbeddedAuth'
 
 export const EmbeddedAuthWrapper = ({ children }: PropsWithChildren) => {
   const { authError, isLoading } = useEmbeddedAuth()
+  const { t } = useTranslate()
 
   if (authError) {
     return (
@@ -22,7 +24,7 @@ export const EmbeddedAuthWrapper = ({ children }: PropsWithChildren) => {
   if (isLoading) {
     return (
       <Flex h="100vh" justify="center" align="center" flexDirection="column">
-        <Spinner size="lg" />
+        <Spinner size="lg" aria-label={t('embeddedAuth.loading')} />
       </Flex>
     )
   }

--- a/apps/builder/src/i18n/de.json
+++ b/apps/builder/src/i18n/de.json
@@ -201,6 +201,7 @@
   "editor.sidebarBlocks.sidebar.icon.unlock.label": "Entsperren",
   "editor.sidebarBlocks.sidebar.lock.label": "Seitenleiste sperren",
   "editor.sidebarBlocks.sidebar.unlock.label": "Seitenleiste entsperren",
+  "embeddedAuth.loading": "Wird geladen...",
   "errorMessage": "Ein Fehler ist aufgetreten",
   "folders.createFolderButton.label": "Ordner erstellen",
   "folders.createTypebotButton.label": "Flow erstellen",

--- a/apps/builder/src/i18n/en.json
+++ b/apps/builder/src/i18n/en.json
@@ -405,6 +405,7 @@
   "editor.sidebarBlocks.sidebar.icon.unlock.label": "Unlock",
   "editor.sidebarBlocks.sidebar.lock.label": "Lock sidebar",
   "editor.sidebarBlocks.sidebar.unlock.label": "Unlock sidebar",
+  "embeddedAuth.loading": "Loading...",
   "emojiList.categories.activities.label": "ACTIVITIES",
   "emojiList.categories.animalsAndNature.label": "ANIMALS & NATURE",
   "emojiList.categories.flags.label": "FLAGS",

--- a/apps/builder/src/i18n/es.json
+++ b/apps/builder/src/i18n/es.json
@@ -404,6 +404,7 @@
   "editor.sidebarBlocks.sidebar.icon.unlock.label": "Desbloquear",
   "editor.sidebarBlocks.sidebar.lock.label": "Bloquear barra lateral",
   "editor.sidebarBlocks.sidebar.unlock.label": "Desbloquear barra lateral",
+  "embeddedAuth.loading": "Cargando...",
   "emojiList.categories.activities.label": "ACTIVIDADES",
   "emojiList.categories.animalsAndNature.label": "ANIMALES Y NATURALEZA",
   "emojiList.categories.flags.label": "BANDERAS",

--- a/apps/builder/src/i18n/fr.json
+++ b/apps/builder/src/i18n/fr.json
@@ -352,6 +352,7 @@
   "editor.sidebarBlocks.sidebar.icon.unlock.label": "Ouverte",
   "editor.sidebarBlocks.sidebar.lock.label": "Fermer la barre latérale",
   "editor.sidebarBlocks.sidebar.unlock.label": "Ouvrir la barre latérale",
+  "embeddedAuth.loading": "Chargement...",
   "emojiList.categories.activities.label": "ACTIVITÉS",
   "emojiList.categories.animalsAndNature.label": "ANIMAUX & NATURE",
   "emojiList.categories.flags.label": "DRAPEAUX",

--- a/apps/builder/src/i18n/it.json
+++ b/apps/builder/src/i18n/it.json
@@ -319,6 +319,7 @@
   "editor.sidebarBlocks.sidebar.icon.unlock.label": "Sblocco",
   "editor.sidebarBlocks.sidebar.lock.label": "Blocca barra laterale",
   "editor.sidebarBlocks.sidebar.unlock.label": "Sblocca barra laterale",
+  "embeddedAuth.loading": "Caricamento...",
   "emojiList.categories.activities.label": "ATTIVITÀ",
   "emojiList.categories.animalsAndNature.label": "ANIMALI E NATURA",
   "emojiList.categories.flags.label": "BANDIERE",

--- a/apps/builder/src/i18n/pt-BR.json
+++ b/apps/builder/src/i18n/pt-BR.json
@@ -404,6 +404,7 @@
   "editor.sidebarBlocks.sidebar.icon.unlock.label": "Desbloquear",
   "editor.sidebarBlocks.sidebar.lock.label": "Bloquear barra lateral",
   "editor.sidebarBlocks.sidebar.unlock.label": "Desbloquear barra lateral",
+  "embeddedAuth.loading": "Carregando...",
   "emojiList.categories.activities.label": "ATIVIDADES",
   "emojiList.categories.animalsAndNature.label": "ANIMAIS & NATUREZA",
   "emojiList.categories.flags.label": "BANDEIRAS",

--- a/apps/builder/src/i18n/pt.json
+++ b/apps/builder/src/i18n/pt.json
@@ -215,6 +215,7 @@
   "editor.sidebarBlocks.sidebar.icon.unlock.label": "Desbloquear",
   "editor.sidebarBlocks.sidebar.lock.label": "Bloquear barra lateral",
   "editor.sidebarBlocks.sidebar.unlock.label": "Desbloquear barra lateral",
+  "embeddedAuth.loading": "A carregar...",
   "errorMessage": "Ocorreu um erro",
   "folders.createFolderButton.label": "Criar uma pasta",
   "folders.createTypebotButton.label": "Criar um Flow",

--- a/apps/builder/src/i18n/ro.json
+++ b/apps/builder/src/i18n/ro.json
@@ -202,6 +202,7 @@
   "editor.sidebarBlocks.sidebar.icon.unlock.label": "Deblocați",
   "editor.sidebarBlocks.sidebar.lock.label": "Blocați bara laterală",
   "editor.sidebarBlocks.sidebar.unlock.label": "Deblocați bara laterală",
+  "embeddedAuth.loading": "Se încarcă...",
   "errorMessage": "A aparut o eroare",
   "folders.createFolderButton.label": "Creați un folder",
   "folders.createTypebotButton.label": "Creați un Flow",


### PR DESCRIPTION
## Summary
Removes the "Authenticating..." text from the embedded loading screen shown when Typebot is embedded inside CloudChat, leaving only the spinner.

Closes cloudhumans/composezao-da-massa#166

## Changes
- `apps/builder/src/features/embedded-auth/EmbeddedAuthWrapper.tsx`: removed the `<Text>` line in the `isLoading` branch and the now-unneeded `gap={4}` on that flex (the `authError` flex/text is untouched).

## Test plan
- [x] `tsc --noEmit` on the builder passes with no new errors
- [x] `Text` import still used by the `authError` branch

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

A alteração parece segura para merge.

- O spinner agora recebe um rótulo localizado para tecnologias assistivas.
- A chave de tradução foi adicionada a todos os idiomas configurados.
- Nenhum problema bloqueante foi encontrado no código alterado.

<sub>Reviews (3): Last reviewed commit: ["fix(builder): use Chakra Spinner label p..."](https://github.com/cloudhumans/typebot.io/commit/7d8aee7c8866812ab20b2f5c134a3aedc8b98058) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45753657)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/cloud-humans/github/cloudhumans/typebot.io/-/custom-context?memory=6970a077-7c35-41d4-a69f-56539d16fd6c))

<!-- /greptile_comment -->