### PR TITLE
✨ feat: campo Tag nos blocos ClaudIA

### DIFF
--- a/packages/forge/blocks/claudia/actions/answer_ticket.ts
+++ b/packages/forge/blocks/claudia/actions/answer_ticket.ts
@@ -32,7 +32,7 @@ export const answerTicket = createAction({
       placeholder: 'e.g. caso_proativo_mat',
       accordion: 'Advanced settings',
       moreInfoTooltip:
-        'Pins the ClaudIA conversation tag. Matched by exact string, so a value that is not configured for the project is ignored silently. Accepts {{variables}}.',
+        'Pins the ClaudIA conversation tag. On most channels it is written to the helpdesk as-is, so spelling matters — a typo creates a new tag rather than being ignored. Cannot contain commas. Accepts {{variables}}.',
     }),
   }),
 })

--- a/packages/forge/blocks/claudia/actions/answer_ticket.ts
+++ b/packages/forge/blocks/claudia/actions/answer_ticket.ts
@@ -9,6 +9,7 @@ export const answerTicket = createAction({
         action: 'ANSWER_TICKET',
         topic: options.topic,
         searchTerm: options.searchTerm,
+        tag: options.tag,
       })
       logs.add(log)
     },
@@ -26,5 +27,10 @@ export const answerTicket = createAction({
         accordion: 'Advanced settings',
         defaultValue: 'lastUserMessages',
       }),
+    tag: option.string.layout({
+      label: 'Tag',
+      placeholder: 'e.g. caso_proativo_mat',
+      accordion: 'Advanced settings',
+    }),
   }),
 })

--- a/packages/forge/blocks/claudia/actions/answer_ticket.ts
+++ b/packages/forge/blocks/claudia/actions/answer_ticket.ts
@@ -31,6 +31,8 @@ export const answerTicket = createAction({
       label: 'Tag',
       placeholder: 'e.g. caso_proativo_mat',
       accordion: 'Advanced settings',
+      moreInfoTooltip:
+        'Pins the ClaudIA conversation tag. Matched by exact string, so a value that is not configured for the project is ignored silently. Accepts {{variables}}.',
     }),
   }),
 })

--- a/packages/forge/blocks/claudia/actions/close-ticket.ts
+++ b/packages/forge/blocks/claudia/actions/close-ticket.ts
@@ -1,14 +1,22 @@
-import { createAction } from '@typebot.io/forge'
+import { createAction, option } from '@typebot.io/forge'
 import { createClaudiaResponseLog } from '../helpers/createClaudiaResponseLog'
 
 export const closeTicket = createAction({
   name: 'Close Ticket [N1]',
   run: {
-    server: ({ logs }) => {
+    server: ({ logs, options }) => {
       const log = createClaudiaResponseLog({
         action: 'CLOSE_TICKET',
+        tag: options.tag,
       })
       logs.add(log)
     },
   },
+  options: option.object({
+    tag: option.string.layout({
+      label: 'Tag',
+      placeholder: 'e.g. caso_proativo_mat',
+      accordion: 'Advanced settings',
+    }),
+  }),
 })

--- a/packages/forge/blocks/claudia/actions/close-ticket.ts
+++ b/packages/forge/blocks/claudia/actions/close-ticket.ts
@@ -18,7 +18,7 @@ export const closeTicket = createAction({
       placeholder: 'e.g. caso_proativo_mat',
       accordion: 'Advanced settings',
       moreInfoTooltip:
-        'Pins the ClaudIA conversation tag. Matched by exact string, so a value that is not configured for the project is ignored silently. Accepts {{variables}}.',
+        'Pins the ClaudIA conversation tag. On most channels it is written to the helpdesk as-is, so spelling matters — a typo creates a new tag rather than being ignored. Cannot contain commas. Accepts {{variables}}.',
     }),
   }),
 })

--- a/packages/forge/blocks/claudia/actions/close-ticket.ts
+++ b/packages/forge/blocks/claudia/actions/close-ticket.ts
@@ -17,6 +17,8 @@ export const closeTicket = createAction({
       label: 'Tag',
       placeholder: 'e.g. caso_proativo_mat',
       accordion: 'Advanced settings',
+      moreInfoTooltip:
+        'Pins the ClaudIA conversation tag. Matched by exact string, so a value that is not configured for the project is ignored silently. Accepts {{variables}}.',
     }),
   }),
 })

--- a/packages/forge/blocks/claudia/actions/end-flow.ts
+++ b/packages/forge/blocks/claudia/actions/end-flow.ts
@@ -24,7 +24,7 @@ export const endFlow = createAction({
       placeholder: 'e.g. caso_proativo_mat',
       accordion: 'Advanced settings',
       moreInfoTooltip:
-        'Pins the ClaudIA conversation tag. Matched by exact string, so a value that is not configured for the project is ignored silently. Accepts {{variables}}.',
+        'Pins the ClaudIA conversation tag. On most channels it is written to the helpdesk as-is, so spelling matters — a typo creates a new tag rather than being ignored. Cannot contain commas. Accepts {{variables}}.',
     }),
   }),
 })

--- a/packages/forge/blocks/claudia/actions/end-flow.ts
+++ b/packages/forge/blocks/claudia/actions/end-flow.ts
@@ -8,6 +8,7 @@ export const endFlow = createAction({
       const log = createClaudiaResponseLog({
         action: 'END_FLOW',
         topic: options.topic,
+        tag: options.tag,
       })
       logs.add(log)
     },
@@ -16,6 +17,11 @@ export const endFlow = createAction({
     topic: option.string.layout({
       label: 'Topic',
       placeholder: 'e.g. PAYMENT',
+      accordion: 'Advanced settings',
+    }),
+    tag: option.string.layout({
+      label: 'Tag',
+      placeholder: 'e.g. caso_proativo_mat',
       accordion: 'Advanced settings',
     }),
   }),

--- a/packages/forge/blocks/claudia/actions/end-flow.ts
+++ b/packages/forge/blocks/claudia/actions/end-flow.ts
@@ -23,6 +23,8 @@ export const endFlow = createAction({
       label: 'Tag',
       placeholder: 'e.g. caso_proativo_mat',
       accordion: 'Advanced settings',
+      moreInfoTooltip:
+        'Pins the ClaudIA conversation tag. Matched by exact string, so a value that is not configured for the project is ignored silently. Accepts {{variables}}.',
     }),
   }),
 })

--- a/packages/forge/blocks/claudia/actions/forward-to-human-ignore-hours.ts
+++ b/packages/forge/blocks/claudia/actions/forward-to-human-ignore-hours.ts
@@ -8,6 +8,7 @@ export const forwardToHumanIgnoreHours = createAction({
       const log = createClaudiaResponseLog({
         action: 'FORWARD_TO_HUMAN_IGNORE_HOURS',
         topic: options.topic,
+        tag: options.tag,
       })
       logs.add(log)
     },
@@ -16,6 +17,11 @@ export const forwardToHumanIgnoreHours = createAction({
     topic: option.string.layout({
       label: 'Topic',
       placeholder: 'e.g. PAYMENT',
+      accordion: 'Advanced settings',
+    }),
+    tag: option.string.layout({
+      label: 'Tag',
+      placeholder: 'e.g. caso_proativo_mat',
       accordion: 'Advanced settings',
     }),
   }),

--- a/packages/forge/blocks/claudia/actions/forward-to-human-ignore-hours.ts
+++ b/packages/forge/blocks/claudia/actions/forward-to-human-ignore-hours.ts
@@ -24,7 +24,7 @@ export const forwardToHumanIgnoreHours = createAction({
       placeholder: 'e.g. caso_proativo_mat',
       accordion: 'Advanced settings',
       moreInfoTooltip:
-        'Pins the ClaudIA conversation tag. Matched by exact string, so a value that is not configured for the project is ignored silently. Accepts {{variables}}.',
+        'Pins the ClaudIA conversation tag. On most channels it is written to the helpdesk as-is, so spelling matters — a typo creates a new tag rather than being ignored. Cannot contain commas. Accepts {{variables}}.',
     }),
   }),
 })

--- a/packages/forge/blocks/claudia/actions/forward-to-human-ignore-hours.ts
+++ b/packages/forge/blocks/claudia/actions/forward-to-human-ignore-hours.ts
@@ -23,6 +23,8 @@ export const forwardToHumanIgnoreHours = createAction({
       label: 'Tag',
       placeholder: 'e.g. caso_proativo_mat',
       accordion: 'Advanced settings',
+      moreInfoTooltip:
+        'Pins the ClaudIA conversation tag. Matched by exact string, so a value that is not configured for the project is ignored silently. Accepts {{variables}}.',
     }),
   }),
 })

--- a/packages/forge/blocks/claudia/actions/forward-to-human.ts
+++ b/packages/forge/blocks/claudia/actions/forward-to-human.ts
@@ -8,6 +8,7 @@ export const forwardToHuman = createAction({
       const log = createClaudiaResponseLog({
         action: 'FORWARD_TO_HUMAN',
         topic: options.topic,
+        tag: options.tag,
       })
       logs.add(log)
     },
@@ -16,6 +17,11 @@ export const forwardToHuman = createAction({
     topic: option.string.layout({
       label: 'Topic',
       placeholder: 'e.g. PAYMENT',
+      accordion: 'Advanced settings',
+    }),
+    tag: option.string.layout({
+      label: 'Tag',
+      placeholder: 'e.g. caso_proativo_mat',
       accordion: 'Advanced settings',
     }),
   }),

--- a/packages/forge/blocks/claudia/actions/forward-to-human.ts
+++ b/packages/forge/blocks/claudia/actions/forward-to-human.ts
@@ -24,7 +24,7 @@ export const forwardToHuman = createAction({
       placeholder: 'e.g. caso_proativo_mat',
       accordion: 'Advanced settings',
       moreInfoTooltip:
-        'Pins the ClaudIA conversation tag. Matched by exact string, so a value that is not configured for the project is ignored silently. Accepts {{variables}}.',
+        'Pins the ClaudIA conversation tag. On most channels it is written to the helpdesk as-is, so spelling matters — a typo creates a new tag rather than being ignored. Cannot contain commas. Accepts {{variables}}.',
     }),
   }),
 })

--- a/packages/forge/blocks/claudia/actions/forward-to-human.ts
+++ b/packages/forge/blocks/claudia/actions/forward-to-human.ts
@@ -23,6 +23,8 @@ export const forwardToHuman = createAction({
       label: 'Tag',
       placeholder: 'e.g. caso_proativo_mat',
       accordion: 'Advanced settings',
+      moreInfoTooltip:
+        'Pins the ClaudIA conversation tag. Matched by exact string, so a value that is not configured for the project is ignored silently. Accepts {{variables}}.',
     }),
   }),
 })

--- a/packages/forge/blocks/claudia/claudiaTag.test.ts
+++ b/packages/forge/blocks/claudia/claudiaTag.test.ts
@@ -18,13 +18,25 @@ const actions = [
     action: forwardToHumanIgnoreHours,
     expectedAction: 'FORWARD_TO_HUMAN_IGNORE_HOURS',
   },
-  { name: closeTicket.name, action: closeTicket, expectedAction: 'CLOSE_TICKET' },
-  { name: answerTicket.name, action: answerTicket, expectedAction: 'ANSWER_TICKET' },
+  {
+    name: closeTicket.name,
+    action: closeTicket,
+    expectedAction: 'CLOSE_TICKET',
+  },
+  {
+    name: answerTicket.name,
+    action: answerTicket,
+    expectedAction: 'ANSWER_TICKET',
+  },
 ]
 
 /**
- * Runs an action's server handler with a stub logs store and returns the logs
- * it emitted. Mirrors what `executeForgedBlock` does at runtime.
+ * Calls an action's server handler directly with already-parsed options and
+ * returns the logs it emitted. `executeForgedBlock` additionally runs the
+ * options through `deepParseVariables` (`{{variable}}` interpolation, and
+ * dropping empty strings) and passes credentials/variables — none of which is
+ * exercised here, since importing that path pulls in the isolated-vm sandbox
+ * that this test runner deliberately excludes.
  */
 const runServer = (action: any, options: Record<string, unknown>) => {
   const emitted: any[] = []
@@ -54,6 +66,19 @@ describe.each(actions)('$name', ({ action, expectedAction }) => {
     expect(logs).toHaveLength(1)
     expect(logs[0].details.action).toBe(expectedAction)
     expect(logs[0].details.tag).toBeUndefined()
+  })
+
+  test('trims authoring whitespace around the tag', () => {
+    const logs = runServer(action, { tag: '  caso_proativo_mat\n' })
+
+    expect(logs[0].details.tag).toBe('caso_proativo_mat')
+  })
+
+  test('drops a blank tag instead of sending an empty string', () => {
+    const logs = runServer(action, { tag: '   ' })
+
+    expect(logs[0].details.tag).toBeUndefined()
+    expect(JSON.stringify(logs[0].details)).not.toContain('tag')
   })
 
   test('declares an optional Tag field under Advanced settings', () => {

--- a/packages/forge/blocks/claudia/claudiaTag.test.ts
+++ b/packages/forge/blocks/claudia/claudiaTag.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from 'vitest'
+import { claudiaBlockSchema } from './schemas'
+import { endFlow } from './actions/end-flow'
+import { forwardToHuman } from './actions/forward-to-human'
+import { forwardToHumanIgnoreHours } from './actions/forward-to-human-ignore-hours'
+import { closeTicket } from './actions/close-ticket'
+import { answerTicket } from './actions/answer_ticket'
+
+const actions = [
+  { name: endFlow.name, action: endFlow, expectedAction: 'END_FLOW' },
+  {
+    name: forwardToHuman.name,
+    action: forwardToHuman,
+    expectedAction: 'FORWARD_TO_HUMAN',
+  },
+  {
+    name: forwardToHumanIgnoreHours.name,
+    action: forwardToHumanIgnoreHours,
+    expectedAction: 'FORWARD_TO_HUMAN_IGNORE_HOURS',
+  },
+  { name: closeTicket.name, action: closeTicket, expectedAction: 'CLOSE_TICKET' },
+  { name: answerTicket.name, action: answerTicket, expectedAction: 'ANSWER_TICKET' },
+]
+
+/**
+ * Runs an action's server handler with a stub logs store and returns the logs
+ * it emitted. Mirrors what `executeForgedBlock` does at runtime.
+ */
+const runServer = (action: any, options: Record<string, unknown>) => {
+  const emitted: any[] = []
+  action.run.server({ options, logs: { add: (log: any) => emitted.push(log) } })
+  return emitted
+}
+
+describe.each(actions)('$name', ({ action, expectedAction }) => {
+  // The `tag` key inside the "Claudia Response" log details is the entire wire
+  // contract with Claudia, which matches it by name and silently ignores any
+  // other spelling. Guard the spelling, not just the presence.
+  test('emits the tag in the Claudia Response log details', () => {
+    const logs = runServer(action, { tag: 'caso_proativo_mat' })
+
+    expect(logs).toHaveLength(1)
+    expect(logs[0].status).toBe('success')
+    expect(logs[0].description).toBe('Claudia Response')
+    expect(logs[0].details).toMatchObject({
+      action: expectedAction,
+      tag: 'caso_proativo_mat',
+    })
+  })
+
+  test('omitting the tag leaves it undefined and still emits the log', () => {
+    const logs = runServer(action, {})
+
+    expect(logs).toHaveLength(1)
+    expect(logs[0].details.action).toBe(expectedAction)
+    expect(logs[0].details.tag).toBeUndefined()
+  })
+
+  test('declares an optional Tag field under Advanced settings', () => {
+    const tagField = (action as any).options?.shape?.tag
+
+    expect(tagField).toBeDefined()
+    expect(tagField.isOptional()).toBe(true)
+    expect(tagField._def.layout).toMatchObject({
+      label: 'Tag',
+      accordion: 'Advanced settings',
+    })
+    // A default would tag conversations for flows that never opted in.
+    expect(tagField._def.layout.defaultValue).toBeUndefined()
+  })
+})
+
+describe('claudiaBlockSchema', () => {
+  test('accepts a block carrying a tag', () => {
+    const result = claudiaBlockSchema.safeParse({
+      id: 'block-1',
+      type: 'claudia',
+      options: { action: 'Close Ticket [N1]', tag: 'caso_proativo_mat' },
+    })
+
+    expect(result.success).toBe(true)
+    expect((result as any).data.options.tag).toBe('caso_proativo_mat')
+  })
+
+  test.each(actions.map(({ action }) => action.name))(
+    'still parses a persisted %s block that has no tag key',
+    (name) => {
+      const result = claudiaBlockSchema.safeParse({
+        id: 'block-2',
+        type: 'claudia',
+        options: { action: name },
+      })
+
+      expect(result.success).toBe(true)
+      expect((result as any).data.options.tag).toBeUndefined()
+    }
+  )
+
+  test('keeps topic and searchTerm working alongside tag', () => {
+    const result = claudiaBlockSchema.safeParse({
+      id: 'block-3',
+      type: 'claudia',
+      options: {
+        action: 'Answer Ticket [N1]',
+        topic: 'PAYMENT',
+        searchTerm: 'firstUserMessage',
+        tag: 'caso_proativo_mat',
+      },
+    })
+
+    expect(result.success).toBe(true)
+    expect((result as any).data.options).toMatchObject({
+      topic: 'PAYMENT',
+      searchTerm: 'firstUserMessage',
+      tag: 'caso_proativo_mat',
+    })
+  })
+})
+
+describe('regression: tag does not disturb existing fields', () => {
+  test('topic is still emitted by the four actions that declare it', () => {
+    const topicActions = [
+      { action: endFlow, expectedAction: 'END_FLOW' },
+      { action: forwardToHuman, expectedAction: 'FORWARD_TO_HUMAN' },
+      {
+        action: forwardToHumanIgnoreHours,
+        expectedAction: 'FORWARD_TO_HUMAN_IGNORE_HOURS',
+      },
+      { action: answerTicket, expectedAction: 'ANSWER_TICKET' },
+    ]
+
+    for (const { action, expectedAction } of topicActions) {
+      const logs = runServer(action, { topic: 'PAYMENT', tag: 'campanha_x' })
+
+      expect(logs[0].details, action.name).toMatchObject({
+        action: expectedAction,
+        topic: 'PAYMENT',
+        tag: 'campanha_x',
+      })
+    }
+  })
+
+  test('searchTerm is still emitted by Answer Ticket', () => {
+    const logs = runServer(answerTicket, {
+      searchTerm: 'firstUserMessage',
+      tag: 'campanha_x',
+    })
+
+    expect(logs[0].details).toMatchObject({
+      action: 'ANSWER_TICKET',
+      searchTerm: 'firstUserMessage',
+      tag: 'campanha_x',
+    })
+  })
+})

--- a/packages/forge/blocks/claudia/helpers/createClaudiaResponseLog.ts
+++ b/packages/forge/blocks/claudia/helpers/createClaudiaResponseLog.ts
@@ -24,5 +24,8 @@ export const createClaudiaResponseLog = (
 ): TypebotLog => ({
   status: 'success',
   description: 'Claudia Response',
-  details: response,
+  // The tag is matched downstream by exact string, so authoring whitespace
+  // would silently mistag the conversation. A blank tag is dropped rather than
+  // sent as an empty string.
+  details: { ...response, tag: response.tag?.trim() || undefined },
 })

--- a/packages/forge/blocks/claudia/helpers/createClaudiaResponseLog.ts
+++ b/packages/forge/blocks/claudia/helpers/createClaudiaResponseLog.ts
@@ -11,6 +11,7 @@ type ClaudiaResponse = {
   action: ClaudiaAction
   topic?: string
   searchTerm?: string
+  tag?: string
 }
 
 type TypebotLog = Extract<


### PR DESCRIPTION
## O que

Adiciona um campo de texto opcional **"Tag"** em *Advanced settings* nos **cinco** blocos ClaudIA
(`End Flow [N1]`, `Forward to Human [N2]`, `Forward to Human [N2] (ignore office hours)`,
`Answer Ticket [N1]`, `Close Ticket [N1]`), pra o autor do fluxo fixar a TAG da conversa.

O valor viaja na chave `tag`, no topo do `details` do log `"Claudia Response"` que o bloco já emite —
ao lado de `topic` e `searchTerm`.

## Por que

Hoje a ClaudIA deriva a TAG sozinha (vector search ou classificador LLM). Quando o fluxo já sabe qual
deve ser a TAG — caso típico: contato proativo, em que cada campanha precisa da sua própria tag — não
existe nenhuma forma de o operador que configura o fluxo fixar esse valor, e a tag acaba derivada do
conteúdo da conversa, sem identificar a origem.

É `option.string` (texto livre) e não `option.enum` de propósito: os valores variam por fluxo e novos
são adicionados com o tempo, então um enum exigiria mudança de código a cada tag nova. Aceita
`{{variáveis}}`, igual ao `topic`.

## Como

- **5 actions** (`actions/*.ts`): novo `option.string` `tag` no accordion "Advanced settings", com
  `moreInfoTooltip` avisando que na maioria dos canais a tag é gravada no helpdesk **como veio** —
  então erro de digitação cria uma tag nova em vez de ser ignorado — e que vírgula não é aceita;
  passado no `createClaudiaResponseLog`.
- **`actions/close-ticket.ts`**: era a única action **sem bloco `options`** — precisou do `options`,
  do `option` no import e do destructure `({ logs })` → `({ logs, options })`.
- **`helpers/createClaudiaResponseLog.ts`**: `tag?: string` no tipo `ClaudiaResponse`. O valor é
  normalizado com `trim()`, e uma tag em branco é **omitida** em vez de virar `""`.
- **`claudiaTag.test.ts`**: novo, 34 testes.

`schemas.ts` não foi tocado (é derivado em runtime via `parseBlockSchema`, pega a opção nova
automaticamente) e nada precisou ser registrado em `index.ts`.

## Comportamento

- **Opcional, sem default.** Fluxo que não preenche o campo produz saída byte-idêntica à de hoje, tanto
  na resposta da API quanto no `Log.details`.
- **Normalização.** O consumidor recebe ou uma string não-vazia já com `trim`, ou nenhuma chave `tag`.
  Nunca `""` e nunca com espaço em volta — um espaço sobrando digitado por engano mistagaria toda uma
  campanha silenciosamente.
- **`{{variável}}`** é interpolada antes de chegar no log (via `deepParseVariables`), e string vazia é
  removida.

## Retrocompatibilidade

O ponto de atenção é o `Close Ticket [N1]`, que passou a ter um objeto `options` pela primeira vez.
Verificado contra o `claudiaBlockSchema` real, com blocos no formato em que já estão persistidos:

| Entrada | Resultado |
|---|---|
| sem `options` | parseia |
| `{action:'Close Ticket [N1]'}` (legado) | parseia |
| legado + chave antiga carregada | parseia, chave removida |
| `+ tag` | parseia, tag preservada |
| `+ outgoingEdgeId` | parseia |
| `tag` numérica / `null` | rejeitada (inalcançável pela UI) |

`parseBlockSchema` faz `.merge(action.options ?? z.object({}))` com o `strip` default do zod, então
adicionar uma chave opcional só amplia o schema. Nenhum fluxo já salvo quebra.

## Par / dependência

- **Lado Claudia** (consome `details.tag`): **cloudhumans/claudia#1586**, já aberta.
- **Ordem de deploy: indiferente.** `ClaudiaLogDetails` já declara `tag` e recebeu
  `@JsonIgnoreProperties(ignoreUnknown = true)`, então as duas metades podem entrar em qualquer ordem
  sem quebrar nada.
- Enquanto nenhum fluxo preencher o campo, **nada muda em produção** — a chave simplesmente não é
  emitida.
- A ClaudIA também faz `trim` e rejeita com WARN tag em branco, `NO_TAG`, ou contendo vírgula (o
  connector faz split do label por vírgula). O `trim` deste lado é complementar, não redundante: evita
  que o valor chegue lá só pra ser descartado.

## Testes

`packages/forge/blocks/claudia/claudiaTag.test.ts` — 34 testes, cobrindo para cada uma das 5 actions:
a chave `tag` no `details` do log, a ausência quando não preenchida, o `trim`, a tag em branco omitida,
e a declaração do campo (opcional, label `Tag`, accordion `Advanced settings`, sem `defaultValue`).
Mais parsing do schema (aceita `tag`; blocos persistidos sem `tag` continuam parseando nas 5 actions;
`topic`/`searchTerm` seguem funcionando junto).

Os testes foram checados por mutação: remover `tag: options.tag` de qualquer uma das 5 actions,
renomear a chave do log, renomear a chave do schema, ou remover o `trim` cada um produz falha
localizada.

Suíte completa: **250 passando**. `tsc` do pacote: limpo. A única suíte que falha localmente é
`packages/bot-engine/executeGroup.test.ts`, por causa do addon nativo do `isolated-vm` não compilado —
falha igual em `main`, sem relação com esta mudança (no CI o install compila normalmente).

## O que falta verificar (para o revisor)

Não consegui validar na UI, por não ter ambiente configurado aqui. Vale conferir no builder:

1. O campo **Tag** aparece em *Advanced settings* nas **5** actions.
2. `{{variável}}` é aceita no campo.
3. Rodar um fluxo com a tag preenchida e conferir que o `details` do log `"Claudia Response"` traz
   `tag`; e que com o campo vazio a chave não aparece.

A renderização foi conferida no código (`ZodActionDiscriminatedUnion` → `ZodObjectLayout` →
`ZodFieldLayout`, com o layout içado do `ZodOptional` pelo `getZodInnerSchema`), mas não no navegador.

AB#8222

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

A PR parece segura para merge.

Nenhuma falha bloqueante permanece.

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Campo Tag no builder] --> B[Schema derivado da action]
  B --> C[Interpolação de variáveis]
  C --> D[Action ClaudIA]
  D --> E[Normalização com trim]
  E --> F[Log Claudia Response details.tag]
```
</details>

<sub>Reviews (2): Last reviewed commit: [":memo: corrige tooltip da Tag sobre grav..."](https://github.com/cloudhumans/typebot.io/commit/b2a983fa4147de05ff1bcc711b73cf09728d04c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50439903)</sub>

**Context used:**

- Knowledge Base — [Forge: the integration block plugin framework](https://app.greptile.com/cloud-humans/-/custom-context/knowledge-base/cloudhumans/typebot.io/-/docs/forge-blocks.md)

<!-- /greptile_comment -->