### PR TITLE
✨ feat: campo "Termo de Pesquisa" no bloco Answer Ticket (par do claudia#1533, AB#8030)

### DIFF
--- a/packages/forge/blocks/claudia/actions/answer_ticket.ts
+++ b/packages/forge/blocks/claudia/actions/answer_ticket.ts
@@ -8,6 +8,7 @@ export const answerTicket = createAction({
       const log = createClaudiaResponseLog({
         action: 'ANSWER_TICKET',
         topic: options.topic,
+        searchTerm: options.searchTerm,
       })
       logs.add(log)
     },
@@ -18,5 +19,12 @@ export const answerTicket = createAction({
       placeholder: 'e.g. PAYMENT',
       accordion: 'Advanced settings',
     }),
+    searchTerm: option
+      .enum(['lastUserMessages', 'firstUserMessage', 'userMessages'])
+      .layout({
+        label: 'Termo de Pesquisa',
+        accordion: 'Advanced settings',
+        defaultValue: 'lastUserMessages',
+      }),
   }),
 })

--- a/packages/forge/blocks/claudia/actions/answer_ticket.ts
+++ b/packages/forge/blocks/claudia/actions/answer_ticket.ts
@@ -22,7 +22,7 @@ export const answerTicket = createAction({
     searchTerm: option
       .enum(['lastUserMessages', 'firstUserMessage', 'userMessages'])
       .layout({
-        label: 'Termo de Pesquisa',
+        label: 'Search Term',
         accordion: 'Advanced settings',
         defaultValue: 'lastUserMessages',
       }),

--- a/packages/forge/blocks/claudia/helpers/createClaudiaResponseLog.ts
+++ b/packages/forge/blocks/claudia/helpers/createClaudiaResponseLog.ts
@@ -10,6 +10,7 @@ type ClaudiaAction =
 type ClaudiaResponse = {
   action: ClaudiaAction
   topic?: string
+  searchTerm?: string
 }
 
 type TypebotLog = Extract<


### PR DESCRIPTION
## O que
Adiciona um seletor **"Termo de Pesquisa"** em *Advanced settings* do bloco **Answer Ticket [N1]**, pra escolher qual mensagem do cliente a ClaudIA usa como input/pergunta no handback do `ANSWER_TICKET`: `lastUserMessages` (default), `firstUserMessage` ou `userMessages`.

## Por que
Hoje o `ANSWER_TICKET` faz a ClaudIA sempre responder à última interação do cliente. Quando o fluxo faz perguntas antes do handback, a IA responde à última fala (ex.: "sim", "pedido 123") e perde o problema original. Este campo deixa o operador escolher qual mensagem direciona a resposta. Demanda de cliente: Agilize (interessado) e Shopee.

## Como
- `answer_ticket.ts`: novo `option.enum` `searchTerm` no accordion "Advanced settings"; passado no `createClaudiaResponseLog`.
- `createClaudiaResponseLog.ts`: `searchTerm?` no tipo `ClaudiaResponse` (viaja no log "Claudia Response", ao lado do `topic`).

## Par / dependência
- Lado Claudia (consome o `searchTerm`): **cloudhumans/claudia#1533**.
- **Ordem de deploy:** Claudia primeiro, depois este.
- **Retrocompatível:** sem escolha → `lastUserMessages` (comportamento atual). Fluxos existentes não mudam.

AB#8030

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

O PR parece seguro para merge, pois nenhuma falha bloqueante elegível para esta revisão de acompanhamento permanece.

Nenhuma falha bloqueante permanece.

<sub>Reviews (2): Last reviewed commit: ["🌐 chore: label &quot;Search Term&quot; em inglês ..."](https://github.com/cloudhumans/typebot.io/commit/5807d7918bb07aa6f87402fa78f3a6386887129e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46810143)</sub>

<!-- /greptile_comment -->