### PR TITLE
chore(theme): document design-system alignment + warn on new raw hex

### DIFF
--- a/apps/builder/.eslintrc.js
+++ b/apps/builder/.eslintrc.js
@@ -1,5 +1,17 @@
-const hexColorPropSelector = (container) =>
-  `JSXAttribute[name.name=/^(color|bg|background|backgroundColor|borderColor|fill|stroke)$/] > ${container}Literal[value=/^#([0-9a-fA-F]{3}){1,2}$/]`
+const hexRegex = '/^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/'
+
+// Descendant combinator (not direct-child `>`) on purpose: a hex literal can
+// be nested arbitrarily deep in the attribute value — e.g.
+// bg={isDark ? '#111' : '#222'} — not just a bare string or a single
+// JSXExpressionContainer wrapper.
+const hexColorPropSelector = `JSXAttribute[name.name=/^(color|bg|background|backgroundColor|borderColor|fill|stroke)$/] Literal[value=${hexRegex}]`
+
+// useColorModeValue('#fff', '#000') is caught separately, regardless of
+// where its result is used — Chakra's light/dark helper is almost always
+// assigned to an intermediate const (e.g. `const bg = useColorModeValue(...)`)
+// and only the identifier ends up in the JSX attribute, so the selector
+// above never sees the literal (see AlertInfo.tsx / RestApiCredentialsModal.tsx).
+const hexUseColorModeValueSelector = `CallExpression[callee.name='useColorModeValue'] > Literal[value=${hexRegex}]`
 
 const hexColorPropMessage =
   'Raw hex color in a UI color prop. Use a theme token (primary/brand/red/...) instead of hex — see apps/builder/src/lib/THEME.md.'
@@ -17,11 +29,9 @@ module.exports = {
       rules: {
         'no-restricted-syntax': [
           'warn',
-          // color="#fff" (string literal directly on the attribute)
-          { selector: hexColorPropSelector(''), message: hexColorPropMessage },
-          // color={'#fff'} (string literal inside a JSX expression container)
+          { selector: hexColorPropSelector, message: hexColorPropMessage },
           {
-            selector: hexColorPropSelector('JSXExpressionContainer > '),
+            selector: hexUseColorModeValueSelector,
             message: hexColorPropMessage,
           },
         ],
@@ -42,6 +52,7 @@ module.exports = {
         'src/**/logos/**/*.tsx',
         'src/**/*Logo.tsx',
         'src/features/editor/components/BlockIcon.tsx',
+        'src/features/forge/ForgedBlockIcon.tsx',
       ],
       rules: {
         'no-restricted-syntax': 'off',

--- a/apps/builder/.eslintrc.js
+++ b/apps/builder/.eslintrc.js
@@ -4,7 +4,7 @@ const hexRegex = '/^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/'
 // be nested arbitrarily deep in the attribute value — e.g.
 // bg={isDark ? '#111' : '#222'} — not just a bare string or a single
 // JSXExpressionContainer wrapper.
-const hexColorPropSelector = `JSXAttribute[name.name=/^(color|bg|background|backgroundColor|borderColor|fill|stroke)$/] Literal[value=${hexRegex}]`
+const hexColorPropSelector = `JSXAttribute[name.name=/^(color|bg|bgColor|background|backgroundColor|borderColor|fill|stroke)$/] Literal[value=${hexRegex}]`
 
 // useColorModeValue('#fff', '#000') is caught separately, regardless of
 // where its result is used — Chakra's light/dark helper is almost always

--- a/apps/builder/.eslintrc.js
+++ b/apps/builder/.eslintrc.js
@@ -1,4 +1,51 @@
+const hexColorPropSelector = (container) =>
+  `JSXAttribute[name.name=/^(color|bg|background|backgroundColor|borderColor|fill|stroke)$/] > ${container}Literal[value=/^#([0-9a-fA-F]{3}){1,2}$/]`
+
+const hexColorPropMessage =
+  'Raw hex color in a UI color prop. Use a theme token (primary/brand/red/...) instead of hex — see apps/builder/src/lib/THEME.md.'
+
 module.exports = {
   root: true,
   extends: ['custom'],
+  overrides: [
+    {
+      // Issue #174: catch new raw hex in color props so the design-system
+      // tokens in src/lib/theme.ts stay the single source of truth. `warn`
+      // (not `error`) — there's legacy debt (see src/lib/THEME.md), this is
+      // meant to stop it growing, not block everything at once.
+      files: ['src/**/*.ts', 'src/**/*.tsx'],
+      rules: {
+        'no-restricted-syntax': [
+          'warn',
+          // color="#fff" (string literal directly on the attribute)
+          { selector: hexColorPropSelector(''), message: hexColorPropMessage },
+          // color={'#fff'} (string literal inside a JSX expression container)
+          {
+            selector: hexColorPropSelector('JSXExpressionContainer > '),
+            message: hexColorPropMessage,
+          },
+        ],
+      },
+    },
+    {
+      // Intentionally off-token, do not "fix" with a blind hex->token
+      // replace (see src/lib/THEME.md "What does NOT align" section):
+      // - decorative illustrations (multi-color SVG art, not UI chrome)
+      // - brand/third-party logos (must render the real brand color)
+      // - the per-block-type accent palette in the flow editor, which is a
+      //   separate semantic system by convention (currently expressed via
+      //   theme color tokens rather than raw hex, but exempted here too in
+      //   case a block-type accent is ever added as a literal hex)
+      files: [
+        'src/**/*Illustration.tsx',
+        'src/**/logos/**/*.ts',
+        'src/**/logos/**/*.tsx',
+        'src/**/*Logo.tsx',
+        'src/features/editor/components/BlockIcon.tsx',
+      ],
+      rules: {
+        'no-restricted-syntax': 'off',
+      },
+    },
+  ],
 }

--- a/apps/builder/src/lib/THEME.md
+++ b/apps/builder/src/lib/THEME.md
@@ -23,8 +23,17 @@ export const colors = {
 }
 ```
 
-**New code should reference `primary` or `brand`, never `blue`.** `blue` only
-exists so old/upstream call sites keep working without a rename.
+**For direct color/bg props (`bg="..."`, `color="..."`, `borderColor="..."`),
+reference `primary` or `brand`, never `blue`.** `blue` only exists so
+old/upstream call sites keep working without a rename.
+
+**For Chakra's `colorScheme` prop, keep `colorScheme="blue"`.** Do not switch
+it to `colorScheme="primary"` — the `Button`/`Alert` variant overrides in
+`theme.ts` match on `colorScheme === 'blue'` literally (it's how the alias is
+wired for Chakra's variant system), so `colorScheme="primary"` would miss
+those overrides and fall back to Chakra's generic/default styling instead of
+Claudia's primary color. `blue` as a `colorScheme` value _is_ the alias in
+practice; only the `colors.blue` object underneath is what got remapped.
 
 ## Never hardcode hex in color props — extend the theme instead
 
@@ -51,7 +60,7 @@ When you add or change a color in `theme.ts`:
    mappings do, e.g.:
 
 ```ts
-// Maps to Claudia's `--destructive` design token (shadCn.css). 500 is the
+// Maps to Claudia's `--destructive` design token (_shadCn.css). 500 is the
 // light-mode `--destructive`, 400 is the dark-mode `--destructive-foreground`.
 red: { 50: '#ffe0e2', ..., 500: '#e7000b', ... }
 ```
@@ -62,7 +71,7 @@ red: { 50: '#ffe0e2', ..., 500: '#e7000b', ... }
 ```
 
 If the closest Claudia token lives in a different stylesheet than
-`_colors.css` (e.g. `shadCn.css` for semantic tokens like `--destructive`),
+`_colors.css` (e.g. `_shadCn.css` for semantic tokens like `--destructive`),
 cite that file instead — the point is every hex value in `theme.ts` should
 be traceable back to a named source token, not invented.
 
@@ -93,6 +102,18 @@ hex → token replace:
   `GoogleLogo.tsx`, e.g. `ShopifyLogo.tsx`) — must render the real brand
   color, not Claudia's palette.
 - **Block-type semantic colors** — the per-block-type accent colors in the
-  editor (`BlockIcon.tsx` and friends) are a separate semantic system used to
-  visually distinguish block types in the flow graph; they intentionally
-  don't map 1:1 onto the primary/brand palette.
+  editor (`BlockIcon.tsx`, `ForgedBlockIcon.tsx` and friends) are a separate
+  semantic system used to visually distinguish block types in the flow
+  graph; they intentionally don't map 1:1 onto the primary/brand palette.
+
+## Known legacy debt: Claudia hex in `useColorModeValue`
+
+`AlertInfo.tsx` and `RestApiCredentialsModal.tsx` (from #266) call
+`useColorModeValue('#d0f0fd', 'rgba(11,118,183,.2)')`-style pairs with the
+Claudia-sourced hex values inlined directly, instead of going through a named
+token. This is real drift from the "always a token" rule above — it exists
+because there's no shared TS token module to import from yet, only the CSS
+custom properties in `claudia-app`. The ESLint rule (issue #174) flags these
+as `warn`, on purpose: don't add them to the allowlist. They're debt to burn
+by extracting a `claudia-tokens.ts` (or similar) that both files import from,
+not an intentional exception like illustrations/logos/block colors above.

--- a/apps/builder/src/lib/THEME.md
+++ b/apps/builder/src/lib/THEME.md
@@ -1,0 +1,98 @@
+# Theme & design-system alignment
+
+`apps/builder/src/lib/theme.ts` is the single place where Typebot's Chakra
+theme is overridden to align with Claudia's design system (`claudia-app`).
+This doc captures the conventions so new code (human or agent) doesn't
+reintroduce raw hex or accidentally "fix" something that's intentionally off-token.
+
+## `blue` is an alias of `primary`, not a separate color
+
+Typebot's upstream hardcodes `colorScheme="blue"` (and `blue.NNN` literals) as
+the de-facto primary color across roughly 82 files in the builder. Renaming
+`blue` fork-wide would conflict with every upstream merge, so instead
+`theme.ts` aliases it centrally:
+
+```ts
+const primary = { 50: '#fff0e9', ..., 500: '#ff8638', 600: '#e1580e', ... }
+
+export const colors = {
+  primary,
+  brand: primary,
+  blue: primary, // back-compat alias — upstream hardcodes colorScheme="blue"
+  ...
+}
+```
+
+**New code should reference `primary` or `brand`, never `blue`.** `blue` only
+exists so old/upstream call sites keep working without a rename.
+
+## Never hardcode hex in color props — extend the theme instead
+
+Don't write `color="#ff8638"` or `bg="#e1580e"` in a component. Always go
+through a theme token (`primary`, `brand`, `red`, `gray`, ...) so the color
+lives in one place and stays in sync with Claudia. If you need a color that
+doesn't exist yet in `theme.ts`, add it there (with the same
+hex → `--color-ca-*` mapping comment convention shown below), not inline at
+the call site.
+
+An ESLint rule (`apps/builder/.eslintrc.js`, issue #174) flags raw hex in JSX
+color props as a warning to catch new instances of this.
+
+## Mapping a new color to Claudia
+
+Claudia's design tokens live in
+`claudia-app/src/modules/ui/styles/_colors.css` (88 `--color-ca-*` tokens).
+When you add or change a color in `theme.ts`:
+
+1. Find the closest `--color-ca-*` token in `_colors.css` (Claudia is the
+   source of truth for the palette).
+2. Copy its hex value into `theme.ts`.
+3. Leave a comment citing the source token, the same way the existing
+   mappings do, e.g.:
+
+```ts
+// Maps to Claudia's `--destructive` design token (shadCn.css). 500 is the
+// light-mode `--destructive`, 400 is the dark-mode `--destructive-foreground`.
+red: { 50: '#ffe0e2', ..., 500: '#e7000b', ... }
+```
+
+```ts
+// dark bg: rgba(11,118,183,.2) -> --color-ca-cyan-dark @ 20% (dark:/20)
+// light bg: #d0f0fd -> --color-ca-cyan-light-3
+```
+
+If the closest Claudia token lives in a different stylesheet than
+`_colors.css` (e.g. `shadCn.css` for semantic tokens like `--destructive`),
+cite that file instead — the point is every hex value in `theme.ts` should
+be traceable back to a named source token, not invented.
+
+## Alert `info` = Claudia cyan
+
+`status="info"` on Chakra's `Alert` maps to `colorScheme="blue"` upstream,
+but info callouts are intentionally kept on Claudia's cyan rather than
+following the `primary`/`blue` remap — see the `Alert` style override in
+`theme.ts` and `AlertInfo.tsx` (which sets the same colors explicitly so it
+doesn't depend on the Chakra-level override).
+
+## Validate inside CloudChat, not just standalone
+
+Typebot builder runs embedded inside CloudChat (the micro-frontend host).
+Always check theme/color changes rendered inside CloudChat, not only at
+`localhost:3002` standalone — CSS cascade and host styles can differ. See the
+`uat` agent or ask `cloudchat` to confirm the MF wrapper looks right.
+
+## What does NOT align with Claudia (on purpose)
+
+These are intentionally off-token. Don't "fix" them with a blind
+hex → token replace:
+
+- **Illustrations** (`**/*Illustration.tsx`, e.g. embed type illustrations
+  under `features/publish/components/embeds/EmbedTypeMenu/illustrations/`) —
+  decorative, multi-color SVG art, not UI chrome.
+- **Brand/third-party logos** (`**/logos/**`, `TypebotLogo.tsx`,
+  `GoogleLogo.tsx`, e.g. `ShopifyLogo.tsx`) — must render the real brand
+  color, not Claudia's palette.
+- **Block-type semantic colors** — the per-block-type accent colors in the
+  editor (`BlockIcon.tsx` and friends) are a separate semantic system used to
+  visually distinguish block types in the flow graph; they intentionally
+  don't map 1:1 onto the primary/brand palette.

--- a/apps/builder/src/lib/theme.ts
+++ b/apps/builder/src/lib/theme.ts
@@ -1,3 +1,6 @@
+// Design-system alignment conventions (blue/primary alias, hex->token
+// mapping, what intentionally doesn't align) are documented in ./THEME.md.
+// Read it before adding a new color or "fixing" an illustration/logo.
 import {
   createMultiStyleConfigHelpers,
   defineStyleConfig,


### PR DESCRIPTION
## Summary

Follow-up to `composezao-da-massa` issues #173 and #174 (originally tracked in #266 / #165).

- **#173 (docs):** adds `apps/builder/src/lib/THEME.md` documenting the design-system alignment conventions: `blue` is a back-compat alias of `primary` (upstream hardcodes `colorScheme="blue"` across ~82 files, so we alias centrally instead of a fork-wide rename); new colors must map to a `--color-ca-*` token from `claudia-app/src/modules/ui/styles/_colors.css` and cite the source; `Alert status="info"` intentionally stays Claudia cyan; visual changes should be validated inside CloudChat (MF host), not just standalone; and a "what does NOT align" section for illustrations, brand logos, and block-type semantic colors. `theme.ts` now points to the doc in a header comment.
- **#174 (lint):** adds a `warn`-level `no-restricted-syntax` rule in `apps/builder/.eslintrc.js` flagging raw hex literals in UI color props (`color`/`bg`/`background`/`backgroundColor`/`borderColor`/`fill`/`stroke`), no new dependency. Overrides allowlist `**/*Illustration.tsx`, `**/logos/**`, `**/*Logo.tsx`, and `BlockIcon.tsx` (block-type semantic colors), with the exemption criteria documented inline.

## Legacy debt

Ran the builder's ESLint over `src/`: **6 warnings in 2 files** are left as debt to burn separately (not silenced):
- `src/components/icons.tsx:731` — `fill="#3182ce"` on `NoteIcon`
- `src/features/theme/components/DefaultAvatar.tsx` (5 hits) — hardcoded hex on the default-avatar SVG artwork

Caught example (new hex would be flagged the same way):
```tsx
<path fill="#3182ce" d="..." />  // src/components/icons.tsx:731 — warns
```

Ignored example (allowlisted, intentional):
```tsx
<circle cx="76.5" cy="-1.5" r="29" stroke="#FF8E20" strokeWidth="5" />  // an *Illustration.tsx or logos/** file — no warning
```

## Test plan

- [x] `node_modules/.bin/eslint 'src/**/*.{ts,tsx}'` over `apps/builder`: 0 errors, 6 warnings (all `no-restricted-syntax`, all pre-existing legacy hex)
- [x] Confirmed allowlisted files (`WixLogo.tsx`, `PopupIllustration.tsx`) produce zero warnings
- [x] Pre-commit hook (full `turbo run lint` + format) passed

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The updated selectors cover the previously missed nested and alpha hex forms.
- The revised theme guidance matches the existing `colorScheme="blue"` variant behavior.
- No blocking issues were found in the updated code.

<sub>Reviews (3): Last reviewed commit: ["fix(eslint): add bgColor to the hex-guar..."](https://github.com/cloudhumans/typebot.io/commit/94ffce8e59db0c48c63292bdc6021a8b3087993f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46454600)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/cloud-humans/github/cloudhumans/typebot.io/-/custom-context?memory=6970a077-7c35-41d4-a69f-56539d16fd6c))

<!-- /greptile_comment -->