### PR TITLE
fix(bot-engine): builder preview of a TOOL flow collects variables again

### DIFF
--- a/packages/bot-engine/startSession.ts
+++ b/packages/bot-engine/startSession.ts
@@ -112,7 +112,12 @@ export const startSession = async ({
     typebot,
     startVariables,
     workspaceName,
-    typebotHistoryId
+    typebotHistoryId,
+    // The headless TOOL contract (never pause, fail loudly on a missing required
+    // param) assumes an agent on the other end. The builder preview runs the same
+    // flow with a human in front of it, so it keeps the interactive Declare
+    // Variables prompt instead.
+    typebot.settings?.general?.type === 'TOOL' && startParams.type !== 'preview'
   )
 
   const initialState: SessionState = {
@@ -520,8 +525,9 @@ const removeLiteBadgeCss = (code: string) => {
 const convertStartTypebotToTypebotInSession = (
   typebot: StartTypebot,
   startVariables: Variable[],
-  workspaceName?: string,
-  typebotHistoryId?: string
+  workspaceName: string | undefined,
+  typebotHistoryId: string | undefined,
+  isToolWorkflow: boolean
 ): TypebotInSession =>
   typebot.version === '6'
     ? {
@@ -536,7 +542,7 @@ const convertStartTypebotToTypebotInSession = (
         variables: startVariables,
         events: typebot.events,
         typebotId: typebot.id,
-        isToolWorkflow: typebot.settings?.general?.type === 'TOOL',
+        isToolWorkflow,
       }
     : {
         version: typebot.version,
@@ -550,7 +556,7 @@ const convertStartTypebotToTypebotInSession = (
         variables: startVariables,
         events: typebot.events,
         typebotId: typebot.id,
-        isToolWorkflow: typebot.settings?.general?.type === 'TOOL',
+        isToolWorkflow,
       }
 
 const extractVariableIdsUsedForTranscript = (


### PR DESCRIPTION
## Problema

Testar um fluxo do tipo TOOL pelo botão **Test** do builder morre com 500:

```json
{"status":500,"body":{"message":"Missing required variable \"expression\" for TOOL workflow",
 "code":"INTERNAL_SERVER_ERROR","data":{"path":"startChatPreview"}}}
```

Qualquer fluxo TOOL com variável obrigatória é intestável pelo preview — e `required` tem `.default(true)` no schema, então até variável antiga sem o campo explícito conta como obrigatória.

## Causa

O contrato headless de TOOL introduzido no #219 (nunca pausar; falhar alto quando falta um parâmetro obrigatório) foi condicionado a `settings.general.type === 'TOOL'` — uma propriedade **do fluxo**, não **de quem chamou**.

O raciocínio "TOOL = headless = não tem humano" vale para o agente chamando via MCP, mas o preview do builder roda o mesmo fluxo com um humano na frente e **não tem como fornecer os argumentos**: `WebPreview.tsx` não passa `prefilledVariables` e não existe UI para informá-los. Resultado: o preview sempre bate no `throw` do primeiro bloco Declare Variables.

Antes do #219 (versão do #148) o preview coletava os valores normalmente, mostrando a `description` como balão e um input de texto.

## Fix

O gate passa a considerar a origem da chamada:

```ts
typebot.settings?.general?.type === 'TOOL' && startParams.type !== 'preview'
```

O `isToolWorkflow` já computado é passado para `convertStartTypebotToTypebotInSession`, em vez de derivado duas vezes (branches v5/v6).

**O caminho do agente não é afetado nem em teoria:** `executeWorkflow` (mcp-tools) chama `startChat`, que é hardcoded `type: 'live'` (`apiHandlers/startChat.ts:70`). Só o preview muda de ramo.

## Validação

Stack local, fluxo TOOL com uma variável obrigatória e uma opcional:

| Caminho | Antes | Depois |
|---|---|---|
| `POST /v1/typebots/{id}/preview/startChat` | 500 `Missing required variable` | **200** — balão com a descrição + text input para a variável obrigatória |
| `POST /v1/typebots/{publicId}/startChat` (live, usado pelo MCP) | throw | **throw** idêntico: `Missing required variable "variavelObrigatoria" for TOOL workflow` |

`vitest run packages/bot-engine`: 75 testes, todos verdes.

## Nota sobre testes

Não adicionei teste unitário novo. A semântica dos dois modos já está coberta em `executeDeclareVariables.test.ts` (casos `isToolWorkflow` true/false); o que mudou aqui é a *derivação* da flag dentro de `startSession`, que não tem harness — cobri-la exigiria mockar prisma, `findTypebot` e `startBotFlow`. Optei pela validação HTTP nos dois caminhos acima. Se preferirem proteção contra remoção acidental do gate, dá para extrair a derivação numa função pura e testá-la isoladamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

O PR parece seguro para merge, pois limita a mudança ao preview interativo e preserva o contrato headless das execuções live.

Os chamadores atuais usam o modo preview somente na interface interativa do builder, enquanto MCP e WhatsApp continuam iniciando sessões live com o comportamento TOOL de falha imediata.

<sub>Reviews (1): Last reviewed commit: ["fix(bot-engine): builder preview of a TO..."](https://github.com/cloudhumans/typebot.io/commit/517fcbea8145c300e469ae66196f677d03cfe195) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46706474)</sub>

**Context used:**

- Knowledge Base — [Bot Engine Runtime](https://app.greptile.com/cloud-humans/-/custom-context/knowledge-base/cloudhumans/typebot.io/-/docs/bot-engine-runtime.md)

<!-- /greptile_comment -->