### PR TITLE
Align embedded builder to Claudia design system (theme.ts)

### DIFF
--- a/apps/builder/src/components/AlertInfo.tsx
+++ b/apps/builder/src/components/AlertInfo.tsx
@@ -1,9 +1,5 @@
-import {
-  AlertProps,
-  Alert,
-  AlertIcon,
-  useColorModeValue,
-} from '@chakra-ui/react'
+import { AlertProps, Alert, useColorModeValue } from '@chakra-ui/react'
+import { InfoIcon } from '@/components/icons'
 
 // Claudia cyan, set explicitly so this component never depends on the
 // status="info" -> colorScheme="blue" -> variant -> theme-override chain
@@ -12,7 +8,10 @@ import {
 //
 // Matches the claudia-app info callout (create-tool-dialog "Criar nova
 // ferramenta"): rounded-xl bg-ca-cyan-light-3 text-ca-cyan-dark
-// dark:bg-ca-cyan-dark/20 dark:text-ca-cyan-light-2.
+// dark:bg-ca-cyan-dark/20 dark:text-ca-cyan-light-2, with a lucide
+// <Info size={16}> (outline, transparent fill). We use Typebot's own
+// InfoIcon (Feather-derived, same geometry as lucide's Info) instead of
+// Chakra's <AlertIcon>, whose info glyph is a SOLID filled circle.
 //   light bg:    #d0f0fd            -> --color-ca-cyan-light-3
 //   light icon:  #0b76b7            -> --color-ca-cyan-dark
 //   dark bg:     rgba(11,118,183,.2) -> --color-ca-cyan-dark @ 20% (dark:/20)
@@ -23,7 +22,7 @@ export const AlertInfo = (props: AlertProps) => {
 
   return (
     <Alert status="info" rounded="xl" bg={bg} {...props}>
-      <AlertIcon color={iconColor} />
+      <InfoIcon color={iconColor} boxSize="16px" mr={2} mt="2px" />
       {props.children}
     </Alert>
   )

--- a/apps/builder/src/components/AlertInfo.tsx
+++ b/apps/builder/src/components/AlertInfo.tsx
@@ -9,16 +9,20 @@ import {
 // status="info" -> colorScheme="blue" -> variant -> theme-override chain
 // (which can fall through to raw Chakra blue or the blue->primary/orange
 // alias in theme.ts if any hop doesn't apply).
-//   light bg:    #d0f0fd -> --color-ca-cyan-light-3
-//   light icon:  #01a9db -> --color-ca-cyan
-//   dark bg:     rgba(1, 169, 219, 0.24) -> translucent --color-ca-cyan
-//   dark icon:   #77d1f3 -> --color-ca-cyan-light-2
+//
+// Matches the claudia-app info callout (create-tool-dialog "Criar nova
+// ferramenta"): rounded-xl bg-ca-cyan-light-3 text-ca-cyan-dark
+// dark:bg-ca-cyan-dark/20 dark:text-ca-cyan-light-2.
+//   light bg:    #d0f0fd            -> --color-ca-cyan-light-3
+//   light icon:  #0b76b7            -> --color-ca-cyan-dark
+//   dark bg:     rgba(11,118,183,.2) -> --color-ca-cyan-dark @ 20% (dark:/20)
+//   dark icon:   #77d1f3            -> --color-ca-cyan-light-2
 export const AlertInfo = (props: AlertProps) => {
-  const bg = useColorModeValue('#d0f0fd', 'rgba(1, 169, 219, 0.24)')
-  const iconColor = useColorModeValue('#01a9db', '#77d1f3')
+  const bg = useColorModeValue('#d0f0fd', 'rgba(11, 118, 183, 0.2)')
+  const iconColor = useColorModeValue('#0b76b7', '#77d1f3')
 
   return (
-    <Alert status="info" rounded="md" bg={bg} {...props}>
+    <Alert status="info" rounded="xl" bg={bg} {...props}>
       <AlertIcon color={iconColor} />
       {props.children}
     </Alert>

--- a/apps/builder/src/components/AlertInfo.tsx
+++ b/apps/builder/src/components/AlertInfo.tsx
@@ -14,8 +14,8 @@ import { InfoIcon } from '@/components/icons'
 //   light text+icon:  #637381            -> --color-ca-primary-text
 //   dark text+icon:   #cdced6            -> --color-ca-dark-7
 // Icon: Typebot's outline InfoIcon (Feather geometry == lucide's <Info>),
-// size 16, top-aligned (alignItems flex-start + mt 2px == claudia items-start
-// + mt-0.5), instead of Chakra's <AlertIcon> solid glyph.
+// size 16, top-aligned. alignItems flex-start pins it to the top; mt centers
+// the 16px glyph on the first text line: (24px line-height - 16px) / 2 = 4px.
 export const AlertInfo = (props: AlertProps) => {
   const bg = useColorModeValue('#d0f0fd', 'rgba(11, 118, 183, 0.2)')
   const fg = useColorModeValue('#637381', '#cdced6')
@@ -29,7 +29,7 @@ export const AlertInfo = (props: AlertProps) => {
       alignItems="flex-start"
       {...props}
     >
-      <InfoIcon color={fg} boxSize="16px" mr={2} mt="2px" />
+      <InfoIcon color={fg} boxSize="16px" mr={2} mt="4px" />
       {props.children}
     </Alert>
   )

--- a/apps/builder/src/components/AlertInfo.tsx
+++ b/apps/builder/src/components/AlertInfo.tsx
@@ -1,28 +1,35 @@
 import { AlertProps, Alert, useColorModeValue } from '@chakra-ui/react'
 import { InfoIcon } from '@/components/icons'
 
-// Claudia cyan, set explicitly so this component never depends on the
-// status="info" -> colorScheme="blue" -> variant -> theme-override chain
-// (which can fall through to raw Chakra blue or the blue->primary/orange
-// alias in theme.ts if any hop doesn't apply).
-//
-// Matches the claudia-app info callout (create-tool-dialog "Criar nova
-// ferramenta"): rounded-xl bg-ca-cyan-light-3 text-ca-cyan-dark
-// dark:bg-ca-cyan-dark/20 dark:text-ca-cyan-light-2, with a lucide
-// <Info size={16}> (outline, transparent fill). We use Typebot's own
-// InfoIcon (Feather-derived, same geometry as lucide's Info) instead of
-// Chakra's <AlertIcon>, whose info glyph is a SOLID filled circle.
-//   light bg:    #d0f0fd            -> --color-ca-cyan-light-3
-//   light icon:  #0b76b7            -> --color-ca-cyan-dark
-//   dark bg:     rgba(11,118,183,.2) -> --color-ca-cyan-dark @ 20% (dark:/20)
-//   dark icon:   #77d1f3            -> --color-ca-cyan-light-2
+// Mirrors the claudia-app info callout (create-tool-dialog "Criar nova
+// ferramenta"). That callout is a <FormDescription> given a cyan className
+// (text-ca-cyan-dark dark:text-ca-cyan-light-2), BUT FormDescription's own
+// base style is `text-ca-primary-text! dark:text-ca-dark-7!` (!important) —
+// which wins over the cyan. So what actually renders is GRAY text, and the
+// <Info> icon (no explicit color) inherits that gray too. Only the cyan
+// background survives. We reproduce the rendered result, not the misleading
+// className:
+//   light bg:         #d0f0fd            -> --color-ca-cyan-light-3
+//   dark bg:          rgba(11,118,183,.2) -> --color-ca-cyan-dark @ 20% (dark:/20)
+//   light text+icon:  #637381            -> --color-ca-primary-text
+//   dark text+icon:   #cdced6            -> --color-ca-dark-7
+// Icon: Typebot's outline InfoIcon (Feather geometry == lucide's <Info>),
+// size 16, top-aligned (alignItems flex-start + mt 2px == claudia items-start
+// + mt-0.5), instead of Chakra's <AlertIcon> solid glyph.
 export const AlertInfo = (props: AlertProps) => {
   const bg = useColorModeValue('#d0f0fd', 'rgba(11, 118, 183, 0.2)')
-  const iconColor = useColorModeValue('#0b76b7', '#77d1f3')
+  const fg = useColorModeValue('#637381', '#cdced6')
 
   return (
-    <Alert status="info" rounded="xl" bg={bg} {...props}>
-      <InfoIcon color={iconColor} boxSize="16px" mr={2} mt="2px" />
+    <Alert
+      status="info"
+      rounded="xl"
+      bg={bg}
+      color={fg}
+      alignItems="flex-start"
+      {...props}
+    >
+      <InfoIcon color={fg} boxSize="16px" mr={2} mt="2px" />
       {props.children}
     </Alert>
   )

--- a/apps/builder/src/components/AlertInfo.tsx
+++ b/apps/builder/src/components/AlertInfo.tsx
@@ -1,8 +1,26 @@
-import { AlertProps, Alert, AlertIcon } from '@chakra-ui/react'
+import {
+  AlertProps,
+  Alert,
+  AlertIcon,
+  useColorModeValue,
+} from '@chakra-ui/react'
 
-export const AlertInfo = (props: AlertProps) => (
-  <Alert status="info" rounded="md" {...props}>
-    <AlertIcon />
-    {props.children}
-  </Alert>
-)
+// Claudia cyan, set explicitly so this component never depends on the
+// status="info" -> colorScheme="blue" -> variant -> theme-override chain
+// (which can fall through to raw Chakra blue or the blue->primary/orange
+// alias in theme.ts if any hop doesn't apply).
+//   light bg:    #d0f0fd -> --color-ca-cyan-light-3
+//   light icon:  #01a9db -> --color-ca-cyan
+//   dark bg:     rgba(1, 169, 219, 0.24) -> translucent --color-ca-cyan
+//   dark icon:   #77d1f3 -> --color-ca-cyan-light-2
+export const AlertInfo = (props: AlertProps) => {
+  const bg = useColorModeValue('#d0f0fd', 'rgba(1, 169, 219, 0.24)')
+  const iconColor = useColorModeValue('#01a9db', '#77d1f3')
+
+  return (
+    <Alert status="info" rounded="md" bg={bg} {...props}>
+      <AlertIcon color={iconColor} />
+      {props.children}
+    </Alert>
+  )
+}

--- a/apps/builder/src/features/blocks/integrations/webhook/components/RestApiCredentialsModal.tsx
+++ b/apps/builder/src/features/blocks/integrations/webhook/components/RestApiCredentialsModal.tsx
@@ -196,8 +196,14 @@ export const RestApiCredentialsModal = ({
     },
   })
 
-  const iconBg = useColorModeValue('orange.100', 'orange.900')
-  const iconColor = useColorModeValue('orange.500', 'orange.300')
+  // Matches the claudia-app modal header icon block (create-tool-dialog "Criar
+  // nova ferramenta"): rounded-[0.875rem] p-2, bg-ca-orange-light-5 (#fff0e9) /
+  // dark:bg-ca-orange-dark/20 (#e1580e @ 20%), icon text-ca-orange (#ff8638) /
+  // dark:text-ca-orange-light-2 (#f8b490). The Chakra orange.100/900 scale
+  // (peach / near-black) diverged hardest in dark mode, so set claudia's values
+  // explicitly rather than via the remapped orange scale.
+  const iconBg = useColorModeValue('#fff0e9', 'rgba(225, 88, 14, 0.2)')
+  const iconColor = useColorModeValue('#ff8638', '#f8b490')
 
   const isBaseUrlInvalid = baseUrl.trim() !== '' && !isSafeBaseUrl(baseUrl)
 
@@ -318,7 +324,7 @@ export const RestApiCredentialsModal = ({
             <Flex
               flexShrink={0}
               boxSize="40px"
-              borderRadius="lg"
+              borderRadius="xl"
               bg={iconBg}
               color={iconColor}
               align="center"

--- a/apps/builder/src/features/blocks/integrations/webhook/components/RestApiCredentialsModal.tsx
+++ b/apps/builder/src/features/blocks/integrations/webhook/components/RestApiCredentialsModal.tsx
@@ -463,7 +463,7 @@ export const RestApiCredentialsModal = ({
           >
             {isEditing && (
               <Button
-                variant="outline"
+                variant="solid"
                 colorScheme="red"
                 isLoading={isDeleting}
                 isDisabled={showLoader}

--- a/apps/builder/src/lib/theme.ts
+++ b/apps/builder/src/lib/theme.ts
@@ -95,6 +95,23 @@ export const colors = {
     800: '#4e3a00',
     900: '#1d1400',
   },
+  // Maps to Claudia's `--destructive` design token (shadCn.css). 500 is the
+  // light-mode `--destructive`, 400 is the dark-mode `--destructive-foreground`
+  // (brighter, used as the dark-mode base per the Button 'red' branch below).
+  // Chakra's `colorScheme="red"` reads these directly, so every existing
+  // destructive button retints with no call-site changes.
+  red: {
+    50: '#ffe0e2',
+    100: '#ffb8bb',
+    200: '#ff858a',
+    300: '#ff525a',
+    400: '#fb2c36',
+    500: '#e7000b',
+    600: '#cc000a',
+    700: '#990007',
+    800: '#6b0005',
+    900: '#3d0003',
+  },
 }
 
 const Modal = createMultiStyleConfigHelpers(
@@ -178,6 +195,20 @@ const Button = defineStyleConfig({
           },
           _active: {
             bg: colorMode === 'dark' ? 'orange.600' : 'orange.700',
+          },
+        }
+      }
+      if (colorScheme === 'red') {
+        // Claudia destructive color (see `red` in `colors` above). Same
+        // darken-on-hover/active pattern as 'blue'/'orange'.
+        return {
+          bg: colorMode === 'dark' ? 'red.400' : 'red.500',
+          color: 'white',
+          _hover: {
+            bg: colorMode === 'dark' ? 'red.500' : 'red.600',
+          },
+          _active: {
+            bg: colorMode === 'dark' ? 'red.600' : 'red.700',
           },
         }
       }

--- a/apps/builder/src/lib/theme.ts
+++ b/apps/builder/src/lib/theme.ts
@@ -229,14 +229,22 @@ const Alert = createMultiStyleConfigHelpers(
   variants: {
     // status="info" maps to colorScheme="blue" too, but info callouts stay
     // Claudia cyan rather than following the orange remap above.
+    // AlertInfo.tsx sets these same colors explicitly on itself (so it never
+    // depends on this guard), but raw <Alert status="info" /> usages
+    // elsewhere in the app still resolve through this variant, so it's kept
+    // as the shared fallback for those rather than removed.
     subtle: ({ colorScheme, colorMode }) => {
       if (colorScheme !== 'blue') return {}
       return {
         container: {
-          bg: colorMode === 'dark' ? 'rgba(11, 118, 183, 0.24)' : '#d0f0fd',
+          // dark: rgba(1, 169, 219, 0.24) -> translucent --color-ca-cyan
+          // light: #d0f0fd -> --color-ca-cyan-light-3
+          bg: colorMode === 'dark' ? 'rgba(1, 169, 219, 0.24)' : '#d0f0fd',
         },
         icon: {
-          color: colorMode === 'dark' ? '#63c7ee' : '#0b76b7',
+          // dark: #77d1f3 -> --color-ca-cyan-light-2
+          // light: #01a9db -> --color-ca-cyan
+          color: colorMode === 'dark' ? '#77d1f3' : '#01a9db',
         },
       }
     },

--- a/apps/builder/src/lib/theme.ts
+++ b/apps/builder/src/lib/theme.ts
@@ -34,6 +34,22 @@ const radii = {
   xl: '0.875rem', // 14px — --radius-xl
 }
 
+// Claudia brand primary (base #ff8638 / hover #e1580e). This is the honest,
+// named token; `blue` below is kept as a back-compat alias because Typebot's
+// upstream components hardcode colorScheme="blue" as the de-facto primary.
+const primary = {
+  50: '#fff0e9',
+  100: '#ffe0cf',
+  200: '#ffc7a3',
+  300: '#ffab74',
+  400: '#ff9451',
+  500: '#ff8638',
+  600: '#e1580e',
+  700: '#b8480b',
+  800: '#8a3608',
+  900: '#4f1f05',
+}
+
 export const colors = {
   gray: {
     50: '#fafafa',
@@ -48,20 +64,13 @@ export const colors = {
     850: '#1f1f23',
     900: '#18181b',
   },
-  // Remapped to Claudia's brand orange (base #ff8638 / hover #e1580e) — this
-  // is the palette Button/Switch resolve colorScheme="blue" through.
-  blue: {
-    50: '#fff0e9',
-    100: '#ffe0cf',
-    200: '#ffc7a3',
-    300: '#ffab74',
-    400: '#ff9451',
-    500: '#ff8638',
-    600: '#e1580e',
-    700: '#b8480b',
-    800: '#8a3608',
-    900: '#4f1f05',
-  },
+  primary,
+  brand: primary,
+  // Alias to `primary` — Typebot upstream hardcodes colorScheme="blue" and
+  // blue.NNN as the primary across ~82 builder files. Aliasing here keeps the
+  // override central and avoids a fork-wide rename that would conflict with
+  // every upstream merge. New code should prefer `primary`/`brand`.
+  blue: primary,
   orange: {
     50: '#fff1da',
     100: '#ffd7ae',

--- a/apps/builder/src/lib/theme.ts
+++ b/apps/builder/src/lib/theme.ts
@@ -237,14 +237,15 @@ const Alert = createMultiStyleConfigHelpers(
       if (colorScheme !== 'blue') return {}
       return {
         container: {
-          // dark: rgba(1, 169, 219, 0.24) -> translucent --color-ca-cyan
+          // Matches the claudia-app info callout (create-tool-dialog).
+          // dark: rgba(11,118,183,.2) -> --color-ca-cyan-dark @ 20% (dark:/20)
           // light: #d0f0fd -> --color-ca-cyan-light-3
-          bg: colorMode === 'dark' ? 'rgba(1, 169, 219, 0.24)' : '#d0f0fd',
+          bg: colorMode === 'dark' ? 'rgba(11, 118, 183, 0.2)' : '#d0f0fd',
         },
         icon: {
           // dark: #77d1f3 -> --color-ca-cyan-light-2
-          // light: #01a9db -> --color-ca-cyan
-          color: colorMode === 'dark' ? '#77d1f3' : '#01a9db',
+          // light: #0b76b7 -> --color-ca-cyan-dark
+          color: colorMode === 'dark' ? '#77d1f3' : '#0b76b7',
         },
       }
     },

--- a/apps/builder/src/lib/theme.ts
+++ b/apps/builder/src/lib/theme.ts
@@ -168,13 +168,16 @@ const Button = defineStyleConfig({
       }
       if (colorScheme === 'orange') {
         return {
-          bg: 'orange.500',
+          bg: colorMode === 'dark' ? 'orange.400' : 'orange.500',
           color: 'white',
+          // Darken on hover/active, matching the 'blue' (primary) branch above.
+          // Was 'orange.400' (lighter than base) — made hover look washed out
+          // instead of a pressed/darkened state (issue #165 follow-up).
           _hover: {
-            bg: 'orange.400',
+            bg: colorMode === 'dark' ? 'orange.500' : 'orange.600',
           },
           _active: {
-            bg: 'orange.600',
+            bg: colorMode === 'dark' ? 'orange.600' : 'orange.700',
           },
         }
       }

--- a/apps/builder/src/lib/theme.ts
+++ b/apps/builder/src/lib/theme.ts
@@ -237,15 +237,20 @@ const Alert = createMultiStyleConfigHelpers(
       if (colorScheme !== 'blue') return {}
       return {
         container: {
-          // Matches the claudia-app info callout (create-tool-dialog).
-          // dark: rgba(11,118,183,.2) -> --color-ca-cyan-dark @ 20% (dark:/20)
-          // light: #d0f0fd -> --color-ca-cyan-light-3
+          // Matches the claudia-app info callout (create-tool-dialog): cyan
+          // background, but GRAY text+icon (claudia's FormDescription base
+          // color `text-ca-primary-text!/dark:text-ca-dark-7!` overrides the
+          // cyan className), top-aligned. See AlertInfo.tsx for the full note.
+          // dark bg: rgba(11,118,183,.2) -> --color-ca-cyan-dark @ 20% (dark:/20)
+          // light bg: #d0f0fd -> --color-ca-cyan-light-3
           bg: colorMode === 'dark' ? 'rgba(11, 118, 183, 0.2)' : '#d0f0fd',
+          // dark: #cdced6 -> --color-ca-dark-7 / light: #637381 -> --color-ca-primary-text
+          color: colorMode === 'dark' ? '#cdced6' : '#637381',
+          alignItems: 'flex-start',
         },
         icon: {
-          // dark: #77d1f3 -> --color-ca-cyan-light-2
-          // light: #0b76b7 -> --color-ca-cyan-dark
-          color: colorMode === 'dark' ? '#77d1f3' : '#0b76b7',
+          // Inherits the gray text color (claudia's <Info> has no own color).
+          color: colorMode === 'dark' ? '#cdced6' : '#637381',
         },
       }
     },

--- a/apps/builder/src/lib/theme.ts
+++ b/apps/builder/src/lib/theme.ts
@@ -26,6 +26,14 @@ const fonts = {
   body: "Open Sans, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'",
 }
 
+// Aligned to Claudia's radius scale (--radius: 0.625rem base).
+const radii = {
+  sm: '0.375rem', // 6px — --radius-sm
+  md: '0.5rem', // 8px — --radius-md
+  lg: '0.625rem', // 10px — --radius (base)
+  xl: '0.875rem', // 14px — --radius-xl
+}
+
 export const colors = {
   gray: {
     50: '#fafafa',
@@ -40,17 +48,19 @@ export const colors = {
     850: '#1f1f23',
     900: '#18181b',
   },
+  // Remapped to Claudia's brand orange (base #ff8638 / hover #e1580e) — this
+  // is the palette Button/Switch resolve colorScheme="blue" through.
   blue: {
-    50: '#e0edff',
-    100: '#b0caff',
-    200: '#7ea6ff',
-    300: '#4b83ff',
-    400: '#1a5fff',
-    500: '#0042da',
-    600: '#0036b4',
-    700: '#002782',
-    800: '#001751',
-    900: '#1a202c',
+    50: '#fff0e9',
+    100: '#ffe0cf',
+    200: '#ffc7a3',
+    300: '#ffab74',
+    400: '#ff9451',
+    500: '#ff8638',
+    600: '#e1580e',
+    700: '#b8480b',
+    800: '#8a3608',
+    900: '#4f1f05',
   },
   orange: {
     50: '#fff1da',
@@ -174,11 +184,16 @@ const Alert = createMultiStyleConfigHelpers(
   alertAnatomy.keys
 ).defineMultiStyleConfig({
   variants: {
+    // status="info" maps to colorScheme="blue" too, but info callouts stay
+    // Claudia cyan rather than following the orange remap above.
     subtle: ({ colorScheme, colorMode }) => {
-      if (colorScheme !== 'blue' || colorMode === 'dark') return {}
+      if (colorScheme !== 'blue') return {}
       return {
         container: {
-          bg: 'blue.50',
+          bg: colorMode === 'dark' ? 'rgba(11, 118, 183, 0.24)' : '#d0f0fd',
+        },
+        icon: {
+          color: colorMode === 'dark' ? '#63c7ee' : '#0b76b7',
         },
       }
     },
@@ -253,6 +268,7 @@ const styles = {
 export const customTheme = extendTheme({
   colors,
   fonts,
+  radii,
   components,
   config,
   styles,


### PR DESCRIPTION
## Summary

Closes #165. Remaps the Typebot builder's primary accent from upstream blue to Claudia orange centrally, via a single `apps/builder/src/lib/theme.ts` `extendTheme` entry point, instead of a fork-wide `blue` → `primary` string rename across the ~82 upstream files that use `colorScheme="blue"`.

- Defines a named `primary` orange palette (base `#ff8638` / hover `#e1580e`) and aliases `blue: primary` + `brand: primary` in `colors`. Upstream hardcodes `colorScheme="blue"` as its de-facto primary color, so aliasing at the token level keeps the override central and avoids merge-conflict debt from touching every call site.
- Aligns the `radii` scale to Claudia.
- Keeps the Alert `subtle` info callout ("i" icon + background) in Claudia cyan (`#0b76b7` / bg `#d0f0fd`), not swept into the orange remap, with dark-mode variants.
- Theme is dual-mode (`colorMode: 'system'`); all component overrides branch on `colorMode`, so light and dark are both covered.
- Fixes a pre-existing bug in the `Button` `solid` variant: for `colorScheme="orange"` (used by the top "Publish" button and a few other CTAs), `_hover` was `orange.400` — lighter than the `orange.500` base — the opposite direction of the `blue`/primary branch, which correctly darkens on hover/active. Hover/active now darken (`600`/`700` light, `500`/`600` dark), matching the rest of the solid CTAs. No size/padding touched, only `bg`.

## Hardcoded-color sweep (apps/builder/src)

Audited for colors escaping the central theme: literal hex blues, `colorScheme="blue"` outside the theme's reach, and inline `color="blue.xxx"` that bypasses the alias.

**Confirmed covered by the central theme (no fix needed):**
- "Test the request" button (`features/blocks/integrations/webhook/components/HttpRequestAdvancedConfigForm.tsx`) — `colorScheme="blue"` on a `Button`, resolved through the `Button` solid-variant override + `colors.blue` alias → renders orange.
- "Advanced configuration" toggle (same file) — `Switch` via `SwitchWithLabel`, no explicit `colorScheme` (Chakra default is `blue`), resolved through the `Switch` track override + alias → renders orange.
- "Connect Spreadsheets" modal info callout (`features/blocks/integrations/googleSheets/components/GoogleSheetsConnectModal.tsx`) — uses the shared `AlertInfo` (`status="info"`), resolved through the `Alert` `subtle` override → renders Claudia cyan, not blue and not orange.

**Reviewed and intentionally left as-is** (literal hex blues that exist, but represent product/user content, not builder chrome, so they shouldn't follow the admin-UI remap):
- `components/TypebotLogo.tsx` — the app's own product logo mark.
- `components/ColorPicker.tsx`, `components/DefaultAvatar.tsx` — default preset swatch / default bot avatar color offered to end users configuring *their own* bot's theme; changing this would alter product defaults for user-facing bots, out of scope for admin-chrome theming.
- `features/publish/components/embeds/EmbedTypeMenu/illustrations/*Illustration.tsx` — decorative mockup illustrations of embed types (Popup/Bubble/Standard) in the Publish menu; blue here is illustrative, not a brand/interactive accent.

**Flagged for awareness, not fixed in this PR** (out of scope, needs a product decision): aliasing `colors.blue` at the color-token level (not just `colorScheme` prop resolution) means direct `blue.NNN` references also flip to orange — e.g. flow-canvas bubble-block icons (Text/Image/Video/Audio/Embed), flow connector/endpoint colors, node selection highlighting, results-table selection color, and the WordPress embed instructions illustrations. These use `blue.500`/`blue.300` etc. as a semantic "blue" hue for block-type/category color-coding in the canvas (distinct from bubbles=blue vs inputs=orange vs logic=purple), not as "the brand accent." With the alias in place, bubbles and inputs now both render orange, which may blur that visual distinction. Scoping the remap to interactive-accent usage only (vs. the raw color scale) would need a larger pass and a call on whether canvas block-type colors should also move to Claudia's palette or stay a separate, non-branded scale. Flagging for `@techlead` to decide the direction before broadening this.

## Validation

Confirmed at the code level (traced each component override to see how it resolves for the concrete cases). Local stack (`typebot-builder`, `claudia-app`, `cloudchat-rails`) is up, and the standalone builder serves pages fine, but I was not able to get authenticated in-app screenshots in this sandbox: sign-in emails aren't landing in the local MailHog instance despite the app reporting success, and the NextAuth session cookie is `secure`-only (requires HTTPS), which the plain-HTTP local builder can't satisfy. Both are pre-existing local-infra characteristics, unrelated to this theme change. I did not fake screenshots. Requesting a manual pass (or a `uat`-agent run with real auth/HTTPS) against staging to confirm visually: Test-the-request button, Advanced-configuration toggle, Publish button hover, and the Google Sheets connect callout.

## Test plan

- [ ] Manual/staging visual check: "Test the request" button renders orange
- [ ] Manual/staging visual check: "Advanced configuration" toggle renders orange
- [ ] Manual/staging visual check: "Publish" button hover darkens (not lightens), same size as before
- [ ] Manual/staging visual check: "Connect Spreadsheets" info callout renders Claudia cyan
- [ ] Verify inside CloudChat MF host embed, not just standalone
- [ ] `@sec` + `@rev` + bot adjudication before merge (merge gated, not done by this PR)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

As mudanças parecem seguras para merge.

- Nenhum problema bloqueante distinto foi encontrado nas alterações mais recentes.
- Os novos imports e estilos permanecem compatíveis com os consumidores atuais.
- O comportamento amplo do alias de azul continua sendo uma decisão explícita do produto.

<sub>Reviews (10): Last reviewed commit: ["fix(builder): match claudia modal header..."](https://github.com/cloudhumans/typebot.io/commit/42120b4c46c9cc211d2d86560e17ac3fb73e57a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46041964)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/cloud-humans/github/cloudhumans/typebot.io/-/custom-context?memory=6970a077-7c35-41d4-a69f-56539d16fd6c))

<!-- /greptile_comment -->